### PR TITLE
[T2.1.3] GET /api/missions — liste + filtres + pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     defaults:
       run:
         working-directory: web/backend
+    env:
+      DATABASE_URL: mysql://root:root@localhost:3306/roblaude
 
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +51,4 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
+    "postinstall": "prisma generate",
     "start": "node dist/index.js"
   },
   "keywords": [],

--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from 'express'
+import { MissionStatus } from '@prisma/client'
+import { z } from 'zod'
+import prisma from '../lib/prisma'
+
+// query params pour GET /api/missions
+const listQuerySchema = z.object({
+  status: z.nativeEnum(MissionStatus).optional(),
+  type: z.enum(['TRANSPORT', 'PICK_AND_PLACE']).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+})
+
+export async function listMissions(req: Request, res: Response) {
+  const parsed = listQuerySchema.safeParse(req.query)
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Paramètres invalides',
+      details: parsed.error.issues.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      })),
+    })
+    return
+  }
+
+  const { status, type, page, limit } = parsed.data
+  const skip = (page - 1) * limit
+
+  const where = {
+    ...(status ? { status } : {}),
+    ...(type ? { type } : {}),
+  }
+
+  const [missions, total] = await Promise.all([
+    prisma.mission.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        fromPoint: true,
+        toPoint: true,
+        robot: { select: { id: true, name: true, status: true } },
+        user: { select: { id: true, name: true, email: true } },
+        object: true,
+      },
+    }),
+    prisma.mission.count({ where }),
+  ])
+
+  res.json({
+    data: missions,
+    total,
+    page,
+    limit,
+  })
+}

--- a/web/backend/src/index.ts
+++ b/web/backend/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import { errorHandler } from './middleware/errorHandler'
+import missionsRouter from './routes/missions'
 
 const app = express()
 const PORT = process.env.PORT || 3001
@@ -10,8 +11,7 @@ app.get('/health', (_req, res) => {
   res.status(200).json({ status: 'ok' })
 })
 
-// routes (à compléter au fil des tickets)
-// app.use('/api/missions', missionsRouter)
+app.use('/api/missions', missionsRouter)
 // app.use('/api/points', pointsRouter)
 // app.use('/api/robots', robotsRouter)
 

--- a/web/backend/src/routes/missions.ts
+++ b/web/backend/src/routes/missions.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import { asyncHandler } from '../middleware/errorHandler'
+import { listMissions } from '../controllers/missionsController'
+
+const router = Router()
+
+// GET /api/missions?status=PENDING&type=TRANSPORT&page=1&limit=20
+router.get('/', asyncHandler(listMissions))
+
+export default router


### PR DESCRIPTION
## Ticket
Closes #26

## Ce qui a été fait
- `GET /api/missions` avec query params : `status`, `type`, `page`, `limit`
- Validation Zod des params (coerce number, nativeEnum)
- Include relations : `fromPoint`, `toPoint`, `robot`, `user`, `object`
- Pagination `skip/take` + `total` count en parallèle
- Réponse : `{ data, total, page, limit }`

## Dépend de
PR #190 (Zod + error handler) — à merger en premier

## CI
- ✅ `npm run build` — OK