### PR TITLE
fix: dette technique Sprint 4 — review Copilot (#218)

### DIFF
--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -223,6 +223,12 @@ export async function cancelMission(req: Request, res: Response) {
   res.json({ data: updated })
 }
 
+// Sentinels typees pour transporter une erreur depuis la transaction
+type ResumeError = { code: 404 | 400; body: object }
+function isResumeError(x: unknown): x is ResumeError {
+  return typeof x === 'object' && x !== null && 'code' in x && 'body' in x
+}
+
 export async function resumeMission(req: Request, res: Response) {
   const id = parseInt(req.params.id, 10)
   if (isNaN(id)) {
@@ -230,39 +236,51 @@ export async function resumeMission(req: Request, res: Response) {
     return
   }
 
-  const mission = await prisma.mission.findUnique({ where: { id } })
-  if (!mission) {
-    res.status(404).json({ error: 'Mission introuvable' })
-    return
-  }
-  if (mission.status !== MissionStatus.PAUSED) {
-    res.status(400).json({ error: 'Mission non reprenable', status: mission.status })
-    return
-  }
-  if (!mission.robotId) {
-    res.status(400).json({ error: 'Aucun robot assigne a la mission' })
-    return
-  }
+  // Tous les checks DANS la transaction pour eviter la race entre
+  // findUnique et le robot.update (Copilot #218 — la mission peut etre
+  // annulee ou son robot reassigne entre les deux).
+  let robotIdForCommand: number
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      const mission = await tx.mission.findUnique({ where: { id } })
+      if (!mission) throw { code: 404, body: { error: 'Mission introuvable' } } satisfies ResumeError
+      if (mission.status !== MissionStatus.PAUSED) {
+        throw { code: 400, body: { error: 'Mission non reprenable', status: mission.status } } satisfies ResumeError
+      }
+      if (!mission.robotId) {
+        throw { code: 400, body: { error: 'Aucun robot assigne a la mission' } } satisfies ResumeError
+      }
 
-  // Robot repasse BUSY. Mission.status sera mis a jour par le robot via
-  // mission/status apres reprise (le robot connait son sous-etat reel).
-  const updated = await prisma.$transaction(async (tx) => {
-    await tx.robot.update({
-      where: { id: mission.robotId! },
-      data: { status: RobotStatus.BUSY },
+      await tx.robot.update({
+        where: { id: mission.robotId },
+        data: { status: RobotStatus.BUSY },
+      })
+
+      const reloaded = await tx.mission.findUnique({
+        where: { id },
+        include: {
+          fromPoint: true,
+          toPoint: true,
+          robot: { select: { id: true, name: true, status: true } },
+          user: { select: { id: true, name: true, email: true } },
+        },
+      })
+      // Theoriquement impossible (on vient de findUnique ci-dessus dans la
+      // meme transaction), mais on garde-fou plutot que renvoyer 200 + null.
+      if (!reloaded) throw { code: 404, body: { error: 'Mission disparue en cours de transaction' } } satisfies ResumeError
+
+      robotIdForCommand = mission.robotId
+      return reloaded
     })
-    return tx.mission.findUnique({
-      where: { id },
-      include: {
-        fromPoint: true,
-        toPoint: true,
-        robot: { select: { id: true, name: true, status: true } },
-        user: { select: { id: true, name: true, email: true } },
-      },
-    })
-  })
 
-  robotMqtt.publishCommand(mission.robotId, 'resume', { missionId: id })
-
-  res.json({ data: updated })
+    // Publish APRES commit reussi (sinon on commande au robot pour rien)
+    robotMqtt.publishCommand(robotIdForCommand!, 'resume', { missionId: id })
+    res.json({ data: updated })
+  } catch (err) {
+    if (isResumeError(err)) {
+      res.status(err.code).json(err.body)
+      return
+    }
+    throw err
+  }
 }

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -9,15 +9,23 @@ import prisma from '../lib/prisma'
 
 const SCHEMA_VERSION = 1
 
-// Payloads attendus depuis le robot (spec §5.4)
+// Payloads attendus depuis le robot (spec §4 + §5.4)
+// timestamp ISO-8601 obligatoire sur tous les messages.
+// reason obligatoire si rejected/failed (spec §5.4 — Copilot review #218).
+
 const missionAckSchema = z.object({
   messageId: z.string().min(1),
+  timestamp: z.string().datetime(),
   missionId: z.number().int().positive(),
   result: z.enum(['accepted', 'rejected']),
   reason: z.string().optional(),
-})
+}).refine(
+  (d) => d.result !== 'rejected' || (d.reason !== undefined && d.reason.length > 0),
+  { message: 'reason est obligatoire si result === "rejected"', path: ['reason'] },
+)
 
 const missionStatusSchema = z.object({
+  timestamp: z.string().datetime(),
   missionId: z.number().int().positive(),
   state: z.nativeEnum(MissionStatus),
   progress: z.number().min(0).max(1).optional(),
@@ -25,10 +33,14 @@ const missionStatusSchema = z.object({
 
 const missionResultSchema = z.object({
   messageId: z.string().min(1),
+  timestamp: z.string().datetime(),
   missionId: z.number().int().positive(),
   result: z.enum(['completed', 'failed', 'cancelled']),
   reason: z.string().optional(),
-})
+}).refine(
+  (d) => d.result !== 'failed' || (d.reason !== undefined && d.reason.length > 0),
+  { message: 'reason est obligatoire si result === "failed"', path: ['reason'] },
+)
 
 // Mapping result -> MissionStatus Prisma
 const RESULT_TO_STATUS = {

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -45,26 +45,42 @@ export type CmdAction =
   | 'loading-confirmed'
   | 'emergency-stop'
 
+// Duree de vie d'un messageId dans le cache d'idempotence. Au-dela, le retry
+// du robot est traite comme un nouveau message. Le robot ne doit pas retry
+// au-dela de cette fenetre (sinon double traitement) — la spec MQTT QoS 2
+// garantit que le broker ne livre pas deux fois en moins de quelques minutes.
+const SEEN_MESSAGE_TTL_MS = 60 * 60 * 1000 // 1 heure
+
 class RobotMqttAdapter {
   private client: MqttClient | null = null
   // messageIds deja traites pour les evenements (cf. spec §4 — idempotence).
-  // In-memory : on perd le set au restart, le robot peut rejouer un ack ; en
-  // pratique l'update Prisma reste idempotent (meme statut ecrit deux fois).
-  private seenMessageIds = new Set<string>()
+  // Map<messageId, expireAt>. TTL pour eviter fuite memoire sur long uptime
+  // (bug Copilot #218 — la demo soutenance tournera 8h).
+  private seenMessageIds = new Map<string, number>()
+
+  /** Purge les messageIds expires. Appele a chaque add. */
+  private purgeExpiredMessageIds(now: number = Date.now()): void {
+    for (const [id, expireAt] of this.seenMessageIds) {
+      if (expireAt <= now) this.seenMessageIds.delete(id)
+    }
+  }
 
   /**
    * Execute fn() une seule fois par messageId.
    * - Marque immediatement (synchrone) pour que deux deliveries concurrentes
    *   du meme messageId ne lancent pas deux fn() en parallele.
-   * - Si fn() throw, on retire le messageId du set : un retry du robot pourra
+   * - Si fn() throw, on retire le messageId du cache : un retry du robot pourra
    *   retenter (sinon un hoquet DB bloquait definitivement — bug Copilot #218).
+   * - Expire apres SEEN_MESSAGE_TTL_MS.
    */
   private async withIdempotence(
     messageId: string,
     fn: () => Promise<void>,
   ): Promise<void> {
+    const now = Date.now()
+    this.purgeExpiredMessageIds(now)
     if (this.seenMessageIds.has(messageId)) return
-    this.seenMessageIds.add(messageId)
+    this.seenMessageIds.set(messageId, now + SEEN_MESSAGE_TTL_MS)
     try {
       await fn()
     } catch (err) {

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -52,6 +52,27 @@ class RobotMqttAdapter {
   // pratique l'update Prisma reste idempotent (meme statut ecrit deux fois).
   private seenMessageIds = new Set<string>()
 
+  /**
+   * Execute fn() une seule fois par messageId.
+   * - Marque immediatement (synchrone) pour que deux deliveries concurrentes
+   *   du meme messageId ne lancent pas deux fn() en parallele.
+   * - Si fn() throw, on retire le messageId du set : un retry du robot pourra
+   *   retenter (sinon un hoquet DB bloquait definitivement — bug Copilot #218).
+   */
+  private async withIdempotence(
+    messageId: string,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    if (this.seenMessageIds.has(messageId)) return
+    this.seenMessageIds.add(messageId)
+    try {
+      await fn()
+    } catch (err) {
+      this.seenMessageIds.delete(messageId)
+      throw err
+    }
+  }
+
   /** Connexion au broker + abonnement aux topics robot (wildcard multi-robot). */
   connect(): void {
     if (this.client) return // deja connecte — singleton
@@ -152,10 +173,7 @@ class RobotMqttAdapter {
       return
     }
     const { messageId, missionId, result, reason } = parsed.data
-    if (this.seenMessageIds.has(messageId)) return
-    this.seenMessageIds.add(messageId)
-
-    try {
+    await this.withIdempotence(messageId, async () => {
       if (result === 'accepted') {
         await prisma.mission.update({
           where: { id: missionId },
@@ -167,10 +185,11 @@ class RobotMqttAdapter {
           data: { status: MissionStatus.FAILED, failureReason: reason ?? 'rejected' },
         })
       }
-    } catch (err) {
+    }).catch((err) => {
+      // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
       console.error('[mqtt] update mission/ack :',
         err instanceof Error ? err.message : err)
-    }
+    })
   }
 
   // mission/status — propage le sous-etat courant. Pas de messageId
@@ -202,14 +221,11 @@ class RobotMqttAdapter {
       return
     }
     const { messageId, missionId, result, reason } = parsed.data
-    if (this.seenMessageIds.has(messageId)) return
-    this.seenMessageIds.add(messageId)
-
     const status = RESULT_TO_STATUS[result]
     const missionData: { status: MissionStatus; failureReason?: string } = { status }
     if (result === 'failed') missionData.failureReason = reason ?? 'failed'
 
-    try {
+    await this.withIdempotence(messageId, async () => {
       await prisma.$transaction([
         prisma.mission.update({ where: { id: missionId }, data: missionData }),
         prisma.robot.update({
@@ -217,10 +233,11 @@ class RobotMqttAdapter {
           data: { status: RobotStatus.AVAILABLE },
         }),
       ])
-    } catch (err) {
+    }).catch((err) => {
+      // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
       console.error('[mqtt] update mission/result :',
         err instanceof Error ? err.message : err)
-    }
+    })
   }
 
   /** Fermeture propre — a appeler a l'arret du serveur. */

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -33,8 +33,13 @@ vi.mock('../lib/prisma', () => ({ default: prismaMock }))
 import { robotMqtt } from '../services/mqtt'
 
 // Helper : reconstruit un message MQTT comme s'il venait du broker.
+// Ajoute schemaVersion + timestamp par defaut (spec §4 — obligatoires).
 function deliver(topic: string, body: object) {
-  const payload = Buffer.from(JSON.stringify({ schemaVersion: 1, ...body }))
+  const payload = Buffer.from(JSON.stringify({
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    ...body,
+  }))
   messageHandler!(topic, payload)
 }
 
@@ -124,17 +129,15 @@ describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
     })
   })
 
-  it('mission/ack rejected sans reason ecrit "rejected"', async () => {
+  it('mission/ack rejected SANS reason est rejete par le schema (spec §5.4)', async () => {
     deliver('roblaude/3/mission/ack', {
       messageId: 'm-3',
       missionId: 7,
       result: 'rejected',
+      // pas de reason -> doit etre rejete
     })
     await Promise.resolve()
-    expect(prismaMock.mission.update).toHaveBeenCalledWith({
-      where: { id: 7 },
-      data: { status: 'FAILED', failureReason: 'rejected' },
-    })
+    expect(prismaMock.mission.update).not.toHaveBeenCalled()
   })
 
   it('mission/ack ignore les messageId deja vus (idempotence)', async () => {
@@ -249,17 +252,16 @@ describe('RobotMqttAdapter — handlers mission/result', () => {
     })
   })
 
-  it('failed sans reason ecrit "failed" en fallback', async () => {
+  it('mission/result failed SANS reason est rejete par le schema (spec §5.4)', async () => {
     deliver('roblaude/3/mission/result', {
       messageId: 'r-3',
       missionId: 42,
       result: 'failed',
+      // pas de reason -> doit etre rejete
     })
     await Promise.resolve()
-    expect(prismaMock.mission.update).toHaveBeenCalledWith({
-      where: { id: 42 },
-      data: { status: 'FAILED', failureReason: 'failed' },
-    })
+    expect(prismaMock.mission.update).not.toHaveBeenCalled()
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
   })
 
   it('cancelled: mission CANCELLED + robot AVAILABLE', async () => {

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -145,6 +145,20 @@ describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
     expect(prismaMock.mission.update).toHaveBeenCalledTimes(1)
   })
 
+  it('mission/ack — un echec Prisma ne consomme pas le messageId (retry OK)', async () => {
+    prismaMock.mission.update
+      .mockRejectedValueOnce(new Error('DB transitoire'))
+      .mockResolvedValueOnce({})
+    const payload = { messageId: 'm-retry', missionId: 42, result: 'accepted' as const }
+    deliver('roblaude/3/mission/ack', payload)
+    await Promise.resolve(); await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledTimes(1)
+    // Retry du robot avec le meme messageId apres l'echec — doit reessayer
+    deliver('roblaude/3/mission/ack', payload)
+    await Promise.resolve(); await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledTimes(2)
+  })
+
   it('mission/ack malforme est ignore (pas de crash)', async () => {
     deliver('roblaude/3/mission/ack', { missionId: 42 }) // pas de messageId/result
     await Promise.resolve()

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -145,6 +145,26 @@ describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
     expect(prismaMock.mission.update).toHaveBeenCalledTimes(1)
   })
 
+  it('mission/ack — un messageId expire est re-traite (TTL 1h)', async () => {
+    // On avance Date.now de 2h pour simuler l'expiration
+    const realNow = Date.now
+    Date.now = () => realNow.call(Date)
+
+    const payload = { messageId: 'm-old', missionId: 42, result: 'accepted' as const }
+    deliver('roblaude/3/mission/ack', payload)
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledTimes(1)
+
+    // 2h plus tard, le robot rejoue le meme messageId (cas peu probable mais
+    // notre TTL doit le laisser passer comme un nouveau message)
+    Date.now = () => realNow.call(Date) + 2 * 60 * 60 * 1000
+    deliver('roblaude/3/mission/ack', payload)
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledTimes(2)
+
+    Date.now = realNow
+  })
+
   it('mission/ack — un echec Prisma ne consomme pas le messageId (retry OK)', async () => {
     prismaMock.mission.update
       .mockRejectedValueOnce(new Error('DB transitoire'))


### PR DESCRIPTION
Closes #218.

Adresse les 4 remarques sérieuses de la review Copilot post-Sprint 4 :

## Commits

1. **`withIdempotence` helper** (#215+#216) — un échec Prisma ne consomme plus le messageId → le retry du robot fonctionne. Avant : si DB hoquetait, mission jamais finalisée silencieusement.
2. **TTL 1h sur `seenMessageIds`** — Map<string, expireAt> + purge à chaque add. Avant : fuite mémoire sur long uptime (problème pour la démo soutenance 8h).
3. **Zod renforcé** — `timestamp` ISO-8601 obligatoire sur tous messages (spec §4), `reason` obligatoire si `rejected`/`failed` (spec §5.4).
4. **POST /resume sécurisé** — tous les checks DANS la transaction (race conditions éliminées) + null guard sur findUnique (plus de réponse 200+null).

## Tests

- `mqtt.test.ts` : 21/21 tests passent (2 ajoutés : retry après échec DB, TTL purge)
- `tsc --noEmit` : OK
- `routes.test.ts` tests exhaustifs /resume (200/400/404) restent en dette — nécessite setup JWT_SECRET pour les tests, à traiter à part

## Reste sur l'issue #218

- LRU/persistence DB pour seenMessageIds (la Map+TTL suffit pour Sprint 5, persistance peut attendre)
- Tests exhaustifs /resume (200/400/404) — nécessite setup auth test
- Pipefail + doc chrony sur PR #214 (traités directement sur la branche T4.3.1)