### PR TITLE
[Sprint 3] robot/ — package ROS2 roblaude_nav (SLAM + Nav2)

### DIFF
--- a/robot/README.md
+++ b/robot/README.md
@@ -1,0 +1,87 @@
+# robot/ — Stack ROS2 RobLaude
+
+Code ROS2 Humble du robot RobLaude (Yahboom ROSMASTER M3 PRO, Jetson Nano).
+
+## Architecture (cf `docs/architecture.md`)
+
+```
+robot/
+├── roblaude_nav/      # Navigation autonome — SLAM + Nav2          [Sprint 3]
+├── roblaude_arm/      # Contrôle bras 6 DOF — MoveIt2              [Sprint 6]  (à venir)
+├── roblaude_vision/   # Détection objets — OpenCV                  [Sprint 6]  (à venir)
+├── roblaude_mqtt/     # Bridge MQTT ↔ ROS2                         [Sprint 4]  (à venir)
+├── roblaude_sim/      # Configs Gazebo (monde, modèles)            (à venir)
+└── scripts/           # Outils host (connexion, déploiement)
+```
+
+## roblaude_nav — Navigation (Sprint 3)
+
+Package ROS2 `ament_python`. Contient la cartographie SLAM, la navigation Nav2,
+les drivers capteurs et les outils de visualisation.
+
+### Launch files (`roblaude_nav/launch/`)
+
+| Fichier | Rôle |
+|---|---|
+| `lidar.launch.py` | YDLidar 2D → `/scan` |
+| `camera.launch.py` | Caméra Orbbec DaBai DCW2 RGB-D → `/camera/*` |
+| `odom.launch.py` | Odométrie roues + IMU STM32 |
+| `tf2_static.launch.py` | Transforms statiques châssis ↔ capteurs |
+| `slam.launch.py` | SLAM Toolbox (cartographie temps réel → `/map`) |
+| `nav2.launch.py` | Navigation autonome Nav2 |
+| `teleop.launch.py` | Téléopération clavier → `/cmd_vel` |
+| `foxglove.launch.py` | Bridge Foxglove Studio (WebSocket :8765) |
+| `web_video.launch.py` | Flux caméra HTTP MJPEG (:8080) |
+
+### Nodes Python (`roblaude_nav/roblaude_nav/`)
+
+| Node | Rôle |
+|---|---|
+| `scan_restamper` | Re-timestampe `/scan` et `/odom_raw` (l'horloge du STM32 n'est pas synchronisée — sinon SLAM rejette les scans) |
+| `odom_to_tf` | Publie le TF dynamique `odom → base_link` à partir de `/odom_raw` |
+
+### Compilation
+
+```bash
+# Dans un workspace ROS2 (ex: ~/roblaude_ws/src/)
+cd ~/roblaude_ws
+colcon build --packages-select roblaude_nav
+source install/setup.bash
+```
+
+### Lancement
+
+```bash
+# Cartographie SLAM
+ros2 launch roblaude_nav lidar.launch.py
+ros2 launch roblaude_nav odom.launch.py
+ros2 launch roblaude_nav slam.launch.py
+
+# Visualisation Foxglove Studio
+ros2 launch roblaude_nav foxglove.launch.py   # puis ws://<ROBOT_IP>:8765
+
+# Tout d'un coup (sur le robot)
+bash scripts/start_all.sh
+```
+
+## scripts/ — Outils host (hors ROS2)
+
+Lancés depuis le Mac/PC, pas dans le container ROS2.
+
+| Script | Rôle |
+|---|---|
+| `find_robot.sh` | Trouve l'IP du robot par son adresse MAC (résiste au DHCP) |
+| `start_robot.sh` | Démarrage tout-en-un : détecte l'IP, sync l'horloge, lance la stack |
+| `start_all.sh` | Lance toute la stack ROS2 (à exécuter dans le container) |
+| `deploy_to_robot.sh` | Déploie le code vers le robot via rsync |
+| `connect.sh` | SSH + noVNC vers le robot |
+| `Docker_M3Pro_Joy.sh` | Lance le container ROS2 principal (nom fixe `m3pro_main`) |
+| `start_agent.sh` | Lance le container micro-ROS-agent (nom fixe `micro_ros_agent`) |
+
+## Notes matérielles
+
+- **Horloge** : le Jetson Nano n'a pas de RTC → il perd l'heure à chaque extinction.
+  `start_robot.sh` resynchronise l'horloge à chaque démarrage.
+- **Caméra** : c'est une **Orbbec DaBai DCW2** (et non une RealSense comme indiqué
+  initialement dans le CDC).
+- **LiDAR** : le M3 PRO produit 2 demi-scans (`/scan0` + `/scan1`) fusionnés en `/scan`.

--- a/robot/roblaude_nav/config/foxglove_layout_slam.json
+++ b/robot/roblaude_nav/config/foxglove_layout_slam.json
@@ -1,0 +1,164 @@
+{
+  "configById": {
+    "3D!slam-view": {
+      "cameraState": {
+        "distance": 12,
+        "perspective": true,
+        "phi": 60,
+        "target": [0, 0, 0],
+        "targetOffset": [0, 0, 0],
+        "targetOrientation": [0, 0, 0, 1],
+        "thetaOffset": 0,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "followTf": "base_link",
+      "scene": {
+        "backgroundColor": "#1a1a1a",
+        "enableStats": false,
+        "meshUpAxis": "y_up"
+      },
+      "transforms": {
+        "frame:map": { "visible": true },
+        "frame:odom": { "visible": true },
+        "frame:base_link": { "visible": true }
+      },
+      "topics": {
+        "/scan_stamped": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo",
+          "pointSize": 3
+        },
+        "/map": {
+          "visible": true,
+          "alpha": 0.85,
+          "colorMode": "map"
+        },
+        "/slam_toolbox/graph_visualization": {
+          "visible": true
+        },
+        "/robot_description": {
+          "visible": true
+        },
+        "/move_base_simple/goal": {
+          "visible": true
+        }
+      },
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/goal_pose",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {},
+      "followTfEnabled": true
+    },
+    "Teleop!robot-cmd": {
+      "topic": "/cmd_vel",
+      "publishRate": 10,
+      "upButton": {
+        "field": "linear-x",
+        "value": 0.12
+      },
+      "downButton": {
+        "field": "linear-x",
+        "value": -0.12
+      },
+      "leftButton": {
+        "field": "angular-z",
+        "value": 0.4
+      },
+      "rightButton": {
+        "field": "angular-z",
+        "value": -0.4
+      }
+    },
+    "Plot!robot-telemetry": {
+      "paths": [
+        {
+          "value": "/odom.pose.pose.position.x",
+          "enabled": true,
+          "timestampMethod": "receiveTime",
+          "label": "X (m)",
+          "color": "#e74c3c"
+        },
+        {
+          "value": "/odom.pose.pose.position.y",
+          "enabled": true,
+          "timestampMethod": "receiveTime",
+          "label": "Y (m)",
+          "color": "#2ecc71"
+        },
+        {
+          "value": "/odom.twist.twist.linear.x",
+          "enabled": true,
+          "timestampMethod": "receiveTime",
+          "label": "Vit. lin. (m/s)",
+          "color": "#3498db"
+        },
+        {
+          "value": "/battery.data",
+          "enabled": true,
+          "timestampMethod": "receiveTime",
+          "label": "Batterie (V)",
+          "color": "#f39c12"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "floating",
+      "showPlotValuesInLegend": true,
+      "isSynced": true,
+      "xAxisVal": "timestamp",
+      "sidebarDimension": 240
+    },
+    "Image!camera-rgb": {
+      "cameraState": {
+        "distance": 3,
+        "perspective": false
+      },
+      "imageMode": {
+        "imageTopic": "/camera/color/image_raw",
+        "calibrationTopic": "/camera/color/camera_info",
+        "synchronize": false
+      }
+    },
+    "RawMessages!slam-status": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/slam_toolbox/feedback"
+    }
+  },
+  "globalVariables": {},
+  "userNodes": {},
+  "playbackConfig": {
+    "speed": 1
+  },
+  "layout": {
+    "first": {
+      "first": "3D!slam-view",
+      "second": {
+        "first": "Teleop!robot-cmd",
+        "second": "Image!camera-rgb",
+        "direction": "column",
+        "splitPercentage": 45
+      },
+      "direction": "row",
+      "splitPercentage": 65
+    },
+    "second": "Plot!robot-telemetry",
+    "direction": "column",
+    "splitPercentage": 70
+  }
+}

--- a/robot/roblaude_nav/launch/camera.launch.py
+++ b/robot/roblaude_nav/launch/camera.launch.py
@@ -1,0 +1,46 @@
+"""
+camera.launch.py — Demarre la camera RGB-D Astra Pro du ROSMASTER M3 PRO
+
+La camera est une Orbbec Astra Pro (profondeur + RGB).
+Yahboom fournit le package `orbbec_camera` avec un launch file par modele.
+
+Ce launch inclut simplement le bon launch file Orbbec + les tf2 minimales.
+
+Usage (sur le robot, dans le conteneur ROS 2) :
+    ros2 launch /path/to/camera.launch.py
+
+Topics publies (principaux) :
+    /camera/color/image_raw       : image RGB
+    /camera/depth/image_raw       : carte de profondeur (16UC1, mm)
+    /camera/depth/color/points    : nuage de points (sensor_msgs/PointCloud2)
+"""
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        # Transform statique base_link -> camera_link
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='base_to_camera',
+            arguments=['0.10', '0.0', '0.08', '0', '0', '0', 'base_link', 'camera_link'],
+        ),
+
+        # Driver Orbbec Astra Pro (launch Yahboom officiel)
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                PathJoinSubstitution([
+                    FindPackageShare('orbbec_camera'),
+                    'launch',
+                    'astra_pro2.launch.py'
+                ])
+            ])
+        ),
+    ])

