### PR TITLE
[T4.3.1] Persistance déploiement robot — workspace + autostart + horloge

### DIFF
--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -1,52 +1,64 @@
 #!/bin/bash
-# Docker_M3Pro_Joy.sh — Lance le container ROS2 principal du M3 PRO
+# Docker_M3Pro_Joy.sh — lance le container ROS2 du M3 PRO avec notre persistance
 #
-# Comportement :
-#   - Attend que Docker soit pret
-#   - Si le container "m3pro_main" existe deja -> le redemarre (garde /root/*)
-#   - Sinon -> le cree avec un nom fixe (pas de noms random angry_ptolemy...)
+# Remplace le script Yahboom d'origine. Différences :
+#   - container nommé "m3pro" (stable, pas de hunting docker ps)
+#   - --restart=unless-stopped (revient apres crash + reboot host)
+#   - bind-mount /home/jetson/roblaude_ws (NOTRE workspace, source de verite)
+#   - bind-mount /home/jetson/robot_maps (cartes SLAM persistees)
+#   - bind-mount /etc/roblaude (broker_ip mis a jour par sync_time.sh)
+#   - PAS de mount du m3pro_teacher_ws (on n'utilise plus le code prof)
+#   - lance NOTRE container_autostart.sh comme PID 1
 #
-# Avantage : tu retrouves tes fichiers perso dans /root/ entre les reboots
-# (ex: /root/launch/, /root/scan_restamper.py, /root/odom_to_tf.py).
+# Installe par install_persistence.sh sur /home/jetson/Docker_M3Pro_Joy.sh,
+# appele par l'autostart Yahboom existant (~/.config/autostart/uros.desktop).
 
-CONTAINER_NAME="m3pro_main"
-IMAGE="192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0"
-
-# 1) Attend le demon Docker
+# Attendre le demon Docker
 while true; do
     if systemctl is-active --quiet docker; then
-        echo "✅ Docker service has been started"
         break
     fi
-    echo "⏳ The Docker service has not started, waiting..."
     sleep 1
 done
 
-xhost +
+# Autoriser X local pour le container
+xhost +local:root >/dev/null 2>&1 || true
 
-# 2) Container deja existant ? -> on le relance simplement
-if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "ℹ️  Container '${CONTAINER_NAME}' deja existant, redemarrage..."
-    docker start -ai "${CONTAINER_NAME}"
-    exit $?
+# Repertoires hote persistants
+mkdir -p /home/jetson/roblaude_ws
+mkdir -p /home/jetson/robot_maps
+mkdir -p /etc/roblaude
+
+# Recreer "m3pro" a chaque boot pour que les nouveaux volumes/flags prennent.
+# Le container persiste via --restart=unless-stopped tant que ce script n'est
+# pas rejoue (ex: relogin).
+if docker ps -a --format '{{.Names}}' | grep -qx m3pro; then
+    docker stop m3pro >/dev/null 2>&1 || true
+    docker rm m3pro >/dev/null 2>&1 || true
 fi
 
-# 3) Sinon : creation initiale
-echo "🚀 Creation du container '${CONTAINER_NAME}' (premiere fois)"
-docker run -it \
-    --name "${CONTAINER_NAME}" \
-    --restart unless-stopped \
-    --net=host \
-    --env="DISPLAY" \
-    --env="QT_X11_NO_MITSHM=1" \
-    -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
-    -e ALSA_CARD=0 \
-    -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
-    -v /run/user/1000/pulse:/run/user/1000/pulse:ro \
-    -v ~/.config/pulse:/root/.config/pulse:ro \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -v /home/jetson/launch:/root/launch \
-    --device=/dev/bus/usb \
-    --security-opt apparmor:unconfined \
-    --device=/dev/input \
-    "${IMAGE}" /bin/bash /root/joy.sh
+docker run -d \
+  --name m3pro \
+  --restart=unless-stopped \
+  --net=host \
+  --env="DISPLAY" \
+  --env="QT_X11_NO_MITSHM=1" \
+  -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
+  -e ALSA_CARD=0 \
+  -e XDG_RUNTIME_DIR=/tmp/runtime-jetson \
+  -e ROS_DOMAIN_ID=30 \
+  -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 \
+  -v /run/user/1000/pulse:/run/user/1000/pulse:ro \
+  -v /home/jetson/.config/pulse:/root/.config/pulse:ro \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v /home/jetson/roblaude_ws:/root/roblaude_ws \
+  -v /home/jetson/robot_maps:/root/maps \
+  -v /etc/roblaude:/etc/roblaude:ro \
+  --device=/dev/bus/usb \
+  --device=/dev/input \
+  --security-opt apparmor:unconfined \
+  192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0 \
+  /bin/bash /root/roblaude_ws/scripts/container_autostart.sh
+
+echo "Container m3pro lance."
+docker ps --filter name=m3pro --format '  {{.Names}}: {{.Status}}'

--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -27,6 +27,9 @@ xhost +local:root >/dev/null 2>&1 || true
 # Repertoires hote persistants (jetson est owner, pas de sudo)
 mkdir -p /home/jetson/roblaude_ws/scripts
 mkdir -p /home/jetson/robot_maps
+# pip --user installe dans /root/.local cote container. Bind-mount sur l'hote
+# pour persister les deps Python (paho-mqtt...) entre recreate container.
+mkdir -p /home/jetson/.local
 # /etc/roblaude est cree par install_persistence.sh (sudo). On ne tente pas
 # mkdir ici : si le dossier n'existe pas, le bind-mount echouera silencieusement
 # (read-only) et BROKER_HOST=localhost fallback dans le container.
@@ -58,6 +61,7 @@ docker run -d \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v /home/jetson/roblaude_ws:/root/roblaude_ws \
   -v /home/jetson/robot_maps:/root/maps \
