### PR TITLE
fix(robot): nom du container m3pro

### DIFF
--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -3,13 +3,13 @@
 #
 # Comportement :
 #   - Attend que Docker soit pret
-#   - Si le container "m3pro_main" existe deja -> le redemarre (garde /root/*)
+#   - Si le container "m3pro" existe deja -> le redemarre (garde /root/*)
 #   - Sinon -> le cree avec un nom fixe (pas de noms random angry_ptolemy...)
 #
 # Avantage : tu retrouves tes fichiers perso dans /root/ entre les reboots
 # (ex: /root/launch/, /root/scan_restamper.py, /root/odom_to_tf.py).
 
-CONTAINER_NAME="m3pro_main"
+CONTAINER_NAME="m3pro"
 IMAGE="192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0"
 
 # 1) Attend le demon Docker

--- a/robot/scripts/deploy_to_robot.sh
+++ b/robot/scripts/deploy_to_robot.sh
@@ -15,7 +15,7 @@ source "$SCRIPT_DIR/find_robot.sh"
 ROBOT_USER="${ROBOT_USER:-jetson}"
 ROBOT_PASS="${ROBOT_PASS:-yahboom}"
 DEST_DIR="${DEST_DIR:-/home/jetson/launch}"
-CONTAINER="${CONTAINER:-m3pro_main}"
+CONTAINER="${CONTAINER:-m3pro}"
 CONTAINER_DEST="${CONTAINER_DEST:-/root/launch}"
 
 # Auto-detect robot par MAC

--- a/robot/scripts/start_all.sh
+++ b/robot/scripts/start_all.sh
@@ -2,7 +2,7 @@
 # start_all.sh - Lance toute la stack ROS2 de navigation RobLaude
 #
 # A lancer DANS le container ROS2 du robot :
-#     docker exec m3pro_main bash /root/roblaude_ws/src/robot/scripts/start_all.sh
+#     docker exec m3pro bash /root/roblaude_ws/src/robot/scripts/start_all.sh
 #
 # Prerequis : le package roblaude_nav doit etre compile (colcon build)
 # dans $ROBLAUDE_WS.

--- a/robot/scripts/start_robot.sh
+++ b/robot/scripts/start_robot.sh
@@ -4,7 +4,7 @@
 # Ce qu il fait (dans l ordre) :
 #   1) Auto-detecte l IP du robot par MAC address (resiste aux changements DHCP)
 #   2) Fixe l horloge du Jetson (pas de RTC -> date perdue a chaque extinction)
-#   3) Verifie que m3pro_main et micro_ros_agent tournent (les demarre sinon)
+#   3) Verifie que m3pro et micro_ros_agent tournent (les demarre sinon)
 #   4) Lance la stack ROS2 complete (start_all.sh dans le container)
 #   5) Ouvre Foxglove Studio (si installe) sur l URL du bridge
 #
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/find_robot.sh"
 
 ROBOT_USER="${ROBOT_USER:-jetson}"
 ROBOT_PASS="${ROBOT_PASS:-yahboom}"
-CONTAINER="${CONTAINER:-m3pro_main}"
+CONTAINER="${CONTAINER:-m3pro}"
 AGENT_CONTAINER="${AGENT_CONTAINER:-micro_ros_agent}"
 
 OPEN_FOXGLOVE=true


### PR DESCRIPTION
Mon fix dans #198 changeait `angry_ptolemy` -> `m3pro_main` dans `Docker_M3Pro_Joy.sh` (et les autres scripts), mais l'image Yahboom du ROSMASTER M3 PRO crée en fait un container nommé **`m3pro`** tout court. Vérifié sur le robot pendant la session de déploiement du bridge MQTT : `docker ps` montre `m3pro`, pas `m3pro_main`.

Du coup les scripts ne ciblaient le bon container chez personne. 6 occurrences corrigées dans 4 fichiers (defaults + commentaires).

## Verifie
- `bash -n` OK sur les 7 scripts
- Aligne avec la realite Yahboom (`docker ps` sur le robot Wissem)