### PR TITLE
[T4.2.5] Backend — traiter mission/result (completed/failed/cancelled) (recréé après rebase)

### DIFF
--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -1,6 +1,6 @@
 import mqtt, { type MqttClient } from 'mqtt'
 import { randomUUID } from 'node:crypto'
-import { MissionStatus } from '@prisma/client'
+import { MissionStatus, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
 
@@ -22,6 +22,20 @@ const missionStatusSchema = z.object({
   state: z.nativeEnum(MissionStatus),
   progress: z.number().min(0).max(1).optional(),
 })
+
+const missionResultSchema = z.object({
+  messageId: z.string().min(1),
+  missionId: z.number().int().positive(),
+  result: z.enum(['completed', 'failed', 'cancelled']),
+  reason: z.string().optional(),
+})
+
+// Mapping result -> MissionStatus Prisma
+const RESULT_TO_STATUS = {
+  completed: MissionStatus.COMPLETED,
+  failed: MissionStatus.FAILED,
+  cancelled: MissionStatus.CANCELLED,
+} as const
 
 /** Actions publiables sur roblaude/{robotId}/cmd/{action}. */
 export type CmdAction =
@@ -118,7 +132,7 @@ class RobotMqttAdapter {
       case 'mission':
         if (sub === 'ack') void this.handleMissionAck(robotId, data)
         else if (sub === 'status') void this.handleMissionStatus(data)
-        // TODO #81 : sub === 'result' -> COMPLETED/FAILED/CANCELLED + failureReason
+        else if (sub === 'result') void this.handleMissionResult(robotId, data)
         break
       case 'connection':
         // TODO #202 : data.online === false (Last Will) -> Robot.status = OFFLINE
@@ -175,6 +189,36 @@ class RobotMqttAdapter {
       })
     } catch (err) {
       console.error('[mqtt] update mission/status :',
+        err instanceof Error ? err.message : err)
+    }
+  }
+
+  // mission/result — fin de mission. On met a jour la mission ET on libere
+  // le robot (Robot.status = AVAILABLE) en une seule transaction.
+  private async handleMissionResult(robotId: number, data: Record<string, unknown>) {
+    const parsed = missionResultSchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] mission/result rejete :', parsed.error.issues)
+      return
+    }
+    const { messageId, missionId, result, reason } = parsed.data
+    if (this.seenMessageIds.has(messageId)) return
+    this.seenMessageIds.add(messageId)
+
+    const status = RESULT_TO_STATUS[result]
+    const missionData: { status: MissionStatus; failureReason?: string } = { status }
+    if (result === 'failed') missionData.failureReason = reason ?? 'failed'
+
+    try {
+      await prisma.$transaction([
+        prisma.mission.update({ where: { id: missionId }, data: missionData }),
+        prisma.robot.update({
+          where: { id: robotId },
+          data: { status: RobotStatus.AVAILABLE },
+        }),
+      ])
+    } catch (err) {
+      console.error('[mqtt] update mission/result :',
         err instanceof Error ? err.message : err)
     }
   }

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -21,7 +21,12 @@ vi.mock('mqtt', () => ({
 }))
 
 const { prismaMock } = vi.hoisted(() => ({
-  prismaMock: { mission: { update: vi.fn().mockResolvedValue({}) } },
+  prismaMock: {
+    mission: { update: vi.fn().mockResolvedValue({}) },
+    robot: { update: vi.fn().mockResolvedValue({}) },
+    // $transaction recoit un tableau de promesses Prisma et resout dans l'ordre.
+    $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
+  },
 }))
 vi.mock('../lib/prisma', () => ({ default: prismaMock }))
 
@@ -163,5 +168,114 @@ describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
     deliver('roblaude/3/mission/status', { missionId: 42, state: 'WAT' })
     await Promise.resolve()
     expect(prismaMock.mission.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('RobotMqttAdapter — handlers mission/result', () => {
+  beforeEach(() => {
+    prismaMock.mission.update.mockClear()
+    prismaMock.robot.update.mockClear()
+    prismaMock.$transaction.mockClear()
+    robotMqtt.disconnect()
+    robotMqtt.connect()
+  })
+
+  it('completed: mission COMPLETED + robot AVAILABLE', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-1',
+      missionId: 42,
+      result: 'completed',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'COMPLETED' },
+    })
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'AVAILABLE' },
+    })
+  })
+
+  it('failed: mission FAILED + failureReason + robot AVAILABLE', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-2',
+      missionId: 42,
+      result: 'failed',
+      reason: 'navigation-timeout',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'FAILED', failureReason: 'navigation-timeout' },
+    })
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'AVAILABLE' },
+    })
+  })
+
+  it('failed sans reason ecrit "failed" en fallback', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-3',
+      missionId: 42,
+      result: 'failed',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'FAILED', failureReason: 'failed' },
+    })
+  })
+
+  it('cancelled: mission CANCELLED + robot AVAILABLE', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-4',
+      missionId: 42,
+      result: 'cancelled',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'CANCELLED' },
+    })
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'AVAILABLE' },
+    })
+  })
+
+  it('mission ET robot mis a jour dans la meme transaction', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-5',
+      missionId: 42,
+      result: 'completed',
+    })
+    await Promise.resolve()
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('mission/result idempotent sur messageId', async () => {
+    const payload = { messageId: 'r-dup', missionId: 42, result: 'completed' as const }
+    deliver('roblaude/3/mission/result', payload)
+    deliver('roblaude/3/mission/result', payload)
+    await Promise.resolve()
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('mission/result malforme est ignore', async () => {
+    deliver('roblaude/3/mission/result', { missionId: 42, result: 'completed' }) // pas de messageId
+    await Promise.resolve()
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('mission/result avec result invalide est ignore', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'r-bad',
+      missionId: 42,
+      result: 'exploded',
+    })
+    await Promise.resolve()
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Ticket #81. Recréation de la PR #210 (base obsolète) après rebase propre sur dev (qui contient maintenant #206 et #215).

Contenu identique à #210 : missionResultSchema, mapping completed/failed/cancelled, transaction Prisma atomique (Mission + Robot.status=AVAILABLE), 8 tests vitest.