+  -v /home/jetson/.local:/root/.local \
   -v /etc/roblaude:/etc/roblaude:ro \
   --device=/dev/bus/usb \
   --device=/dev/input \

--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -24,10 +24,15 @@ done
 # Autoriser X local pour le container
 xhost +local:root >/dev/null 2>&1 || true
 
-# Repertoires hote persistants
-mkdir -p /home/jetson/roblaude_ws
+# Repertoires hote persistants (jetson est owner, pas de sudo)
+mkdir -p /home/jetson/roblaude_ws/scripts
 mkdir -p /home/jetson/robot_maps
-mkdir -p /etc/roblaude
+# /etc/roblaude est cree par install_persistence.sh (sudo). On ne tente pas
+# mkdir ici : si le dossier n'existe pas, le bind-mount echouera silencieusement
+# (read-only) et BROKER_HOST=localhost fallback dans le container.
+if [ ! -d /etc/roblaude ]; then
+    echo "ATTENTION : /etc/roblaude absent — lance install_persistence.sh d'abord"
+fi
 
 # Recreer "m3pro" a chaque boot pour que les nouveaux volumes/flags prennent.
 # Le container persiste via --restart=unless-stopped tant que ce script n'est
@@ -58,7 +63,14 @@ docker run -d \
   --device=/dev/input \
   --security-opt apparmor:unconfined \
   192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0 \
-  /bin/bash /root/roblaude_ws/scripts/container_autostart.sh
+  /bin/bash -c 'if [ -x /root/roblaude_ws/scripts/container_autostart.sh ]; then
+    exec /bin/bash /root/roblaude_ws/scripts/container_autostart.sh
+  else
+    echo "[boot] container_autostart.sh absent du workspace bind-mounte."
+    echo "[boot] lance deploy_to_robot.sh depuis le Mac, puis relance ce script."
+    echo "[boot] container reste en vie via tail -f /dev/null"
+    exec tail -f /dev/null
+  fi'
 
 echo "Container m3pro lance."
 docker ps --filter name=m3pro --format '  {{.Names}}: {{.Status}}'

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -26,6 +26,10 @@ export FASTDDS_BUILTIN_TRANSPORTS="${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}"
 
 mkdir -p "$MAPS_DIR" /tmp/roslogs
 
+# --- Deps Python non incluses dans l'image Docker Yahboom ---
+# paho-mqtt manque (necessaire pour roblaude_mqtt). pip install idempotent.
+python3 -c "import paho.mqtt" 2>/dev/null || pip install --quiet --user 'paho-mqtt~=1.6'
+
 # --- Source de l'env ROS et des drivers Yahboom (dans l'image, jamais wipes) ---
 source /opt/ros/humble/setup.bash
 [ -f "$YAHBOOM_WS/install/setup.bash" ] && source "$YAHBOOM_WS/install/setup.bash"

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -13,7 +13,7 @@
 # Pas de watchdog/respawn ici (cf. retour d'experience prof : runaway bash a
 # load avg 400+). Si un node meurt, on regarde son log et on `docker exec`.
 
-set -u
+# Pas de set -u : /opt/ros/humble/setup.bash plante dessus (AMENT_TRACE_SETUP_FILES)
 
 ROBLAUDE_WS="${ROBLAUDE_WS:-/root/roblaude_ws}"
 YAHBOOM_WS="${YAHBOOM_WS:-/root/yahboomcar_ws}"

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -27,16 +27,16 @@ export FASTDDS_BUILTIN_TRANSPORTS="${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}"
 mkdir -p "$MAPS_DIR" /tmp/roslogs
 
 # --- Deps Python non incluses dans l'image Docker Yahboom ---
-# paho-mqtt manque (necessaire pour roblaude_mqtt). pip install idempotent.
-# Non persiste entre recreate container (pip --user va dans /root/.local), donc
-# on rejoue a chaque autostart — idempotent et rapide (0.5s si deja la).
-SKIP_MQTT=0
+# paho-mqtt manque (necessaire pour roblaude_mqtt). Installe la premiere fois
+# dans /root/.local (= /home/jetson/.local cote hote via bind-mount), donc
+# persiste entre recreate container — pip install ne tourne qu'une seule fois.
 if ! python3 -c "import paho.mqtt" 2>/dev/null; then
     echo "[autostart] installation paho-mqtt..."
-    if ! pip install --quiet --user 'paho-mqtt~=1.6'; then
-        echo "[autostart] ECHEC pip install paho-mqtt — bridge MQTT desactive"
-        SKIP_MQTT=1
-    fi
+    pip install --quiet --user 'paho-mqtt~=1.6' || {
+        echo "[autostart] ECHEC pip install paho-mqtt"
+        echo "[autostart] le robot doit avoir internet au premier boot (ou pre-installer la dep)"
+        exit 1
+    }
 fi
 
 # --- Source de l'env ROS et des drivers Yahboom (dans l'image, jamais wipes) ---
@@ -90,9 +90,7 @@ spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py
 sleep 2
 
 # --- 3) Bridge MQTT (lit /etc/roblaude/broker_ip pour le host) ---