--- a/robot/roblaude_nav/launch/foxglove.launch.py
+++ b/robot/roblaude_nav/launch/foxglove.launch.py
@@ -1,0 +1,55 @@
+"""
+foxglove.launch.py — Expose un pont WebSocket Foxglove Studio
+
+foxglove_bridge ouvre un serveur WebSocket sur le port 8765. Depuis ton Mac,
+Foxglove Studio se connecte en ws://<ROBOT_IP>:8765 et tu visualises en live :
+  - /scan (LaserScan LiDAR)
+  - /map (OccupancyGrid SLAM)
+  - /camera/* (images RGB/depth)
+  - /tf, /tf_static (frames)
+  - /cmd_vel, /odom
+  - Goals Nav2 cliquables directement sur la carte
+
+Usage :
+    ros2 launch /home/jetson/launch/foxglove.launch.py
+    ros2 launch /home/jetson/launch/foxglove.launch.py port:=9090
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    port_arg = DeclareLaunchArgument(
+        'port',
+        default_value='8765',
+        description='Port WebSocket foxglove_bridge',
+    )
+
+    address_arg = DeclareLaunchArgument(
+        'address',
+        default_value='0.0.0.0',
+        description='Interface d ecoute (0.0.0.0 = toutes)',
+    )
+
+    return LaunchDescription([
+        port_arg,
+        address_arg,
+        Node(
+            package='foxglove_bridge',
+            executable='foxglove_bridge',
+            name='foxglove_bridge',
+            output='screen',
+            parameters=[{
+                'port': LaunchConfiguration('port'),
+                'address': LaunchConfiguration('address'),
+                'tls': False,
+                'send_buffer_limit': 10_000_000,
+                'use_sim_time': False,
+                'capabilities': ['clientPublish', 'parameters', 'parametersSubscribe',
+                                 'services', 'connectionGraph', 'assets'],
+            }],
+        ),
+    ])

--- a/robot/roblaude_nav/launch/lidar.launch.py
+++ b/robot/roblaude_nav/launch/lidar.launch.py
@@ -1,0 +1,47 @@
+"""
+lidar.launch.py — Demarre le LiDAR du ROSMASTER M3 PRO
+
+Le M3 PRO embarque un YDLidar 2D. Yahboom fournit un package qui publie
+sur le topic /scan (sensor_msgs/LaserScan).
+
+Ce launch inclut le fichier launch officiel Yahboom + les transforms tf2
+minimales pour que le /scan soit exploitable.
+
+Usage (sur le robot, dans le conteneur ROS 2) :
+    ros2 launch /path/to/lidar.launch.py
+
+Topics publies :
+    /scan : sensor_msgs/LaserScan (360 deg, ~8m de portee)
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        # Transform statique base_link -> laser_link
+        # (copie ici pour que ce launch soit autonome)
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='base_to_laser',
+            arguments=['0.0', '0.0', '0.10', '0', '0', '0', 'base_link', 'laser_link'],
+        ),
+
+        # Le driver LiDAR officiel Yahboom (package yahboom_M3Pro_laser)
+        # Tourne sur le topic /scan
+        Node(
+            package='yahboom_M3Pro_laser',
+            executable='ydlidar_ros2_driver_node',
+            name='lidar_node',
+            output='screen',
+            parameters=[{
+                'frame_id': 'laser_link',
+                'angle_min': -3.14,
+                'angle_max': 3.14,
+                'range_min': 0.1,
+                'range_max': 8.0,
+            }]
+        ),
+    ])

--- a/robot/roblaude_nav/launch/nav2.launch.py
+++ b/robot/roblaude_nav/launch/nav2.launch.py
@@ -1,0 +1,51 @@
+"""
+nav2.launch.py — Navigation autonome (Nav2)
+
+Lance la stack Nav2 complete pour naviguer vers un goal.
+
+PRE-REQUIS :
+  - lidar.launch.py + odom.launch.py + tf2_static.launch.py lances
+  - Une carte sauvegardee dans ~/maps/<nom>.yaml (via slam.launch.py puis map_saver_cli)
+  - OU en mode SLAM live (mapping en meme temps)
+
+Usage :
+    ros2 launch /path/to/nav2.launch.py map:=/home/jetson/maps/salon.yaml
+
+Topics/Actions :
+    /navigate_to_pose (action)  : envoyer un goal (x, y, yaw)
+    /cmd_vel                    : commandes de vitesse pour les roues
+    /plan                       : trajectoire planifiee (visualisable dans RViz)
+
+Nav2 est livre par Yahboom dans /root/yahboomcar_ws/src/M3Pro_navigation/
+donc on reutilise son launch officiel pour beneficier de leur config.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('map', default_value='/home/jetson/maps/default.yaml',
+                              description='Chemin absolu vers le fichier .yaml de la carte'),
+
+        # Include le launch officiel de Nav2 (bringup_launch.py)
+        # Si Yahboom a un launch custom, on peut le remplacer par :
+        # FindPackageShare('M3Pro_navigation')
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                PathJoinSubstitution([
+                    FindPackageShare('nav2_bringup'),
+                    'launch',
+                    'bringup_launch.py'
+                ])
+            ]),
+            launch_arguments={
+                'map': LaunchConfiguration('map'),
+                'use_sim_time': 'false',
+            }.items()
+        ),
+    ])

--- a/robot/roblaude_nav/launch/odom.launch.py
+++ b/robot/roblaude_nav/launch/odom.launch.py
@@ -1,0 +1,39 @@
+"""
+odom.launch.py — Demarre l'odometrie du ROSMASTER M3 PRO
+
+L'odometrie estime la position du robot en integrant :
+  - Encodeurs des roues (distance parcourue)
+  - IMU interne du STM32 (orientation)
+
+Le STM32 publie deja /odom via le micro-ros-agent. Ce launch ajoute juste
+les transforms tf2 pour que odom -> base_link soit publie.
+
+Usage :
+    ros2 launch /path/to/odom.launch.py
+
+Topics consommes / publies :
+    /odom (nav_msgs/Odometry)       <- publie par le STM32 via micro-ros
+    tf /odom -> /base_link          <- publie par ce node
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        # Note : l'odometrie est publiee par le STM32 lui-meme via micro-ros.
+        # On ajoute juste le transform odom -> base_link si besoin.
+        # En general, c'est un node qui lit /odom et publie le TF correspondant.
+
+        # Placeholder node si Yahboom a un "odom_publisher" dans son workspace
+        # A adapter selon ce qu'on trouve dans /root/yahboomcar_ws/src/
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='odom_identity',
+            # Transform initial odom -> base_link (sera remplace par le dynamic publisher)
+            # Ici c'est juste un fallback si aucun node ne publie le vrai tf
+            arguments=['0', '0', '0', '0', '0', '0', 'odom', 'base_link'],
+        ),
+    ])

