### PR TITLE
[T2.1.9] Validation Zod + error handler global

### DIFF
--- a/web/backend/package-lock.json
+++ b/web/backend/package-lock.json
@@ -12,7 +12,8 @@
         "@prisma/client": "^6.19.2",
         "dotenv": "^17.3.1",
         "express": "^4.22.1",
-        "prisma": "^6.19.2"
+        "prisma": "^6.19.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/express": "^4.17.25",
@@ -2099,6 +2100,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -15,7 +15,8 @@
     "@prisma/client": "^6.19.2",
     "dotenv": "^17.3.1",
     "express": "^4.22.1",
-    "prisma": "^6.19.2"
+    "prisma": "^6.19.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.25",

--- a/web/backend/src/index.ts
+++ b/web/backend/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { errorHandler } from './middleware/errorHandler'
 
 const app = express()
 const PORT = process.env.PORT || 3001
@@ -8,6 +9,14 @@ app.use(express.json())
 app.get('/health', (_req, res) => {
   res.status(200).json({ status: 'ok' })
 })
+
+// routes (à compléter au fil des tickets)
+// app.use('/api/missions', missionsRouter)
+// app.use('/api/points', pointsRouter)
+// app.use('/api/robots', robotsRouter)
+
+// error handler — doit être en dernier
+app.use(errorHandler)
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)

--- a/web/backend/src/lib/prisma.ts
+++ b/web/backend/src/lib/prisma.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from '@prisma/client'
+
+// singleton — pas de nouvelle instance à chaque import
+const prisma = new PrismaClient()
+
+export default prisma

--- a/web/backend/src/middleware/errorHandler.ts
+++ b/web/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from 'express'
+import { PrismaClientKnownRequestError, PrismaClientInitializationError } from '@prisma/client/runtime/library'
+
+// format d'erreur uniforme pour toute l'API
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  // erreurs Prisma courantes
+  if (err instanceof PrismaClientKnownRequestError) {
+    if (err.code === 'P2025') {
+      res.status(404).json({ error: 'Ressource introuvable' })
+      return
+    }
+    if (err.code === 'P2002') {
+      res.status(409).json({ error: 'Cette valeur existe déjà' })
+      return
+    }
+  }
+
+  // erreur de connexion DB
+  if (err instanceof PrismaClientInitializationError) {
+    console.error('[DB] connexion impossible:', (err as Error).message)
+    res.status(503).json({ error: 'Base de données indisponible' })
+    return
+  }
+
+  // erreur générique — pas de stack trace en prod
+  if (err instanceof Error) {
+    console.error('[ERROR]', err.message)
+    res.status(500).json({
+      error: process.env.NODE_ENV === 'production' ? 'Erreur interne' : err.message,
+    })
+    return
+  }
+
+  res.status(500).json({ error: 'Erreur interne' })
+}
+
+// wrapper pour éviter try/catch dans chaque controller
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next)
+  }
+}

--- a/web/backend/src/middleware/validate.ts
+++ b/web/backend/src/middleware/validate.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction } from 'express'
+import { ZodSchema } from 'zod'
+
+// middleware réutilisable — valide req.body contre un schéma Zod
+export function validateBody(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body)
+    if (!result.success) {
+      res.status(400).json({
+        error: 'Données invalides',
+        details: result.error.issues.map((e) => ({
+          field: e.path.join('.'),
+          message: e.message,
+        })),
+      })
+      return
+    }
+    req.body = result.data
+    next()
+  }
+}
+
+export function validateQuery(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.query)
+    if (!result.success) {
+      res.status(400).json({
+        error: 'Paramètres invalides',
+        details: result.error.issues.map((e) => ({
+          field: e.path.join('.'),
+          message: e.message,
+        })),
+      })
+      return
+    }
+    // cast nécessaire : Zod retourne un type générique, Express attend ParsedQs
+    req.query = result.data as typeof req.query
+    next()
+  }
+}

--- a/web/backend/src/types/api.ts
+++ b/web/backend/src/types/api.ts
@@ -1,0 +1,15 @@
+export interface ApiError {
+  error: string
+  details?: unknown
+}
+
+export interface ApiSuccess<T> {
+  data: T
+}
+
+export interface PaginatedResponse<T> {
+  data: T[]
+  total: number
+  page: number
+  limit: number
+}


### PR DESCRIPTION
## Ticket
Closes #32

## Ce qui a été fait
- `src/middleware/validate.ts` — `validateBody` + `validateQuery` (Zod v4, `.issues`)
- `src/middleware/errorHandler.ts` — handler global : Prisma P2025 → 404, P2002 → 409, 500 sans stack trace en prod + `asyncHandler` wrapper
- `src/lib/prisma.ts` — singleton PrismaClient
- `src/types/api.ts` — types `ApiError`, `ApiSuccess`, `PaginatedResponse`
- `src/index.ts` — error handler branché en dernier

## CI
- ✅ `npm run build` — OK (TypeScript strict)