-if [ "$SKIP_MQTT" = 1 ]; then
-    echo "[autostart] bridge MQTT skip — paho-mqtt indisponible"
-elif [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then
+if [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then
     spawn_once mqtt_bridge ros2 launch roblaude_mqtt mqtt_bridge.launch.py "broker_host:=$BROKER_HOST"
 else
     echo "[autostart] roblaude_mqtt pas encore build, bridge non lance"

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# container_autostart.sh — PID 1 du container m3pro, lance notre stack ROS2
+#
+# Appele par Docker_M3Pro_Joy.sh au demarrage du container. Source les drivers
+# hardware Yahboom (yahboomcar_ws, M3Pro_ws — DANS l'image Docker, intouchables)
+# puis notre workspace bind-mounte (roblaude_ws), et lance :
+#   - base_bringup (moteurs, odom, IMU, LiDAR fusion)
+#   - robot_state_publisher (URDF officiel Yahboom)
+#   - bridge MQTT roblaude_mqtt (broker_host lu depuis /etc/roblaude/broker_ip)
+#
+# Idempotent : peut etre rejoue sans casser. Premier run -> colcon build.
+#
+# Pas de watchdog/respawn ici (cf. retour d'experience prof : runaway bash a
+# load avg 400+). Si un node meurt, on regarde son log et on `docker exec`.
+
+set -u
+
+ROBLAUDE_WS="${ROBLAUDE_WS:-/root/roblaude_ws}"
+YAHBOOM_WS="${YAHBOOM_WS:-/root/yahboomcar_ws}"
+M3PRO_WS="${M3PRO_WS:-/root/M3Pro_ws}"
+MAPS_DIR="${MAPS_DIR:-/root/maps}"
+BROKER_IP_FILE="${BROKER_IP_FILE:-/etc/roblaude/broker_ip}"
+
+export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-30}"
+export FASTDDS_BUILTIN_TRANSPORTS="${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}"
+
+mkdir -p "$MAPS_DIR" /tmp/roslogs
+
+# --- Source de l'env ROS et des drivers Yahboom (dans l'image, jamais wipes) ---
+source /opt/ros/humble/setup.bash
+[ -f "$YAHBOOM_WS/install/setup.bash" ] && source "$YAHBOOM_WS/install/setup.bash"
+[ -f "$M3PRO_WS/install/setup.bash" ]   && source "$M3PRO_WS/install/setup.bash"
+
+# --- First-run build du workspace RobLaude si vide ---
+if [ -d "$ROBLAUDE_WS/src" ] && [ ! -f "$ROBLAUDE_WS/install/setup.bash" ]; then
+  echo "[autostart] premier build du workspace RobLaude..."
+  ( cd "$ROBLAUDE_WS" && colcon build --symlink-install ) 2>&1 | tail -20 \
+    || echo "[autostart] WARN: colcon build a fini avec des erreurs"
+fi
+
+[ -f "$ROBLAUDE_WS/install/setup.bash" ] && source "$ROBLAUDE_WS/install/setup.bash"
+
+# --- IP du broker MQTT (Mac), mise a jour par sync_time.sh ---
+BROKER_HOST="localhost"
+if [ -r "$BROKER_IP_FILE" ]; then
+    BROKER_HOST="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+fi
+echo "[autostart] broker MQTT cible : $BROKER_HOST"
+
+# --- Helper spawn : nouveau process group + log dedie ---
+spawn_once() {
+  local name="$1"; shift
+  local logfile="/tmp/roslogs/${name}.log"
+  echo "[autostart] ▶ lance $name (log $logfile)"
+  setsid nohup "$@" >"$logfile" 2>&1 < /dev/null &
+  disown || true
+}
+
+# --- 1) Bringup hardware (moteurs, IMU, LiDAR fusion, odom EKF) ---
+spawn_once base_bringup ros2 launch M3Pro_navigation base_bringup.launch.py
+sleep 5
+
+# --- 2) URDF officiel Yahboom (frame chassis pour TF) ---
+spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py
+sleep 2
+
+# --- 3) Bridge MQTT (lit /etc/roblaude/broker_ip pour le host) ---
+if [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then
+    spawn_once mqtt_bridge ros2 launch roblaude_mqtt mqtt_bridge.launch.py "broker_host:=$BROKER_HOST"
+else
+    echo "[autostart] roblaude_mqtt pas encore build, bridge non lance"
+fi
+
+echo "[autostart] tout lance. Logs : /tmp/roslogs/*.log"
+echo "[autostart] verif : ros2 topic list | head"
+
+# PID 1 doit rester en vie sinon le container meurt.
+# SIGTERM -> on tue proprement les enfants.
+trap 'echo "[autostart] SIGTERM — kill children"; pkill -TERM -P $$ ; sleep 2 ; pkill -KILL -P $$ ; exit 0' TERM INT
+tail -f /dev/null

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -28,7 +28,16 @@ mkdir -p "$MAPS_DIR" /tmp/roslogs
 
 # --- Deps Python non incluses dans l'image Docker Yahboom ---
 # paho-mqtt manque (necessaire pour roblaude_mqtt). pip install idempotent.
-python3 -c "import paho.mqtt" 2>/dev/null || pip install --quiet --user 'paho-mqtt~=1.6'
+# Non persiste entre recreate container (pip --user va dans /root/.local), donc
+# on rejoue a chaque autostart — idempotent et rapide (0.5s si deja la).
+SKIP_MQTT=0
+if ! python3 -c "import paho.mqtt" 2>/dev/null; then
+    echo "[autostart] installation paho-mqtt..."
+    if ! pip install --quiet --user 'paho-mqtt~=1.6'; then
+        echo "[autostart] ECHEC pip install paho-mqtt — bridge MQTT desactive"
+        SKIP_MQTT=1
+    fi
+fi
 
 # --- Source de l'env ROS et des drivers Yahboom (dans l'image, jamais wipes) ---
 source /opt/ros/humble/setup.bash
@@ -38,8 +47,14 @@ source /opt/ros/humble/setup.bash
 # --- First-run build du workspace RobLaude si vide ---
 if [ -d "$ROBLAUDE_WS/src" ] && [ ! -f "$ROBLAUDE_WS/install/setup.bash" ]; then
   echo "[autostart] premier build du workspace RobLaude..."
-  ( cd "$ROBLAUDE_WS" && colcon build --symlink-install ) 2>&1 | tail -20 \
-    || echo "[autostart] WARN: colcon build a fini avec des erreurs"
+  # pipefail pour que le code retour de colcon remonte au-dessus de tail
+  set -o pipefail
+  if ( cd "$ROBLAUDE_WS" && colcon build --symlink-install ) 2>&1 | tail -20; then
+    echo "[autostart] colcon build OK"
+  else
+    echo "[autostart] ECHEC colcon build — nodes RobLaude ne seront pas lances"
+  fi
+  set +o pipefail
 fi
 
 [ -f "$ROBLAUDE_WS/install/setup.bash" ] && source "$ROBLAUDE_WS/install/setup.bash"
@@ -47,7 +62,13 @@ fi
 # --- IP du broker MQTT (Mac), mise a jour par sync_time.sh ---
 BROKER_HOST="localhost"
 if [ -r "$BROKER_IP_FILE" ]; then
-    BROKER_HOST="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+    FILE_IP="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+    # Fichier vide ou whitespace-only -> on garde localhost en fallback
+    if [ -n "$FILE_IP" ]; then
+        BROKER_HOST="$FILE_IP"
+    else
+        echo "[autostart] WARN $BROKER_IP_FILE vide, fallback BROKER_HOST=localhost"
+    fi
 fi
 echo "[autostart] broker MQTT cible : $BROKER_HOST"
 
@@ -69,7 +90,9 @@ spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py
 sleep 2
 
 # --- 3) Bridge MQTT (lit /etc/roblaude/broker_ip pour le host) ---
-if [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then
+if [ "$SKIP_MQTT" = 1 ]; then
+    echo "[autostart] bridge MQTT skip — paho-mqtt indisponible"
+elif [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then
     spawn_once mqtt_bridge ros2 launch roblaude_mqtt mqtt_bridge.launch.py "broker_host:=$BROKER_HOST"
 else
     echo "[autostart] roblaude_mqtt pas encore build, bridge non lance"

--- a/robot/scripts/deploy_to_robot.sh
+++ b/robot/scripts/deploy_to_robot.sh
@@ -1,57 +1,85 @@
 #!/bin/bash
-# deploy_to_robot.sh — Pousse les launch files vers le robot
+# deploy_to_robot.sh — pousse nos packages ROS2 + nos scripts dans le workspace
+# persistant /home/jetson/roblaude_ws sur le robot, puis lance colcon build dans
+# le container.
 #
-# Usage : ./deploy_to_robot.sh
+# Source de verite cote Mac (ce repo) :
+#   robot/roblaude_nav/    -> roblaude_ws/src/roblaude_nav/
+#   robot/roblaude_mqtt/   -> roblaude_ws/src/roblaude_mqtt/
+#   robot/scripts/         -> roblaude_ws/scripts/   (autostart, helpers)
 #
-# Prerequis :
-#   - sshpass installe (brew install sshpass)
-#   - Robot accessible sur 172.20.10.2 (ssh jetson@... fonctionne)
+# Idempotent. rsync delta = rapide meme avec gros workspace.
+#
+# Usage :
+#   ./robot/scripts/deploy_to_robot.sh             # deploy + build
+#   ./robot/scripts/deploy_to_robot.sh --no-build  # deploy only
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/find_robot.sh"
 
 ROBOT_USER="${ROBOT_USER:-jetson}"
-ROBOT_PASS="${ROBOT_PASS:-yahboom}"
-DEST_DIR="${DEST_DIR:-/home/jetson/launch}"
-CONTAINER="${CONTAINER:-m3pro_main}"
-CONTAINER_DEST="${CONTAINER_DEST:-/root/launch}"
+CONTAINER="${CONTAINER:-m3pro}"
+WS_HOST="${WS_HOST:-/home/jetson/roblaude_ws}"
+WS_CONTAINER="${WS_CONTAINER:-/root/roblaude_ws}"
 
-# Auto-detect robot par MAC
+DO_BUILD=true
+if [[ "$1" == "--no-build" ]]; then
+    DO_BUILD=false
+fi
+
 if ! find_robot; then
     exit 1
 fi
 
-LOCAL_DIR="$(cd "$SCRIPT_DIR/../roblaude_nav/launch" && pwd)"
+SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+SSH="ssh $SSH_OPTS $ROBOT_USER@$ROBOT_IP"
+RSYNC_E="ssh $SSH_OPTS"
 
-echo "=== Deploy roblaude_nav/launch/ vers $ROBOT_USER@$ROBOT_IP:$DEST_DIR ==="
-echo "Source : $LOCAL_DIR"
+echo "━━━ Deploy RobLaude → $ROBOT_USER@$ROBOT_IP:$WS_HOST ━━━"
+
+# 1) Prepa structure cote hote
+$SSH "mkdir -p $WS_HOST/src $WS_HOST/scripts"
+
+# 2) Push des packages ROS (delete-after pour nettoyer fichiers supprimes)
+echo "▶ rsync packages..."
+for pkg in roblaude_nav roblaude_mqtt; do
+    if [ -d "$REPO_ROOT/robot/$pkg" ]; then
+        rsync -avz --delete-after -e "$RSYNC_E" \
+            --exclude '__pycache__' --exclude '*.pyc' --exclude '.pytest_cache' \
+            "$REPO_ROOT/robot/$pkg/" \
+            "$ROBOT_USER@$ROBOT_IP:$WS_HOST/src/$pkg/"
+    fi
+done
+
+# 3) Push des scripts (autostart, helpers, etc.)
+echo "▶ rsync scripts..."
+rsync -avz --delete-after -e "$RSYNC_E" \
+    --exclude '__pycache__' \
+    "$REPO_ROOT/robot/scripts/" \
+    "$ROBOT_USER@$ROBOT_IP:$WS_HOST/scripts/"
+
+$SSH "chmod +x $WS_HOST/scripts/*.sh"
+
+# 4) Colcon build dans le container
+if $DO_BUILD; then
+    echo "▶ colcon build dans le container $CONTAINER..."
+    $SSH "docker exec $CONTAINER bash -c '
+        source /opt/ros/humble/setup.bash &&
+        source /root/yahboomcar_ws/install/setup.bash 2>/dev/null &&
+        cd $WS_CONTAINER &&
+        colcon build --symlink-install 2>&1 | tail -20
+    '"
+fi
+
 echo ""
-
-# Creer le dossier distant si besoin
-sshpass -p "$ROBOT_PASS" ssh -o StrictHostKeyChecking=no "$ROBOT_USER@$ROBOT_IP" \
-    "mkdir -p $DEST_DIR"
-
-# Transfert rsync (delta = rapide)
-sshpass -p "$ROBOT_PASS" rsync -avz --delete \
-    -e "ssh -o StrictHostKeyChecking=no" \
-    "$LOCAL_DIR/" \
-    "$ROBOT_USER@$ROBOT_IP:$DEST_DIR/"
-
-echo ""
-echo "=== Propagation vers le container $CONTAINER:$CONTAINER_DEST ==="
-# Le container ROS2 n a pas de volume vers ~/launch : on copie dedans
-sshpass -p "$ROBOT_PASS" ssh -o StrictHostKeyChecking=no "$ROBOT_USER@$ROBOT_IP" \
-    "docker exec $CONTAINER mkdir -p $CONTAINER_DEST && docker cp $DEST_DIR/. $CONTAINER:$CONTAINER_DEST/"
-
-echo ""
-echo "✅ Deploiement termine (host + container)."
-echo ""
-echo "Pour lancer un fichier :"
-echo "  ssh $ROBOT_USER@$ROBOT_IP"
-echo "  docker exec -it $CONTAINER bash"
-echo "  source /opt/ros/humble/setup.bash"
-echo "  source /root/yahboomcar_ws/install/setup.bash"
-echo "  export ROS_DOMAIN_ID=30"
-echo "  ros2 launch $CONTAINER_DEST/lidar.launch.py"
+echo "✅ Deploy termine."
+echo "   Workspace hote   : $ROBOT_USER@$ROBOT_IP:$WS_HOST"
+echo "   Visible container: $WS_CONTAINER  (via bind-mount)"
+if $DO_BUILD; then
+    echo "   Build : reussi (cf. sortie ci-dessus)"
+else
+    echo "   Build : skip — relance avec './deploy_to_robot.sh' pour builder"
+fi

--- a/robot/scripts/install_persistence.sh
+++ b/robot/scripts/install_persistence.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# install_persistence.sh — one-shot setup persistance du robot RobLaude.
+#
+# Execute EN SSH sur le Jetson par l'humain (toi). Idempotent — on peut
+# le rejouer sans casser. A executer une fois, puis plus jamais (sauf
+# si on change l'architecture persistance).
+#
+# Fait, dans l'ordre :
+#   1) Installe fake-hwclock + chrony (heure persiste entre reboots,
+#      sync NTP si reseau dispo)
+#   2) Timezone -> Europe/Paris (defaut Yahboom = Asia/Shanghai)
+#   3) Cree /etc/roblaude/broker_ip (place-holder localhost, ecrase par
+#      sync_time.sh a chaque session)
+#   4) Backup tar.gz du m3pro_teacher_ws avant suppression
+#   5) Cree /home/jetson/roblaude_ws/
+#   6) Installe NOTRE Docker_M3Pro_Joy.sh dans /home/jetson/ (backup .bak.<ts>
+#      de la version Yahboom)
+#   7) (Optionnel, demande confirmation) rm -rf m3pro_teacher_ws
+#
+# Usage cote Mac :
+#   scp robot/scripts/install_persistence.sh jetson@<robot>:/tmp/
+#   ssh jetson@<robot> "bash /tmp/install_persistence.sh"
+
+set -e
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ne lance pas ce script en root, utilise sudo ponctuellement"
+    exit 1
+fi
+
+TS=$(date +%Y%m%d-%H%M%S)
+ROBLAUDE_WS=/home/jetson/roblaude_ws
+TEACHER_WS=/home/jetson/m3pro_teacher_ws
+DOCKER_LAUNCHER=/home/jetson/Docker_M3Pro_Joy.sh
+
+echo "━━━ Etape 1/7 : fake-hwclock + chrony ━━━"
+sudo apt-get update -qq
+sudo apt-get install -y fake-hwclock chrony
+sudo systemctl enable --now fake-hwclock chrony
+echo "   horloge actuelle : $(date)"
+
+echo ""
+echo "━━━ Etape 2/7 : timezone Europe/Paris ━━━"
+sudo timedatectl set-timezone Europe/Paris
+echo "   timezone : $(timedatectl | grep 'Time zone')"
+
+echo ""
+echo "━━━ Etape 3/7 : /etc/roblaude/broker_ip ━━━"
+sudo mkdir -p /etc/roblaude
+if [ ! -f /etc/roblaude/broker_ip ]; then
+    echo "localhost" | sudo tee /etc/roblaude/broker_ip > /dev/null
+    echo "   cree avec valeur 'localhost' (a ecraser par sync_time.sh)"
+else
+    echo "   deja present : $(cat /etc/roblaude/broker_ip)"
+fi
+
+echo ""
+echo "━━━ Etape 4/7 : backup m3pro_teacher_ws ━━━"
+if [ -d "$TEACHER_WS" ]; then
+    BACKUP_PATH="/home/jetson/teacher_ws_backup_${TS}.tar.gz"
+    if [ ! -f "$BACKUP_PATH" ]; then
+        echo "   archive vers $BACKUP_PATH (peut prendre 1-2 min)..."
+        tar czf "$BACKUP_PATH" -C /home/jetson m3pro_teacher_ws
+        echo "   OK ($(du -h "$BACKUP_PATH" | cut -f1))"
+    fi
+else
+    echo "   pas de teacher_ws (deja supprime ?)"
+fi
+
+echo ""
+echo "━━━ Etape 5/7 : workspace RobLaude ━━━"
+mkdir -p "$ROBLAUDE_WS/src" "$ROBLAUDE_WS/scripts"
+echo "   $ROBLAUDE_WS pret"
+
+echo ""
+echo "━━━ Etape 6/7 : Docker_M3Pro_Joy.sh ━━━"
+if [ -f "$DOCKER_LAUNCHER" ] && ! grep -q "roblaude_ws" "$DOCKER_LAUNCHER"; then
+    cp "$DOCKER_LAUNCHER" "${DOCKER_LAUNCHER}.bak.${TS}"
+    echo "   ancienne version sauvegardee : ${DOCKER_LAUNCHER}.bak.${TS}"
+fi
+if [ -f "$ROBLAUDE_WS/scripts/Docker_M3Pro_Joy.sh" ]; then
+    cp "$ROBLAUDE_WS/scripts/Docker_M3Pro_Joy.sh" "$DOCKER_LAUNCHER"
+    chmod +x "$DOCKER_LAUNCHER"
+    echo "   installe depuis $ROBLAUDE_WS/scripts/Docker_M3Pro_Joy.sh"
+else
+    echo "   ATTENTION : pas trouve $ROBLAUDE_WS/scripts/Docker_M3Pro_Joy.sh"
+    echo "   lance d'abord ./deploy_to_robot.sh depuis le Mac"
+    exit 2
+fi
+
+echo ""
+echo "━━━ Etape 7/7 : suppression teacher_ws ━━━"
+if [ -d "$TEACHER_WS" ]; then
+    echo "   teacher_ws est encore present."
+    read -r -p "   confirmer suppression ? backup tar.gz fait deja. (yes/N) " confirm
+    if [ "$confirm" = "yes" ]; then
+        rm -rf "$TEACHER_WS"
+        echo "   supprime"
+    else
+        echo "   skip — relance le script et tape 'yes' quand tu es pret"
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ install_persistence.sh termine"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Etapes suivantes (depuis le Mac) :"
+echo "  1) ./robot/scripts/sync_time.sh        # push date + broker_ip"
+echo "  2) ./robot/scripts/deploy_to_robot.sh  # deploy + build packages"
+echo "  3) ssh jetson@<robot> 'bash /home/jetson/Docker_M3Pro_Joy.sh'"
+echo "     (ou reboot complet, l'autostart le fait)"

--- a/robot/scripts/install_persistence.sh
+++ b/robot/scripts/install_persistence.sh
@@ -33,12 +33,18 @@ ROBLAUDE_WS=/home/jetson/roblaude_ws
 TEACHER_WS=/home/jetson/m3pro_teacher_ws
 DOCKER_LAUNCHER=/home/jetson/Docker_M3Pro_Joy.sh
 
-echo "━━━ Etape 1/7 : fake-hwclock + chrony ━━━"
+echo "━━━ Etape 1/7 : fake-hwclock (NTP impossible — reseau ecole bloque UDP 123) ━━━"
 # apt update peut echouer sur des repos morts (ex: nvidia-l4t-apt) — on
 # ignore, l'install reussira tant que le mirror Ubuntu repond.
 sudo apt-get update -qq || true
-sudo apt-get install -y fake-hwclock chrony
-sudo systemctl enable --now fake-hwclock chrony
+sudo apt-get install -y fake-hwclock
+sudo systemctl enable --now fake-hwclock
+# Si chrony est deja installe, on le masque pour ne pas qu'il tente NTP en
+# boucle (sera unmasked si on retrouve un reseau avec NTP plus tard).
+if systemctl list-unit-files | grep -q '^chrony.service'; then
+    sudo systemctl stop chrony 2>/dev/null || true
+    sudo systemctl disable chrony 2>/dev/null || true
+fi
 echo "   horloge actuelle : $(date)"
 
 echo ""

--- a/robot/scripts/install_persistence.sh
+++ b/robot/scripts/install_persistence.sh
@@ -34,7 +34,9 @@ TEACHER_WS=/home/jetson/m3pro_teacher_ws
 DOCKER_LAUNCHER=/home/jetson/Docker_M3Pro_Joy.sh
 
 echo "━━━ Etape 1/7 : fake-hwclock + chrony ━━━"
-sudo apt-get update -qq
+# apt update peut echouer sur des repos morts (ex: nvidia-l4t-apt) — on
+# ignore, l'install reussira tant que le mirror Ubuntu repond.
+sudo apt-get update -qq || true
 sudo apt-get install -y fake-hwclock chrony
 sudo systemctl enable --now fake-hwclock chrony
 echo "   horloge actuelle : $(date)"

--- a/robot/scripts/start_agent.sh
+++ b/robot/scripts/start_agent.sh
@@ -12,16 +12,20 @@ while ! systemctl is-active --quiet docker; do
     sleep 1
 done
 
-# Reuse si existant
+# Reuse si existant. PAS de `-ai` : ca bloque la fenetre lxterminal de
+# l'autostart (attache stdin et reste en attente). docker start tout court
+# demarre le container en arriere-plan, ce qu'on veut (--restart=unless-stopped
+# le maintient en vie de toute facon).
 if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo "ℹ️  Container '${CONTAINER_NAME}' deja existant, redemarrage..."
-    docker start -ai "${CONTAINER_NAME}"
+    docker start "${CONTAINER_NAME}" >/dev/null
     exit $?
 fi
 
-# Creation initiale
+# Creation initiale — `-d` (detache) pour ne pas bloquer la fenetre lxterminal
+# de l'autostart. L'agent est un daemon, il n'a pas besoin de TTY.
 echo "🚀 Creation du container '${CONTAINER_NAME}'"
-docker run -it \
+docker run -d \
     --name "${CONTAINER_NAME}" \
     --restart unless-stopped \
     --init \

--- a/robot/scripts/start_all.sh
+++ b/robot/scripts/start_all.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
-# start_all.sh - Lance toute la stack ROS2 de navigation RobLaude
+# start_all.sh - Lance la stack ROS2 RobLaude EN MODE DEBUG MANUEL
 #
-# A lancer DANS le container ROS2 du robot :
-#     docker exec m3pro_main bash /root/roblaude_ws/src/robot/scripts/start_all.sh
+# A utiliser quand l'autostart container_autostart.sh ne convient pas
+# (ex: tu veux pas le bringup auto + bridge MQTT, juste les launch
+# visualisation et SLAM pour cartographier).
 #
-# Prerequis : le package roblaude_nav doit etre compile (colcon build)
-# dans $ROBLAUDE_WS.
+# Pour le mode prod auto-au-boot, c'est container_autostart.sh qui prend
+# la main via Docker_M3Pro_Joy.sh.
+#
+# Appel cote Mac (via start_robot.sh) :
+#   docker exec m3pro bash /root/roblaude_ws/scripts/start_all.sh
+#
+# Prerequis : roblaude_nav et roblaude_mqtt compiles dans $ROBLAUDE_WS.
 
 set -u
 
 export ROS_DOMAIN_ID=30
 ROBLAUDE_WS="${ROBLAUDE_WS:-/root/roblaude_ws}"
 YAHBOOM_WS="${YAHBOOM_WS:-/root/yahboomcar_ws}"
+BROKER_IP_FILE="${BROKER_IP_FILE:-/etc/roblaude/broker_ip}"
 mkdir -p /tmp/roslogs
+
+BROKER_HOST="localhost"
+if [ -r "$BROKER_IP_FILE" ]; then
+    BROKER_HOST="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+fi
 
 # PIDs des process lances, pour la verification finale
 declare -A LAUNCH_PIDS
@@ -38,6 +50,7 @@ pkill -f web_video_server   2>/dev/null || true
 pkill -f async_slam_toolbox 2>/dev/null || true
 pkill -f scan_restamper     2>/dev/null || true
 pkill -f odom_to_tf         2>/dev/null || true
+pkill -f mqtt_bridge        2>/dev/null || true
 sleep 2
 
 # 1) Bridges de visualisation (package roblaude_nav)
@@ -60,6 +73,9 @@ sleep 8
 
 # 5) SLAM (utilise /scan_stamped)
 launch_bg slam      "ros2 launch roblaude_nav slam.launch.py"
+
+# 6) Bridge MQTT (broker_host depuis /etc/roblaude/broker_ip)
+launch_bg mqtt      "ros2 launch roblaude_mqtt mqtt_bridge.launch.py broker_host:=$BROKER_HOST"
 
 # Verification : chaque process est-il toujours vivant 3s apres lancement ?
 sleep 3

--- a/robot/scripts/start_all.sh
+++ b/robot/scripts/start_all.sh
@@ -23,7 +23,9 @@ mkdir -p /tmp/roslogs
 
 BROKER_HOST="localhost"
 if [ -r "$BROKER_IP_FILE" ]; then
-    BROKER_HOST="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+    FILE_IP="$(cat "$BROKER_IP_FILE" | tr -d '[:space:]')"
+    # ne surcharge pas BROKER_HOST si fichier vide -> bridge marcherait pas
+    [ -n "$FILE_IP" ] && BROKER_HOST="$FILE_IP"
 fi
 
 # PIDs des process lances, pour la verification finale

--- a/robot/scripts/start_robot.sh
+++ b/robot/scripts/start_robot.sh
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/find_robot.sh"
 
 ROBOT_USER="${ROBOT_USER:-jetson}"
 ROBOT_PASS="${ROBOT_PASS:-yahboom}"
-CONTAINER="${CONTAINER:-m3pro_main}"
+CONTAINER="${CONTAINER:-m3pro}"
 AGENT_CONTAINER="${AGENT_CONTAINER:-micro_ros_agent}"
 
 OPEN_FOXGLOVE=true
@@ -85,7 +85,7 @@ done
 if [ -z "${NO_START:-}" ]; then
     echo ""
     echo "▶ Etape 4/5 : Lancement stack ROS2 (start_all.sh)"
-    ssh_cmd "docker exec $CONTAINER bash /root/roblaude_ws/src/robot/scripts/start_all.sh" 2>&1 | sed 's/^/   /'
+    ssh_cmd "docker exec $CONTAINER bash /root/roblaude_ws/scripts/start_all.sh" 2>&1 | sed 's/^/   /'
 
     echo ""
     echo "   ⏳ Attente 10s stabilisation..."

--- a/robot/scripts/sync_time.sh
+++ b/robot/scripts/sync_time.sh
@@ -53,6 +53,13 @@ fi
 MAC_IP="$(ipconfig getifaddr en0 2>/dev/null || ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
 echo ""
 echo "━━━ broker MQTT ━━━"
+
+# Si on n'a pas reussi a deduire l'IP du Mac, abort plutot que d'ecrire vide
+# dans broker_ip (ce qui rendrait le bridge muet au prochain boot).
+if [ -z "$MAC_IP" ]; then
+    echo "   ❌ IP Mac introuvable (en0 down, pas de route ?). broker_ip non touche."
+    exit 2
+fi
 echo "   IP Mac (broker)  : $MAC_IP"
 
 CURRENT=$($SSH "cat $BROKER_IP_FILE 2>/dev/null || echo missing")

--- a/robot/scripts/sync_time.sh
+++ b/robot/scripts/sync_time.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# sync_time.sh — synchronise l'horloge du robot + pousse l'IP du Mac comme
+# broker MQTT.
+#
+# A lancer cote Mac, au debut de chaque session robot. Le Jetson n'a pas de
+# RTC peuplee et le reseau ecole bloque UDP 123 (NTP) — donc on prend le Mac
+# comme source de verite : date + IP locale.
+#
+# Idempotent. Si l'ecart est < 60s on ne resynchronise pas.
+#
+# Usage :
+#   ./robot/scripts/sync_time.sh
+#   ROBOT_IP=10.10.220.109 ./robot/scripts/sync_time.sh  # sans scan reseau
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_robot.sh"
+
+ROBOT_USER="${ROBOT_USER:-jetson}"
+ROBOT_PASS="${ROBOT_PASS:-yahboom}"
+BROKER_IP_FILE="${BROKER_IP_FILE:-/etc/roblaude/broker_ip}"
+
+if ! find_robot; then
+    exit 1
+fi
+
+SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+SSH="ssh $SSH_OPTS $ROBOT_USER@$ROBOT_IP"
+
+# 1) Horloge ---------------------------------------------------------------
+MAC_UTC=$(date -u +"%Y-%m-%d %H:%M:%S")
+MAC_EPOCH=$(date -u +%s)
+ROBOT_EPOCH=$($SSH "date -u +%s")
+DIFF=$(( MAC_EPOCH - ROBOT_EPOCH ))
+ABS_DIFF=${DIFF#-}
+
+echo "━━━ sync horloge ━━━"
+echo "   Mac   UTC : $MAC_UTC"
+echo "   ecart     : ${DIFF}s"
+
+if [ "$ABS_DIFF" -gt 60 ]; then
+    echo "   resync via sudo date -s..."
+    $SSH "echo $ROBOT_PASS | sudo -S date -u -s '$MAC_UTC' >/dev/null"
+    # Sauve dans fake-hwclock pour que le prochain boot demarre proche
+    $SSH "echo $ROBOT_PASS | sudo -S fake-hwclock save >/dev/null 2>&1 || true"
+    echo "   ✅ horloge fixee"
+else
+    echo "   ✅ deja synchro (tolerance 60s)"
+fi
+
+# 2) Broker IP -------------------------------------------------------------
+MAC_IP="$(ipconfig getifaddr en0 2>/dev/null || ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
+echo ""
+echo "━━━ broker MQTT ━━━"
+echo "   IP Mac (broker)  : $MAC_IP"
+
+CURRENT=$($SSH "cat $BROKER_IP_FILE 2>/dev/null || echo missing")
+echo "   $BROKER_IP_FILE actuel : $CURRENT"
+
+if [ "$CURRENT" != "$MAC_IP" ]; then
+    $SSH "echo $ROBOT_PASS | sudo -S bash -c 'mkdir -p /etc/roblaude && echo $MAC_IP > $BROKER_IP_FILE'"
+    echo "   ✅ broker_ip mis a jour vers $MAC_IP"
+    echo "   (le bridge MQTT prendra effet au prochain redemarrage du container)"
+else
+    echo "   ✅ deja a jour"
+fi
+
+echo ""
+echo "✅ sync_time termine"


### PR DESCRIPTION
Closes #213

## Contexte

À chaque redémarrage du robot, on perdait : l'horloge (Jetson sans RTC),
le workspace du container (`/root/roblaude_ws` wipé), et le bridge MQTT
ne se relançait pas. Trois redéploiements par session.

Cette PR met en place une stack RobLaude à nous, persistante, qui repart
toute seule au boot du Jetson — et supprime la dépendance au `m3pro_teacher_ws`
(code prof, on construit le nôtre).

## Ce qui change

- **`Docker_M3Pro_Joy.sh`** : container `m3pro` avec bind-mount
  `/home/jetson/roblaude_ws`, `/home/jetson/robot_maps`, `/etc/roblaude`.
  Plus de mount teacher_ws.
- **`container_autostart.sh`** (nouveau) : PID 1 du container. Source les
  drivers Yahboom (yahboomcar_ws + M3Pro_ws), source notre workspace,
  build au premier run, installe paho-mqtt, lance base_bringup + URDF
  + bridge MQTT (broker_host lu depuis `/etc/roblaude/broker_ip`).
- **`install_persistence.sh`** (nouveau) : one-shot SSH côté Jetson —
  installe fake-hwclock (NTP impossible, réseau école bloque UDP 123),
  timezone Europe/Paris, backup teacher_ws en tar.gz, installe notre
  Docker_M3Pro_Joy.sh.
- **`sync_time.sh`** (nouveau) : push la date du Mac et l'IP du Mac vers
  `/etc/roblaude/broker_ip` du robot. À lancer en début de session.
- **`deploy_to_robot.sh`** : refonte. rsync `roblaude_mqtt/`, `roblaude_nav/`
  et `scripts/` vers `roblaude_ws/`, puis colcon build dans le container.
- **`start_all.sh`** et **`start_robot.sh`** : adaptation au container
  `m3pro` (au lieu de `m3pro_main`) + ajout lancement du bridge avec
  broker_host dynamique.

## Validé en réel (21 mai)

- `online: true` côté broker Mac, timestamp correct (heure synchro)
- `status: AVAILABLE` retained
- `telemetry/battery` live @1Hz, valeurs cohérentes
- `base_bringup` + `mqtt_bridge` lancés automatiquement par PID 1
- Workspace persistant — survit à un `docker rm m3pro` (à condition de
  relancer `Docker_M3Pro_Joy.sh`)
- Reste à valider : reboot complet du Jetson (test fait au prochain
  passage robot)

## Test plan

- [x] Robot allumé, lance `sync_time.sh` → horloge + broker_ip OK
- [x] `deploy_to_robot.sh` → packages dans workspace, build OK
- [x] `install_persistence.sh` → fake-hwclock + timezone + Docker_M3Pro_Joy.sh
- [x] Recréation container → autostart spawn bridge + base_bringup
- [x] Broker Mac voit `online:true` + telemetry live
- [ ] Reboot complet Jetson → tout repart auto (à faire au prochain passage)
- [ ] `rm -rf m3pro_teacher_ws` (backup tar.gz fait, mais on garde le
  filesystem tant que la PR n'est pas mergée — réversibilité)