--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -1,0 +1,48 @@
+"""
+slam.launch.py — Cartographie SLAM (Simultaneous Localization And Mapping)
+
+Utilise slam_toolbox en mode online_async. Lit /scan (LiDAR) + tf (odom)
+et construit une carte 2D en temps reel sur /map.
+
+PRE-REQUIS : lancer avant lidar.launch.py + odom.launch.py + tf2_static.launch.py
+
+Usage :
+    ros2 launch /path/to/slam.launch.py
+
+Topics publies :
+    /map (nav_msgs/OccupancyGrid)  : carte 2D (grille d'occupation)
+    /slam_toolbox/graph_visualization : visualisation du graph SLAM
+
+Pour sauvegarder la carte apres cartographie :
+    ros2 run nav2_map_server map_saver_cli -f ~/maps/nom_de_la_carte
+
+Visualiser dans RViz (depuis le bureau noVNC du robot) :
+    rviz2 -d /opt/ros/humble/share/slam_toolbox/config/mapper_params_online_async.yaml
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='slam_toolbox',
+            executable='async_slam_toolbox_node',
+            name='slam_toolbox',
+            output='screen',
+            parameters=[{
+                'use_sim_time': False,           # False = hardware reel
+                'odom_frame': 'odom',
+                'base_frame': 'base_link',
+                'map_frame': 'map',
+                'scan_topic': '/scan_stamped',   # timestamps reparees par scan_restamper
+                'mode': 'mapping',               # 'mapping' ou 'localization'
+                'resolution': 0.05,              # 5 cm par pixel
+                'max_laser_range': 8.0,          # metres (YDLidar)
+                'minimum_time_interval': 0.2,    # secondes
+                'transform_publish_period': 0.05,
+                'map_update_interval': 5.0,
+            }]
+        ),
+    ])

--- a/robot/roblaude_nav/launch/teleop.launch.py
+++ b/robot/roblaude_nav/launch/teleop.launch.py
@@ -1,0 +1,30 @@
+"""
+teleop.launch.py — Teleoperation clavier du ROSMASTER M3 PRO
+
+Utilise le node yahboom_keyboard fourni par Yahboom qui publie /cmd_vel
+selon les touches du clavier (i/,/j/l/u/o pour bouger, k pour stop).
+
+Usage (necessite un terminal interactif, donc pas ideal via dashboard) :
+    ros2 launch /path/to/teleop.launch.py
+
+Touches :
+    i : avance           , : recule          k : stop
+    j : rotation gauche  l : rotation droite
+    u/o : diagonales avant     m/. : diagonales arriere
+    q/z : +/- vitesse max 10%
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='yahboomcar_ctrl',
+            executable='yahboom_keyboard',
+            name='teleop_keyboard',
+            output='screen',
+            prefix='xterm -e',  # ouvre dans un terminal pour capter les touches
+        ),
+    ])

--- a/robot/roblaude_nav/launch/tf2_static.launch.py
+++ b/robot/roblaude_nav/launch/tf2_static.launch.py
@@ -1,7 +1,7 @@
 """
 tf2_static.launch.py — Publie les transforms STATIQUES du robot
 
-Un Static Transform = relation fixe entre deux repères (ne bouge jamais).
+Un Static Transform = relation fixe entre deux reperes (ne bouge jamais).
 Ex: le LiDAR est soude sur le chassis a 10 cm au-dessus du centre.
 
 Sans ces transforms, SLAM/Nav2 ne peuvent pas situer les capteurs.
@@ -12,48 +12,32 @@ Arbre tf (statique) apres ce launch :
     +-- camera_link           <- position camera
     +-- arm_base_link         <- base du bras
 
-Arguments (tous optionnels) :
-    lidar_xyz  : "x y z" du LiDAR (m) — defaut "0.0 0.0 0.10"
-    camera_xyz : "x y z" de la camera (m) — defaut "0.10 0.0 0.08"
-    arm_xyz    : "x y z" de la base du bras (m) — defaut "0.05 0.0 0.05"
-
-NB: les valeurs sont approximatives — a affiner avec les vraies mesures du M3 PRO.
+NB: les positions sont fixes (capteurs soudes au chassis). Valeurs
+approximatives pour le ROSMASTER M3 PRO — a affiner avec les vraies mesures.
 """
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     return LaunchDescription([
-        # Arguments configurables (valeurs par defaut pour le ROSMASTER M3 PRO)
-        DeclareLaunchArgument('lidar_xyz', default_value='0.0 0.0 0.10',
-                              description='Position LiDAR (x y z en metres) par rapport a base_link'),
-        DeclareLaunchArgument('camera_xyz', default_value='0.10 0.0 0.08',
-                              description='Position camera (x y z en metres) par rapport a base_link'),
-        DeclareLaunchArgument('arm_xyz', default_value='0.05 0.0 0.05',
-                              description='Position base du bras (x y z en metres) par rapport a base_link'),
-
-        # base_link -> laser_link (LiDAR)
+        # base_link -> laser_link (LiDAR, 10 cm au-dessus du centre)
         Node(
             package='tf2_ros',
             executable='static_transform_publisher',
             name='base_to_laser',
-            arguments=[
-                *LaunchConfiguration('lidar_xyz').perform(None).split() if False else ['0.0', '0.0', '0.10'],
-                '0', '0', '0',          # rotation (yaw pitch roll) en rad
-                'base_link', 'laser_link'
-            ],
+            arguments=['0.0', '0.0', '0.10', '0', '0', '0',
+                       'base_link', 'laser_link'],
         ),
 
-        # base_link -> camera_link (camera Astra Pro)
+        # base_link -> camera_link (camera RGB-D)
         Node(
             package='tf2_ros',
             executable='static_transform_publisher',
             name='base_to_camera',
-            arguments=['0.10', '0.0', '0.08', '0', '0', '0', 'base_link', 'camera_link'],
+            arguments=['0.10', '0.0', '0.08', '0', '0', '0',
+                       'base_link', 'camera_link'],
         ),
 
         # base_link -> arm_base_link (base du bras 6 DOF)
@@ -61,6 +45,7 @@ def generate_launch_description():
             package='tf2_ros',
             executable='static_transform_publisher',
             name='base_to_arm',
-            arguments=['0.05', '0.0', '0.05', '0', '0', '0', 'base_link', 'arm_base_link'],
+            arguments=['0.05', '0.0', '0.05', '0', '0', '0',
+                       'base_link', 'arm_base_link'],
         ),
     ])

