### PR TITLE
[T4.2.3] Backend — traiter mission/ack et mission/status (recréé après rebase sur dev)

### DIFF
--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -1,18 +1,27 @@
 import mqtt, { type MqttClient } from 'mqtt'
 import { randomUUID } from 'node:crypto'
+import { MissionStatus } from '@prisma/client'
+import { z } from 'zod'
+import prisma from '../lib/prisma'
 
-/**
- * Adaptateur MQTT du backend — singleton.
- *
- * Squelette du ticket T4.2.1. La connexion au broker, l'abonnement wildcard
- * et la publication des commandes sont fonctionnels. Le traitement des
- * messages entrants (mise a jour Prisma + relai WebSocket) reste a faire
- * dans les tickets T4.2.3, T4.2.4, T4.2.5 et T4.2.9.
- *
- * Topics et formats : voir docs/mqtt-spec.md
- */
+// Adaptateur MQTT du backend — singleton.
+// Topics et formats : voir docs/mqtt-spec.md
 
 const SCHEMA_VERSION = 1
+
+// Payloads attendus depuis le robot (spec §5.4)
+const missionAckSchema = z.object({
+  messageId: z.string().min(1),
+  missionId: z.number().int().positive(),
+  result: z.enum(['accepted', 'rejected']),
+  reason: z.string().optional(),
+})
+
+const missionStatusSchema = z.object({
+  missionId: z.number().int().positive(),
+  state: z.nativeEnum(MissionStatus),
+  progress: z.number().min(0).max(1).optional(),
+})
 
 /** Actions publiables sur roblaude/{robotId}/cmd/{action}. */
 export type CmdAction =
@@ -24,6 +33,10 @@ export type CmdAction =
 
 class RobotMqttAdapter {
   private client: MqttClient | null = null
+  // messageIds deja traites pour les evenements (cf. spec §4 — idempotence).
+  // In-memory : on perd le set au restart, le robot peut rejouer un ack ; en
+  // pratique l'update Prisma reste idempotent (meme statut ecrit deux fois).
+  private seenMessageIds = new Set<string>()
 
   /** Connexion au broker + abonnement aux topics robot (wildcard multi-robot). */
   connect(): void {
@@ -103,7 +116,8 @@ class RobotMqttAdapter {
         // TODO #202 : mettre a jour Robot.status + relai status_change
         break
       case 'mission':
-        // TODO #79 : sub === 'ack' | 'status' -> Mission.status
+        if (sub === 'ack') void this.handleMissionAck(robotId, data)
+        else if (sub === 'status') void this.handleMissionStatus(data)
         // TODO #81 : sub === 'result' -> COMPLETED/FAILED/CANCELLED + failureReason
         break
       case 'connection':
@@ -112,10 +126,57 @@ class RobotMqttAdapter {
       default:
         console.warn(`[mqtt] famille de topic inconnue : ${family}`)
     }
+  }
 
-    // Reference robotId/sub en attendant les TODO ci-dessus (evite le bruit lint).
-    void robotId
-    void sub
+  // mission/ack — accepted: on attache le robot a la mission.
+  //               rejected: status = FAILED + failureReason.
+  // L'idempotence repose sur messageId (cf. spec §4).
+  private async handleMissionAck(robotId: number, data: Record<string, unknown>) {
+    const parsed = missionAckSchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] mission/ack rejete :', parsed.error.issues)
+      return
+    }
+    const { messageId, missionId, result, reason } = parsed.data
+    if (this.seenMessageIds.has(messageId)) return
+    this.seenMessageIds.add(messageId)
+
+    try {
+      if (result === 'accepted') {
+        await prisma.mission.update({
+          where: { id: missionId },
+          data: { robotId },
+        })
+      } else {
+        await prisma.mission.update({
+          where: { id: missionId },
+          data: { status: MissionStatus.FAILED, failureReason: reason ?? 'rejected' },
+        })
+      }
+    } catch (err) {
+      console.error('[mqtt] update mission/ack :',
+        err instanceof Error ? err.message : err)
+    }
+  }
+
+  // mission/status — propage le sous-etat courant. Pas de messageId
+  // (etat retained, on ecrase, pas besoin de dedoublonner).
+  private async handleMissionStatus(data: Record<string, unknown>) {
+    const parsed = missionStatusSchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] mission/status rejete :', parsed.error.issues)
+      return
+    }
+    const { missionId, state } = parsed.data
+    try {
+      await prisma.mission.update({
+        where: { id: missionId },
+        data: { status: state },
+      })
+    } catch (err) {
+      console.error('[mqtt] update mission/status :',
+        err instanceof Error ? err.message : err)
+    }
   }
 
   /** Fermeture propre — a appeler a l'arret du serveur. */

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
-// Mock du client mqtt — on capture les appels sans toucher au reseau.
-// Doit etre defini avant l'import du module teste.
+// Mocks — definis avant l'import du module teste (hoisting vi.mock).
+let messageHandler: ((topic: string, payload: Buffer) => void) | null = null
+
 const fakeClient = {
   publish: vi.fn(),
   subscribe: vi.fn(),
   end: vi.fn(),
   on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
-    // On declenche 'connect' immediatement pour pouvoir tester subscribe.
     if (event === 'connect') cb()
+    if (event === 'message') {
+      messageHandler = cb as (topic: string, payload: Buffer) => void
+    }
     return fakeClient
   }),
 }
