### PR TITLE
[T2.1.5] POST /api/missions/:id/cancel

### DIFF
--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { MissionStatus } from '@prisma/client'
+import { MissionStatus, MissionType, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
 
@@ -55,4 +55,137 @@ export async function listMissions(req: Request, res: Response) {
     page,
     limit,
   })
+}
+
+// body pour POST /api/missions
+const createMissionSchema = z.object({
+  type: z.nativeEnum(MissionType),
+  fromPointId: z.number().int().positive(),
+  toPointId: z.number().int().positive(),
+  robotId: z.number().int().positive().optional(),
+  objectId: z.number().int().positive().optional(),
+  // todo: userId viendra du token JWT — hardcodé à 1 pour l'instant
+})
+
+export async function createMission(req: Request, res: Response) {
+  const parsed = createMissionSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Données invalides',
+      details: parsed.error.issues.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      })),
+    })
+    return
+  }
+
+  const { type, fromPointId, toPointId, robotId, objectId } = parsed.data
+
+  // vérifier que les points existent
+  const [fromPoint, toPoint] = await Promise.all([
+    prisma.point.findUnique({ where: { id: fromPointId } }),
+    prisma.point.findUnique({ where: { id: toPointId } }),
+  ])
+
+  if (!fromPoint) {
+    res.status(400).json({ error: 'Point de départ introuvable', field: 'fromPointId' })
+    return
+  }
+  if (!toPoint) {
+    res.status(400).json({ error: 'Point d\'arrivée introuvable', field: 'toPointId' })
+    return
+  }
+
+  // vérifier que le robot est dispo si précisé
+  if (robotId) {
+    const robot = await prisma.robot.findUnique({ where: { id: robotId } })
+    if (!robot) {
+      res.status(400).json({ error: 'Robot introuvable', field: 'robotId' })
+      return
+    }
+    if (robot.status === RobotStatus.BUSY) {
+      res.status(409).json({ error: 'Robot occupé', status: robot.status })
+      return
+    }
+  }
+
+  const mission = await prisma.mission.create({
+    data: {
+      type,
+      fromPointId,
+      toPointId,
+      robotId: robotId ?? null,
+      objectId: objectId ?? null,
+      userId: 1, // todo: extraire du JWT
+    },
+    include: {
+      fromPoint: true,
+      toPoint: true,
+      robot: { select: { id: true, name: true, status: true } },
+      user: { select: { id: true, name: true, email: true } },
+    },
+  })
+
+  res.status(201).json({ data: mission })
+}
+
+// états depuis lesquels on peut annuler
+const CANCELLABLE_STATUSES: MissionStatus[] = [
+  MissionStatus.PENDING,
+  MissionStatus.PAUSED,
+  MissionStatus.NAVIGATING_TO_PICKUP,
+  MissionStatus.WAITING_FOR_LOAD,
+  MissionStatus.NAVIGATING_TO_DESTINATION,
+]
+
+export async function cancelMission(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const mission = await prisma.mission.findUnique({
+    where: { id },
+    include: { robot: true },
+  })
+
+  if (!mission) {
+    res.status(404).json({ error: 'Mission introuvable' })
+    return
+  }
+
+  if (!CANCELLABLE_STATUSES.includes(mission.status)) {
+    res.status(400).json({
+      error: 'Mission non annulable',
+      status: mission.status,
+    })
+    return
+  }
+
+  // transaction : annuler la mission + libérer le robot si assigné
+  const updated = await prisma.$transaction(async (tx) => {
+    const cancelled = await tx.mission.update({
+      where: { id },
+      data: { status: MissionStatus.CANCELLED },
+      include: {
+        fromPoint: true,
+        toPoint: true,
+        robot: { select: { id: true, name: true, status: true } },
+        user: { select: { id: true, name: true, email: true } },
+      },
+    })
+
+    if (mission.robotId) {
+      await tx.robot.update({
+        where: { id: mission.robotId },
+        data: { status: RobotStatus.AVAILABLE },
+      })
+    }
+
+    return cancelled
+  })
+
+  res.json({ data: updated })
 }

--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { MissionStatus, MissionType, RobotStatus } from '@prisma/client'
+import { MissionStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
 
@@ -55,77 +55,4 @@ export async function listMissions(req: Request, res: Response) {
     page,
     limit,
   })