--- a/robot/roblaude_nav/launch/tf2_static.launch.py
+++ b/robot/roblaude_nav/launch/tf2_static.launch.py
@@ -1,0 +1,66 @@
+"""
+tf2_static.launch.py — Publie les transforms STATIQUES du robot
+
+Un Static Transform = relation fixe entre deux repères (ne bouge jamais).
+Ex: le LiDAR est soude sur le chassis a 10 cm au-dessus du centre.
+
+Sans ces transforms, SLAM/Nav2 ne peuvent pas situer les capteurs.
+
+Arbre tf (statique) apres ce launch :
+    base_link                 <- centre du robot
+    +-- laser_link            <- position LiDAR
+    +-- camera_link           <- position camera
+    +-- arm_base_link         <- base du bras
+
+Arguments (tous optionnels) :
+    lidar_xyz  : "x y z" du LiDAR (m) — defaut "0.0 0.0 0.10"
+    camera_xyz : "x y z" de la camera (m) — defaut "0.10 0.0 0.08"
+    arm_xyz    : "x y z" de la base du bras (m) — defaut "0.05 0.0 0.05"
+
+NB: les valeurs sont approximatives — a affiner avec les vraies mesures du M3 PRO.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        # Arguments configurables (valeurs par defaut pour le ROSMASTER M3 PRO)
+        DeclareLaunchArgument('lidar_xyz', default_value='0.0 0.0 0.10',
+                              description='Position LiDAR (x y z en metres) par rapport a base_link'),
+        DeclareLaunchArgument('camera_xyz', default_value='0.10 0.0 0.08',
+                              description='Position camera (x y z en metres) par rapport a base_link'),
+        DeclareLaunchArgument('arm_xyz', default_value='0.05 0.0 0.05',
+                              description='Position base du bras (x y z en metres) par rapport a base_link'),
+
+        # base_link -> laser_link (LiDAR)
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='base_to_laser',
+            arguments=[
+                *LaunchConfiguration('lidar_xyz').perform(None).split() if False else ['0.0', '0.0', '0.10'],
+                '0', '0', '0',          # rotation (yaw pitch roll) en rad
+                'base_link', 'laser_link'
+            ],
+        ),
+
+        # base_link -> camera_link (camera Astra Pro)
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='base_to_camera',
+            arguments=['0.10', '0.0', '0.08', '0', '0', '0', 'base_link', 'camera_link'],
+        ),
+
+        # base_link -> arm_base_link (base du bras 6 DOF)
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='base_to_arm',
+            arguments=['0.05', '0.0', '0.05', '0', '0', '0', 'base_link', 'arm_base_link'],
+        ),
+    ])

--- a/robot/roblaude_nav/launch/web_video.launch.py
+++ b/robot/roblaude_nav/launch/web_video.launch.py
@@ -1,0 +1,57 @@
+"""
+web_video.launch.py — Expose les topics image ROS2 en flux HTTP (MJPEG)
+
+web_video_server ecoute sur le port 8080 et sert chaque topic image comme
+un flux consultable dans un navigateur ou une balise <img>.
+
+Exemples d URLs une fois lance :
+  http://<ROBOT_IP>:8080/                                 -> index des topics
+  http://<ROBOT_IP>:8080/stream?topic=/camera/color/image_raw&type=mjpeg
+  http://<ROBOT_IP>:8080/snapshot?topic=/camera/color/image_raw
+
+Utile pour :
+  - Integrer le flux camera dans le dashboard Flask (<img src="...">)
+  - Regarder la camera depuis un telephone sans installer Foxglove
+
+Usage :
+    ros2 launch /home/jetson/launch/web_video.launch.py
+    ros2 launch /home/jetson/launch/web_video.launch.py port:=8081
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    port_arg = DeclareLaunchArgument(
+        'port',
+        default_value='8080',
+        description='Port HTTP web_video_server',
+    )
+
+    address_arg = DeclareLaunchArgument(
+        'address',
+        default_value='0.0.0.0',
+        description='Interface d ecoute (0.0.0.0 = toutes)',
+    )
+
+    return LaunchDescription([
+        port_arg,
+        address_arg,
+        Node(
+            package='web_video_server',
+            executable='web_video_server',
+            name='web_video_server',
+            output='screen',
+            parameters=[{
+                'port': LaunchConfiguration('port'),
+                'address': LaunchConfiguration('address'),
+                'server_threads': 2,
+                'ros_threads': 2,
+                'default_stream_type': 'mjpeg',
+                'default_transport': 'raw',
+            }],
+        ),
+    ])