@@ -17,9 +20,20 @@ vi.mock('mqtt', () => ({
   default: { connect: vi.fn(() => fakeClient) },
 }))
 
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: { mission: { update: vi.fn().mockResolvedValue({}) } },
+}))
+vi.mock('../lib/prisma', () => ({ default: prismaMock }))
+
 import { robotMqtt } from '../services/mqtt'
 
-describe('RobotMqttAdapter', () => {
+// Helper : reconstruit un message MQTT comme s'il venait du broker.
+function deliver(topic: string, body: object) {
+  const payload = Buffer.from(JSON.stringify({ schemaVersion: 1, ...body }))
+  messageHandler!(topic, payload)
+}
+
+describe('RobotMqttAdapter — transport', () => {
   beforeEach(() => {
     fakeClient.publish.mockClear()
     fakeClient.subscribe.mockClear()
@@ -68,5 +82,86 @@ describe('RobotMqttAdapter', () => {
     const [topic, payload] = fakeClient.publish.mock.calls[0]
     expect(topic).toBe('roblaude/1/cmd/emergency-stop')
     expect(JSON.parse(payload as string).reason).toBe('user-pressed-stop')
+  })
+})
+
+describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
+  beforeEach(() => {
+    prismaMock.mission.update.mockClear()
+    robotMqtt.disconnect()
+    robotMqtt.connect()
+  })
+
+  it('mission/ack accepted attache le robotId a la mission', async () => {
+    deliver('roblaude/3/mission/ack', {
+      messageId: 'm-1',
+      missionId: 42,
+      result: 'accepted',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { robotId: 3 },
+    })
+  })
+
+  it('mission/ack rejected met le statut a FAILED + failureReason', async () => {
+    deliver('roblaude/3/mission/ack', {
+      messageId: 'm-2',
+      missionId: 42,
+      result: 'rejected',
+      reason: 'robot-busy',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'FAILED', failureReason: 'robot-busy' },
+    })
+  })
+
+  it('mission/ack rejected sans reason ecrit "rejected"', async () => {
+    deliver('roblaude/3/mission/ack', {
+      messageId: 'm-3',
+      missionId: 7,
+      result: 'rejected',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { status: 'FAILED', failureReason: 'rejected' },
+    })
+  })
+
+  it('mission/ack ignore les messageId deja vus (idempotence)', async () => {
+    const payload = { messageId: 'm-dup', missionId: 42, result: 'accepted' as const }
+    deliver('roblaude/3/mission/ack', payload)
+    deliver('roblaude/3/mission/ack', payload)
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('mission/ack malforme est ignore (pas de crash)', async () => {
+    deliver('roblaude/3/mission/ack', { missionId: 42 }) // pas de messageId/result
+    await Promise.resolve()
+    expect(prismaMock.mission.update).not.toHaveBeenCalled()
+  })
+
+  it('mission/status met a jour le sous-etat', async () => {
+    deliver('roblaude/3/mission/status', {
+      missionId: 42,
+      state: 'NAVIGATING_TO_PICKUP',
+      progress: 0.35,
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'NAVIGATING_TO_PICKUP' },
+    })
+  })
+
+  it('mission/status avec un state invalide est ignore', async () => {
+    deliver('roblaude/3/mission/status', { missionId: 42, state: 'WAT' })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Ticket #79. Recréation de la PR #207 (auto-fermée par GitHub après merge de #206) après rebase propre sur dev.

Contenu identique à #207 : 2 schemas Zod, idempotence par messageId, handleMissionAck + handleMissionStatus, 7 tests vitest.

Voir #207 fermée pour le contexte complet.