### PR TITLE
[T4.2.7] Backend — POST /missions/:id/resume + publish cmd/resume (recréé après rebase)

### DIFF
--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { MissionStatus, MissionType, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
+import { robotMqtt } from '../services/mqtt'
 
 // query params pour GET /api/missions
 const listQuerySchema = z.object({
@@ -218,6 +219,50 @@ export async function cancelMission(req: Request, res: Response) {
 
     return cancelled
   })
+
+  res.json({ data: updated })
+}
+
+export async function resumeMission(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const mission = await prisma.mission.findUnique({ where: { id } })
+  if (!mission) {
+    res.status(404).json({ error: 'Mission introuvable' })
+    return
+  }
+  if (mission.status !== MissionStatus.PAUSED) {
+    res.status(400).json({ error: 'Mission non reprenable', status: mission.status })
+    return
+  }
+  if (!mission.robotId) {
+    res.status(400).json({ error: 'Aucun robot assigne a la mission' })
+    return
+  }
+
+  // Robot repasse BUSY. Mission.status sera mis a jour par le robot via
+  // mission/status apres reprise (le robot connait son sous-etat reel).
+  const updated = await prisma.$transaction(async (tx) => {
+    await tx.robot.update({
+      where: { id: mission.robotId! },
+      data: { status: RobotStatus.BUSY },
+    })
+    return tx.mission.findUnique({
+      where: { id },
+      include: {
+        fromPoint: true,
+        toPoint: true,
+        robot: { select: { id: true, name: true, status: true } },
+        user: { select: { id: true, name: true, email: true } },
+      },
+    })
+  })
+
+  robotMqtt.publishCommand(mission.robotId, 'resume', { missionId: id })
 
   res.json({ data: updated })
 }

--- a/web/backend/src/routes/missions.ts
+++ b/web/backend/src/routes/missions.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
-import { listMissions, getMission, createMission, cancelMission } from '../controllers/missionsController'
+import { listMissions, getMission, createMission, cancelMission, resumeMission } from '../controllers/missionsController'
 
 const router = Router()
 
@@ -15,5 +15,8 @@ router.post('/', asyncHandler(createMission))
 
 // POST /api/missions/:id/cancel
 router.post('/:id/cancel', asyncHandler(cancelMission))
+
+// POST /api/missions/:id/resume — relance une mission PAUSED
+router.post('/:id/resume', asyncHandler(resumeMission))
 
 export default router

--- a/web/backend/src/test/routes.test.ts
+++ b/web/backend/src/test/routes.test.ts
@@ -37,6 +37,11 @@ describe('Routes protegees (sans token = 401)', () => {
     const res = await request(app).get('/api/robots/1/status')
     expect(res.status).toBe(401)
   })
+
+  it('POST /api/missions/1/resume → 401', async () => {
+    const res = await request(app).post('/api/missions/1/resume').send({})
+    expect(res.status).toBe(401)
+  })
 })
 
 describe('Routes publiques', () => {


### PR DESCRIPTION
Ticket #83. Recréation de la PR #211 (base obsolète) après rebase propre sur dev.

Contenu identique à #211 : endpoint POST /api/missions/:id/resume (authGuard), gestion 400/404, transaction Robot.status=BUSY, publish cmd/resume QoS 2.