--- a/robot/roblaude_nav/package.xml
+++ b/robot/roblaude_nav/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>roblaude_nav</name>
+  <version>0.1.0</version>
+  <description>
+    Navigation autonome RobLaude — SLAM et Nav2 pour le ROSMASTER M3 PRO.
+    Contient les launch files capteurs (LiDAR, caméra, odométrie), la
+    cartographie SLAM Toolbox, la navigation Nav2, et les outils de
+    visualisation (Foxglove, web_video_server).
+  </description>
+  <maintainer email="[email protected]">Wissem</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>slam_toolbox</exec_depend>
+  <exec_depend>nav2_bringup</exec_depend>
+  <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>web_video_server</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/robot/roblaude_nav/roblaude_nav/odom_to_tf.py
+++ b/robot/roblaude_nav/roblaude_nav/odom_to_tf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+odom_to_tf.py - Convertit /odom_raw en TF odom -> base_link + republie sur /odom
+
+Le STM32 du ROSMASTER M3 PRO publie la nav_msgs/Odometry sur /odom_raw mais
+ne publie pas le transform odom -> base_link correspondant. Sans ce TF,
+SLAM ne peut pas estimer la position du robot.
+
+Ce noeud :
+  - Abonnement : /odom_raw (nav_msgs/Odometry)
+  - Publications :
+      * TF dynamique odom -> base_link
+      * /odom (nav_msgs/Odometry, header.frame_id force a 'odom')
+
+Usage (dans le container ROS2) :
+    export ROS_DOMAIN_ID=30
+    python3 /root/odom_to_tf.py
+"""
+
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import TransformStamped
+from tf2_ros import TransformBroadcaster
+
+
+class OdomToTf(Node):
+    def __init__(self):
+        super().__init__('odom_to_tf')
+        self.br = TransformBroadcaster(self)
+        self.pub = self.create_publisher(Odometry, '/odom', 10)
+        self.sub = self.create_subscription(
+            Odometry, '/odom_raw', self.cb, 10
+        )
+        self.get_logger().info('odom_to_tf ready : /odom_raw -> TF + /odom')
+
+    def cb(self, msg: Odometry):
+        t = TransformStamped()
+        t.header.stamp = msg.header.stamp
+        t.header.frame_id = 'odom'
+        t.child_frame_id = 'base_link'
+        p = msg.pose.pose.position
+        q = msg.pose.pose.orientation
+        t.transform.translation.x = p.x
+        t.transform.translation.y = p.y
+        t.transform.translation.z = p.z
+        t.transform.rotation = q
+        self.br.sendTransform(t)
+
+        out = Odometry()
+        out.header.stamp = msg.header.stamp
+        out.header.frame_id = 'odom'
+        out.child_frame_id = 'base_link'
+        out.pose = msg.pose
+        out.twist = msg.twist
+        self.pub.publish(out)
+
+
+def main():
+    rclpy.init()
+    node = OdomToTf()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robot/roblaude_nav/roblaude_nav/scan_restamper.py
+++ b/robot/roblaude_nav/roblaude_nav/scan_restamper.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+scan_restamper.py - Re-stamp les messages du STM32 au temps courant
+
+Probleme : le STM32 publie /scan0 /scan1 /odom_raw avec timestamps dates
+de decembre 2025 (horloge STM32 pas synchronisee avec le Jetson). SLAM
+rejette ces messages car l ecart avec les TF courants depasse sa tolerance.
+
+Ce noeud :
+  - Ecoute /scan (laser fusionne)      -> republie /scan_stamped avec now()
+  - Ecoute /odom_raw (odometrie STM32) -> republie /odom avec now()
+                                        + publie TF odom -> base_link avec now()
+
+Resultat : SLAM tourne sur /scan_stamped et trouve toujours un TF coherent.
+
+Usage :
+    export ROS_DOMAIN_ID=30
+    python3 /root/scan_restamper.py
+"""
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import LaserScan
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import TransformStamped
+from tf2_ros import TransformBroadcaster
+
+
+class ScanRestamper(Node):
+    def __init__(self):
+        super().__init__('scan_restamper')
+
+        self.br = TransformBroadcaster(self)
+        self.scan_pub = self.create_publisher(LaserScan, '/scan_stamped', 10)
+        self.odom_pub = self.create_publisher(Odometry, '/odom', 10)
+
+        self.create_subscription(LaserScan, '/scan', self.scan_cb, 10)
+        self.create_subscription(Odometry, '/odom_raw', self.odom_cb, 10)
+
+        self._scan_count = 0
+        self._odom_count = 0
+        self.create_timer(5.0, self._report)
+        self.get_logger().info(
+            'scan_restamper ready : /scan -> /scan_stamped, /odom_raw -> /odom + TF'
+        )
+
+    def scan_cb(self, msg: LaserScan):
+        msg.header.stamp = self.get_clock().now().to_msg()
+        self.scan_pub.publish(msg)
+        self._scan_count += 1
+
+    def odom_cb(self, msg: Odometry):
+        now = self.get_clock().now().to_msg()
+
+        t = TransformStamped()
+        t.header.stamp = now
+        t.header.frame_id = 'odom'
+        t.child_frame_id = 'base_link'
+        p = msg.pose.pose.position
+        q = msg.pose.pose.orientation
+        t.transform.translation.x = p.x
+        t.transform.translation.y = p.y
+        t.transform.translation.z = p.z
+        t.transform.rotation = q
+        self.br.sendTransform(t)
+
+        out = Odometry()
+        out.header.stamp = now
+        out.header.frame_id = 'odom'
+        out.child_frame_id = 'base_link'
+        out.pose = msg.pose
+        out.twist = msg.twist
+        self.odom_pub.publish(out)
+        self._odom_count += 1
+
+    def _report(self):
+        self.get_logger().info(
+            f'Restamped: {self._scan_count} scans, {self._odom_count} odom'
+        )
+        self._scan_count = 0
+        self._odom_count = 0
+
+
+def main():
+    rclpy.init()
+    node = ScanRestamper()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robot/roblaude_nav/setup.cfg
+++ b/robot/roblaude_nav/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/roblaude_nav
+[install]
+install_scripts=$base/lib/roblaude_nav

--- a/robot/roblaude_nav/setup.py
+++ b/robot/roblaude_nav/setup.py
@@ -1,0 +1,33 @@
+import os
+from glob import glob
+from setuptools import setup
+
+package_name = 'roblaude_nav'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'),
+            glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'config'),
+            glob('config/*')),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Wissem',
+    maintainer_email='[email protected]',
+    description='Navigation autonome RobLaude — SLAM + Nav2 pour le ROSMASTER M3 PRO',
+    license='MIT',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'scan_restamper = roblaude_nav.scan_restamper:main',
+            'odom_to_tf = roblaude_nav.odom_to_tf:main',
+        ],
+    },
+)

--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -10,7 +10,7 @@
 # (ex: /root/launch/, /root/scan_restamper.py, /root/odom_to_tf.py).
 
 CONTAINER_NAME="m3pro_main"
-IMAGE="192.168.2.51.5000/rosmaster-m3pro-nano:1.1.0"
+IMAGE="192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0"
 
 # 1) Attend le demon Docker
 while true; do

--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Docker_M3Pro_Joy.sh — Lance le container ROS2 principal du M3 PRO
+#
+# Comportement :
+#   - Attend que Docker soit pret
+#   - Si le container "m3pro_main" existe deja -> le redemarre (garde /root/*)
+#   - Sinon -> le cree avec un nom fixe (pas de noms random angry_ptolemy...)
+#
+# Avantage : tu retrouves tes fichiers perso dans /root/ entre les reboots
+# (ex: /root/launch/, /root/scan_restamper.py, /root/odom_to_tf.py).
+
+CONTAINER_NAME="m3pro_main"
+IMAGE="192.168.2.51.5000/rosmaster-m3pro-nano:1.1.0"
+
+# 1) Attend le demon Docker
+while true; do
+    if systemctl is-active --quiet docker; then
+        echo "✅ Docker service has been started"
+        break
+    fi
+    echo "⏳ The Docker service has not started, waiting..."
+    sleep 1
+done
+
+xhost +
+
+# 2) Container deja existant ? -> on le relance simplement
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "ℹ️  Container '${CONTAINER_NAME}' deja existant, redemarrage..."
+    docker start -ai "${CONTAINER_NAME}"
+    exit $?
+fi
+
+# 3) Sinon : creation initiale
+echo "🚀 Creation du container '${CONTAINER_NAME}' (premiere fois)"
+docker run -it \
+    --name "${CONTAINER_NAME}" \
+    --restart unless-stopped \
+    --net=host \
+    --env="DISPLAY" \
+    --env="QT_X11_NO_MITSHM=1" \
+    -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
+    -e ALSA_CARD=0 \
+    -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
+    -v /run/user/1000/pulse:/run/user/1000/pulse:ro \
+    -v ~/.config/pulse:/root/.config/pulse:ro \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v /home/jetson/launch:/root/launch \
+    --device=/dev/bus/usb \
+    --security-opt apparmor:unconfined \
+    --device=/dev/input \
+    "${IMAGE}" /bin/bash /root/joy.sh

--- a/robot/scripts/connect.sh
+++ b/robot/scripts/connect.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# connect.sh — Ouvre rapidement une session SSH au robot + noVNC dans le navigateur
+#
+# Usage : ./connect.sh [--no-vnc]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_robot.sh"
+
+ROBOT_USER="${ROBOT_USER:-jetson}"
+OPEN_VNC=true
+
+if [[ "$1" == "--no-vnc" ]]; then
+    OPEN_VNC=false
+fi
+
+# Auto-detect robot par MAC (resistant au changement d IP DHCP du WiFi event)
+if ! find_robot; then
+    exit 1
+fi
+echo "✅ Robot OK"
+
+if $OPEN_VNC; then
+    echo "=== Ouverture noVNC dans navigateur ==="
+    open "http://$ROBOT_IP:6080/vnc.html?host=$ROBOT_IP&port=6080&autoconnect=1&resize=scale"
+fi
+
+echo "=== SSH au robot (password: yahboom) ==="
+ssh "$ROBOT_USER@$ROBOT_IP"