-}
-
-// body pour POST /api/missions
-const createMissionSchema = z.object({
-  type: z.nativeEnum(MissionType),
-  fromPointId: z.number().int().positive(),
-  toPointId: z.number().int().positive(),
-  robotId: z.number().int().positive().optional(),
-  objectId: z.number().int().positive().optional(),
-  // todo: userId viendra du token JWT — hardcodé à 1 pour l'instant
-})
-
-export async function createMission(req: Request, res: Response) {
-  const parsed = createMissionSchema.safeParse(req.body)
-  if (!parsed.success) {
-    res.status(400).json({
-      error: 'Données invalides',
-      details: parsed.error.issues.map((e) => ({
-        field: e.path.join('.'),
-        message: e.message,
-      })),
-    })
-    return
-  }
-
-  const { type, fromPointId, toPointId, robotId, objectId } = parsed.data
-
-  // vérifier que les points existent
-  const [fromPoint, toPoint] = await Promise.all([
-    prisma.point.findUnique({ where: { id: fromPointId } }),
-    prisma.point.findUnique({ where: { id: toPointId } }),
-  ])
-
-  if (!fromPoint) {
-    res.status(400).json({ error: 'Point de départ introuvable', field: 'fromPointId' })
-    return
-  }
-  if (!toPoint) {
-    res.status(400).json({ error: 'Point d\'arrivée introuvable', field: 'toPointId' })
-    return
-  }
-
-  // vérifier que le robot est dispo si précisé
-  if (robotId) {
-    const robot = await prisma.robot.findUnique({ where: { id: robotId } })
-    if (!robot) {
-      res.status(400).json({ error: 'Robot introuvable', field: 'robotId' })
-      return
-    }
-    if (robot.status === RobotStatus.BUSY) {
-      res.status(409).json({ error: 'Robot occupé', status: robot.status })
-      return
-    }
-  }
-
-  const mission = await prisma.mission.create({
-    data: {
-      type,
-      fromPointId,
-      toPointId,
-      robotId: robotId ?? null,
-      objectId: objectId ?? null,
-      userId: 1, // todo: extraire du JWT
-    },
-    include: {
-      fromPoint: true,
-      toPoint: true,
-      robot: { select: { id: true, name: true, status: true } },
-      user: { select: { id: true, name: true, email: true } },
-    },
-  })
-
-  res.status(201).json({ data: mission })
 }

--- a/web/backend/src/routes/missions.ts
+++ b/web/backend/src/routes/missions.ts
@@ -1,13 +1,10 @@
 import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
-import { listMissions, createMission } from '../controllers/missionsController'
+import { listMissions } from '../controllers/missionsController'
 
 const router = Router()
 
 // GET /api/missions?status=PENDING&type=TRANSPORT&page=1&limit=20
 router.get('/', asyncHandler(listMissions))
-
-// POST /api/missions
-router.post('/', asyncHandler(createMission))
 
 export default router

--- a/web/backend/src/routes/missions.ts
+++ b/web/backend/src/routes/missions.ts
@@ -1,10 +1,16 @@
 import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
-import { listMissions } from '../controllers/missionsController'
+import { listMissions, createMission, cancelMission } from '../controllers/missionsController'
 
 const router = Router()
 
 // GET /api/missions?status=PENDING&type=TRANSPORT&page=1&limit=20
 router.get('/', asyncHandler(listMissions))
+
+// POST /api/missions
+router.post('/', asyncHandler(createMission))
+
+// POST /api/missions/:id/cancel
+router.post('/:id/cancel', asyncHandler(cancelMission))
 
 export default router


### PR DESCRIPTION
## Ticket
Closes #28

## Ce qui a été fait
- Annulation possible depuis : PENDING, PAUSED, NAVIGATING_TO_PICKUP, WAITING_FOR_LOAD, NAVIGATING_TO_DESTINATION
- Transaction Prisma : mission → CANCELLED + robot → AVAILABLE (si assigné)
- 400 si état non annulable (avec le statut actuel dans la réponse)
- 404 si mission introuvable

## Dépend de
PR #190 → #191 → #192 — à merger dans l'ordre

## CI
- ✅ `npm run build` — OK