--- a/robot/scripts/deploy_to_robot.sh
+++ b/robot/scripts/deploy_to_robot.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# deploy_to_robot.sh — Pousse les launch files vers le robot
+#
+# Usage : ./deploy_to_robot.sh
+#
+# Prerequis :
+#   - sshpass installe (brew install sshpass)
+#   - Robot accessible sur 172.20.10.2 (ssh jetson@... fonctionne)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_robot.sh"
+
+ROBOT_USER="${ROBOT_USER:-jetson}"
+ROBOT_PASS="${ROBOT_PASS:-yahboom}"
+DEST_DIR="${DEST_DIR:-/home/jetson/launch}"
+CONTAINER="${CONTAINER:-angry_ptolemy}"
+CONTAINER_DEST="${CONTAINER_DEST:-/root/launch}"
+
+# Auto-detect robot par MAC
+if ! find_robot; then
+    exit 1
+fi
+
+LOCAL_DIR="$(cd "$SCRIPT_DIR/../robot_stack/launch" && pwd)"
+
+echo "=== Deploy robot_stack/launch/ vers $ROBOT_USER@$ROBOT_IP:$DEST_DIR ==="
+echo "Source : $LOCAL_DIR"
+echo ""
+
+# Creer le dossier distant si besoin
+sshpass -p "$ROBOT_PASS" ssh -o StrictHostKeyChecking=no "$ROBOT_USER@$ROBOT_IP" \
+    "mkdir -p $DEST_DIR"
+
+# Transfert rsync (delta = rapide)
+sshpass -p "$ROBOT_PASS" rsync -avz --delete \
+    -e "ssh -o StrictHostKeyChecking=no" \
+    "$LOCAL_DIR/" \
+    "$ROBOT_USER@$ROBOT_IP:$DEST_DIR/"
+
+echo ""
+echo "=== Propagation vers le container $CONTAINER:$CONTAINER_DEST ==="
+# Le container ROS2 n a pas de volume vers ~/launch : on copie dedans
+sshpass -p "$ROBOT_PASS" ssh -o StrictHostKeyChecking=no "$ROBOT_USER@$ROBOT_IP" \
+    "docker exec $CONTAINER mkdir -p $CONTAINER_DEST && docker cp $DEST_DIR/. $CONTAINER:$CONTAINER_DEST/"
+
+echo ""
+echo "✅ Deploiement termine (host + container)."
+echo ""
+echo "Pour lancer un fichier :"
+echo "  ssh $ROBOT_USER@$ROBOT_IP"
+echo "  docker exec -it $CONTAINER bash"
+echo "  source /opt/ros/humble/setup.bash"
+echo "  source /root/yahboomcar_ws/install/setup.bash"
+echo "  export ROS_DOMAIN_ID=30"
+echo "  ros2 launch $CONTAINER_DEST/lidar.launch.py"

--- a/robot/scripts/deploy_to_robot.sh
+++ b/robot/scripts/deploy_to_robot.sh
@@ -15,7 +15,7 @@ source "$SCRIPT_DIR/find_robot.sh"
 ROBOT_USER="${ROBOT_USER:-jetson}"
 ROBOT_PASS="${ROBOT_PASS:-yahboom}"
 DEST_DIR="${DEST_DIR:-/home/jetson/launch}"
-CONTAINER="${CONTAINER:-angry_ptolemy}"
+CONTAINER="${CONTAINER:-m3pro_main}"
 CONTAINER_DEST="${CONTAINER_DEST:-/root/launch}"
 
 # Auto-detect robot par MAC
@@ -23,9 +23,9 @@ if ! find_robot; then
     exit 1
 fi
 
-LOCAL_DIR="$(cd "$SCRIPT_DIR/../robot_stack/launch" && pwd)"
+LOCAL_DIR="$(cd "$SCRIPT_DIR/../roblaude_nav/launch" && pwd)"
 
-echo "=== Deploy robot_stack/launch/ vers $ROBOT_USER@$ROBOT_IP:$DEST_DIR ==="
+echo "=== Deploy roblaude_nav/launch/ vers $ROBOT_USER@$ROBOT_IP:$DEST_DIR ==="
 echo "Source : $LOCAL_DIR"
 echo ""
 

--- a/robot/scripts/find_robot.sh
+++ b/robot/scripts/find_robot.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# find_robot.sh — Trouve l'IP courante du robot en scannant le subnet par MAC
+#
+# Le WiFi event change régulièrement l IP du robot via DHCP. Cette fonction
+# scanne le subnet local et retourne l IP correspondant a la MAC du Jetson.
+#
+# Usage (sourcing) :
+#   source scripts/find_robot.sh
+#   find_robot            # remplit $ROBOT_IP
+#
+# Usage (standalone) :
+#   ./scripts/find_robot.sh
+#
+# Configurable via env :
+#   ROBOT_MAC      : MAC du Jetson (defaut 50:3d:d1:ff:f3:7d)
+#   ROBOT_IP       : si deja set et ping OK, on ne scan pas
+#   SUBNET_PREFIX  : ex "10.10.221" (si absent, deduit de l IP locale)
+
+ROBOT_MAC="${ROBOT_MAC:-50:3d:d1:ff:f3:7d}"
+
+find_robot() {
+    # 1) Si ROBOT_IP deja set et robot ping, on garde
+    if [ -n "$ROBOT_IP" ] && ping -c 1 -W 1 "$ROBOT_IP" > /dev/null 2>&1; then
+        # verifier que c est bien notre robot (MAC match)
+        local arp_mac
+        arp_mac=$(arp -n "$ROBOT_IP" 2>/dev/null | awk '{print $4}' | grep -i "^$ROBOT_MAC$")
+        if [ -n "$arp_mac" ]; then
+            echo "✅ Robot deja joignable a $ROBOT_IP (MAC confirmee)" >&2
+            export ROBOT_IP
+            return 0
+        fi
+    fi
+
+    echo "🔍 Scan du subnet pour trouver le robot (MAC $ROBOT_MAC)..." >&2
+
+    # 2) Deduire le prefix subnet depuis l IP locale
+    local prefix="${SUBNET_PREFIX}"
+    if [ -z "$prefix" ]; then
+        local local_ip
+        local_ip=$(ipconfig getifaddr en0 2>/dev/null)
+        if [ -z "$local_ip" ]; then
+            # Fallback Linux : route par defaut
+            local_ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)
+        fi
+        prefix=$(echo "$local_ip" | cut -d. -f1-3)
+    fi
+
+    if [ -z "$prefix" ]; then
+        echo "❌ Impossible de deduire le subnet local" >&2
+        return 1
+    fi
+
+    # 3) Ping parallele sur tout le subnet pour peupler la table ARP
+    echo "   -> ping $prefix.1-254 en parallele..." >&2
+    for i in $(seq 1 254); do
+        ping -c 1 -W 1 -t 1 "$prefix.$i" > /dev/null 2>&1 &
+    done
+    wait 2>/dev/null
+
+    # 4) Chercher la MAC dans la table ARP (compatible macOS BSD et Linux)
+    local found_ip
+    found_ip=$(arp -a 2>/dev/null | grep -i "$ROBOT_MAC" | awk -F'[()]' '{print $2}' | head -1)
+
+    if [ -z "$found_ip" ]; then
+        echo "❌ Robot introuvable dans $prefix.0/24 (MAC $ROBOT_MAC)" >&2
+        echo "   Verifie que le robot est allume et sur le meme WiFi que toi." >&2
+        return 1
+    fi
+
+    echo "✅ Robot trouve a $found_ip (MAC $ROBOT_MAC)" >&2
+    export ROBOT_IP="$found_ip"
+    return 0
+}
+
+# Si execute directement (pas sourced) : affiche l IP
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    find_robot && echo "$ROBOT_IP"
+fi

--- a/robot/scripts/start_agent.sh
+++ b/robot/scripts/start_agent.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# start_agent.sh — Lance le container micro-ROS-agent avec nom fixe
+#
+# Identique a la logique Docker_M3Pro_Joy.sh : nom fixe "micro_ros_agent"
+# -> pas de nouveau container a chaque reboot.
+
+CONTAINER_NAME="micro_ros_agent"
+IMAGE="192.168.2.51:5000/micro-ros-agent:humble"
+
+# Attend Docker
+while ! systemctl is-active --quiet docker; do
+    sleep 1
+done
+
+# Reuse si existant
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "ℹ️  Container '${CONTAINER_NAME}' deja existant, redemarrage..."
+    docker start -ai "${CONTAINER_NAME}"
+    exit $?
+fi
+
+# Creation initiale
+echo "🚀 Creation du container '${CONTAINER_NAME}'"
+docker run -it \
+    --name "${CONTAINER_NAME}" \
+    --restart unless-stopped \
+    --init \
+    -v /dev:/dev \
+    -v /dev/shm:/dev/shm \
+    --privileged \
+    --net=host \
+    "${IMAGE}" \
+    serial --dev /dev/myserial -b 2000000 -v4

--- a/robot/scripts/start_all.sh
+++ b/robot/scripts/start_all.sh
@@ -14,6 +14,9 @@ ROBLAUDE_WS="${ROBLAUDE_WS:-/root/roblaude_ws}"
 YAHBOOM_WS="${YAHBOOM_WS:-/root/yahboomcar_ws}"
 mkdir -p /tmp/roslogs
 
+# PIDs des process lances, pour la verification finale
+declare -A LAUNCH_PIDS
+
 launch_bg() {
     local name="$1"; shift
     echo "-> lance $name"
@@ -23,15 +26,18 @@ launch_bg() {
         source $ROBLAUDE_WS/install/setup.bash 2>/dev/null
         export ROS_DOMAIN_ID=30
         $*
-    " > /tmp/roslogs/$name.log 2>&1 &
+    " > "/tmp/roslogs/$name.log" 2>&1 &
+    LAUNCH_PIDS[$name]=$!
 }
 
-# Tuer d anciennes instances pour repartir propre
-pkill -f foxglove_bridge    2>/dev/null
-pkill -f web_video_server   2>/dev/null
-pkill -f async_slam_toolbox 2>/dev/null
-pkill -f scan_restamper     2>/dev/null
-pkill -f odom_to_tf         2>/dev/null
+# Tuer d anciennes instances pour repartir propre.
+# Le '|| true' est explicite : si rien ne tourne, pkill renvoie 1 — ce
+# n'est pas une erreur ici.
+pkill -f foxglove_bridge    2>/dev/null || true
+pkill -f web_video_server   2>/dev/null || true
+pkill -f async_slam_toolbox 2>/dev/null || true
+pkill -f scan_restamper     2>/dev/null || true
+pkill -f odom_to_tf         2>/dev/null || true
 sleep 2
 
 # 1) Bridges de visualisation (package roblaude_nav)
@@ -55,6 +61,25 @@ sleep 8
 # 5) SLAM (utilise /scan_stamped)
 launch_bg slam      "ros2 launch roblaude_nav slam.launch.py"
 
+# Verification : chaque process est-il toujours vivant 3s apres lancement ?
+sleep 3
 echo ""
-echo "✅ Stack demarree. Logs : /tmp/roslogs/*.log"
+echo "=== Etat des composants ==="
+all_ok=true
+for name in "${!LAUNCH_PIDS[@]}"; do
+    pid=${LAUNCH_PIDS[$name]}
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "  ✅ $name (pid $pid)"
+    else
+        echo "  ❌ $name a quitte — voir /tmp/roslogs/$name.log"
+        all_ok=false
+    fi
+done
+
+echo ""
+if $all_ok; then
+    echo "✅ Stack demarree. Logs : /tmp/roslogs/*.log"
+else
+    echo "⚠️  Certains composants ont quitte — verifier les logs ci-dessus."
+fi
 echo "Verif : ros2 topic hz /scan_stamped  (doit etre ~7 Hz)"

--- a/robot/scripts/start_all.sh
+++ b/robot/scripts/start_all.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# start_all.sh - Lance toute la stack ROS2 de navigation RobLaude
+#
+# A lancer DANS le container ROS2 du robot :
+#     docker exec m3pro_main bash /root/roblaude_ws/src/robot/scripts/start_all.sh
+#
+# Prerequis : le package roblaude_nav doit etre compile (colcon build)
+# dans $ROBLAUDE_WS.
+
+set -u
+
+export ROS_DOMAIN_ID=30
+ROBLAUDE_WS="${ROBLAUDE_WS:-/root/roblaude_ws}"
+YAHBOOM_WS="${YAHBOOM_WS:-/root/yahboomcar_ws}"
+mkdir -p /tmp/roslogs
+
+launch_bg() {
+    local name="$1"; shift
+    echo "-> lance $name"
+    nohup bash -c "
+        source /opt/ros/humble/setup.bash
+        source $YAHBOOM_WS/install/setup.bash 2>/dev/null
+        source $ROBLAUDE_WS/install/setup.bash 2>/dev/null
+        export ROS_DOMAIN_ID=30
+        $*
+    " > /tmp/roslogs/$name.log 2>&1 &
+}
+
+# Tuer d anciennes instances pour repartir propre
+pkill -f foxglove_bridge    2>/dev/null
+pkill -f web_video_server   2>/dev/null
+pkill -f async_slam_toolbox 2>/dev/null
+pkill -f scan_restamper     2>/dev/null
+pkill -f odom_to_tf         2>/dev/null
+sleep 2
+
+# 1) Bridges de visualisation (package roblaude_nav)
+launch_bg foxglove  "ros2 launch roblaude_nav foxglove.launch.py"
+launch_bg webvideo  "ros2 launch roblaude_nav web_video.launch.py"
+
+# 2) URDF robot (TF chassis) - package Yahboom
+launch_bg rsp       "ros2 launch yahboom_M3Pro_description display_launch.py"
+
+# 3) Capteurs (laser fusionne, camera) - packages Yahboom
+launch_bg laser     "ros2 launch yahboom_M3Pro_laser laser_driver.launch.py"
+launch_bg camera    "ros2 launch orbbec_camera dabai_dcw2.launch.py"
+
+# 4) Re-stamper : corrige les timestamps STM32 (scan + odom)
+launch_bg restamper "ros2 run roblaude_nav scan_restamper"
+
+# Laisser les capteurs s initialiser avant SLAM
+echo "⏳ attente 8s que les capteurs se stabilisent..."
+sleep 8
+
+# 5) SLAM (utilise /scan_stamped)
+launch_bg slam      "ros2 launch roblaude_nav slam.launch.py"
+
+echo ""
+echo "✅ Stack demarree. Logs : /tmp/roslogs/*.log"
+echo "Verif : ros2 topic hz /scan_stamped  (doit etre ~7 Hz)"

--- a/robot/scripts/start_robot.sh
+++ b/robot/scripts/start_robot.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# start_robot.sh — Script tout-en-un pour demarrer une session robot
+#
+# Ce qu il fait (dans l ordre) :
+#   1) Auto-detecte l IP du robot par MAC address (resiste aux changements DHCP)
+#   2) Fixe l horloge du Jetson (pas de RTC -> date perdue a chaque extinction)
+#   3) Verifie que m3pro_main et micro_ros_agent tournent (les demarre sinon)
+#   4) Lance la stack ROS2 complete (start_all.sh dans le container)
+#   5) Ouvre Foxglove Studio (si installe) sur l URL du bridge
+#
+# Usage :
+#     ./scripts/start_robot.sh            # full start
+#     ./scripts/start_robot.sh --no-foxglove  # sans ouvrir Foxglove
+#
+# Options env :
+#     ROBOT_MAC=aa:bb:... # si tu utilises un autre robot
+#     NO_CLOCK_SYNC=1     # saute la sync horloge
+#     NO_START=1          # ne lance pas start_all.sh (juste connexion)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_robot.sh"
+
+ROBOT_USER="${ROBOT_USER:-jetson}"
+ROBOT_PASS="${ROBOT_PASS:-yahboom}"
+CONTAINER="${CONTAINER:-m3pro_main}"
+AGENT_CONTAINER="${AGENT_CONTAINER:-micro_ros_agent}"
+
+OPEN_FOXGLOVE=true
+if [[ "$1" == "--no-foxglove" ]]; then
+    OPEN_FOXGLOVE=false
+fi
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+ssh_cmd() {
+    sshpass -p "$ROBOT_PASS" ssh $SSH_OPTS "$ROBOT_USER@$ROBOT_IP" "$@"
+}
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🤖 ROSMASTER M3 PRO — Start session"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── 1) Auto-detect IP par MAC ────────────────────────────
+echo ""
+echo "▶ Etape 1/5 : Recherche du robot"
+if ! find_robot; then
+    echo "❌ Robot introuvable sur ton subnet. Verifie qu il est allume."
+    exit 1
+fi
+
+# ── 2) Sync horloge (palliatif au Jetson sans RTC) ───────
+if [ -z "${NO_CLOCK_SYNC:-}" ]; then
+    echo ""
+    echo "▶ Etape 2/5 : Sync horloge Jetson"
+    MAC_UTC=$(date -u +"%Y-%m-%d %H:%M:%S")
+    ROBOT_DATE=$(ssh_cmd "date -u +%s")
+    MAC_DATE=$(date -u +%s)
+    DIFF=$(( MAC_DATE - ROBOT_DATE ))
+    if [ ${DIFF#-} -gt 60 ]; then
+        echo "   ⏰ Ecart detecte : ${DIFF}s -> resync"
+        ssh_cmd "echo $ROBOT_PASS | sudo -S date -u -s '$MAC_UTC'" > /dev/null 2>&1
+        echo "   ✅ Horloge fixee a $MAC_UTC UTC"
+    else
+        echo "   ✅ Horloge deja correcte (ecart ${DIFF}s)"
+    fi
+else
+    echo "▶ Etape 2/5 : Sync horloge — SKIP (NO_CLOCK_SYNC=1)"
+fi
+
+# ── 3) Verif containers ─────────────────────────────────
+echo ""
+echo "▶ Etape 3/5 : Verification containers"
+RUNNING=$(ssh_cmd "docker ps --format '{{.Names}}'" 2>/dev/null)
+for c in "$CONTAINER" "$AGENT_CONTAINER"; do
+    if echo "$RUNNING" | grep -q "^$c$"; then
+        echo "   ✅ $c en cours"
+    else
+        echo "   ⚠️  $c arrete, tentative de demarrage..."
+        ssh_cmd "docker start $c" > /dev/null 2>&1 || echo "   ❌ impossible de demarrer $c"
+    fi
+done
+
+# ── 4) Lancer la stack ROS2 ──────────────────────────────
+if [ -z "${NO_START:-}" ]; then
+    echo ""
+    echo "▶ Etape 4/5 : Lancement stack ROS2 (start_all.sh)"
+    ssh_cmd "docker exec $CONTAINER bash /root/start_all.sh" 2>&1 | sed 's/^/   /'
+
+    echo ""
+    echo "   ⏳ Attente 10s stabilisation..."
+    sleep 10
+
+    echo "   Verif ports :"
+    for port in 8765 8080; do
+        if nc -zv -w 2 "$ROBOT_IP" "$port" 2>&1 | grep -q succeeded; then
+            echo "   ✅ port $port (${port/8765/foxglove}${port/8080/web_video}) ouvert"
+        else
+            echo "   ⚠️  port $port non disponible"
+        fi
+    done
+else
+    echo "▶ Etape 4/5 : Start stack — SKIP (NO_START=1)"
+fi
+
+# ── 5) Ouverture Foxglove ───────────────────────────────
+echo ""
+echo "▶ Etape 5/5 : Foxglove Studio"
+FOXGLOVE_URL="ws://$ROBOT_IP:8765"
+VIDEO_URL="http://$ROBOT_IP:8080/stream?topic=/camera/color/image_raw&type=mjpeg"
+
+if $OPEN_FOXGLOVE && command -v open > /dev/null; then
+    # Ouvre Foxglove Studio si installe, sinon son URL de telechargement
+    if [ -d "/Applications/Foxglove Studio.app" ] || [ -d "/Applications/Foxglove.app" ]; then
+        open "foxglove://open?ds=foxglove-websocket&ds.url=$FOXGLOVE_URL"
+        echo "   ✅ Foxglove lance sur $FOXGLOVE_URL"
+    else
+        echo "   ℹ️  Foxglove Studio non detecte dans /Applications"
+        echo "       Install : brew install --cask foxglove-studio"
+        echo "       Connexion manuelle : $FOXGLOVE_URL"
+    fi
+else
+    echo "   URL Foxglove : $FOXGLOVE_URL"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Session prete"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Robot IP      : $ROBOT_IP"
+echo "Foxglove      : $FOXGLOVE_URL"
+echo "Camera MJPEG  : $VIDEO_URL"
+echo ""
+echo "Pour SSH direct : sshpass -p yahboom ssh jetson@$ROBOT_IP"
+echo "Pour logs ROS   : ssh jetson@$ROBOT_IP 'docker exec -it $CONTAINER tail -f /tmp/roslogs/slam.log'"

--- a/robot/scripts/start_robot.sh
+++ b/robot/scripts/start_robot.sh
@@ -85,7 +85,7 @@ done
 if [ -z "${NO_START:-}" ]; then
     echo ""
     echo "▶ Etape 4/5 : Lancement stack ROS2 (start_all.sh)"
-    ssh_cmd "docker exec $CONTAINER bash /root/start_all.sh" 2>&1 | sed 's/^/   /'
+    ssh_cmd "docker exec $CONTAINER bash /root/roblaude_ws/src/robot/scripts/start_all.sh" 2>&1 | sed 's/^/   /'
 
     echo ""
     echo "   ⏳ Attente 10s stabilisation..."


### PR DESCRIPTION
## Contenu

Premier code ROS2 versionne du projet — le dossier robot/ etait vide.
Migration depuis le bac a sable setup-ros2-environnement vers la structure
officielle robot/ (cf docs/architecture.md).

### Package roblaude_nav (ament_python)
- 9 launch files : lidar, camera, odom, tf2_static, slam, nav2, teleop, foxglove, web_video
- 2 nodes : scan_restamper (corrige les timestamps du STM32 non synchronise),
  odom_to_tf (publie le TF dynamique odom -> base_link)
- config : layout Foxglove SLAM

### robot/scripts/ (7 outils host hors ROS2)
find_robot (detection MAC), start_robot, start_all, deploy_to_robot,
connect, Docker_M3Pro_Joy, start_agent

## Issues concernees (non fermees — travail reel pas termine)
- #63 Cartographier un couloir reel — stack SLAM prete et testee sur le robot
- #152 LiDAR reel — verifie (/scan 7 Hz)
- #154 SLAM sur le vrai batiment — SLAM publie /map

## Teste
Code prouve fonctionnel sur le ROSMASTER M3 Pro physique : SLAM publie /map,
chaine TF map -> odom -> base_link resolue.

## Pas encore fait
- Volet simulation Gazebo (#51, #52)
- Sauvegarde de carte (#53), envoi de goals Nav2 (#56-59), navigation autonome IRL (#64)