### PR TITLE
[T4.2.9] Backend — handlers telemetry/battery + status + connection (#202)

### DIFF
--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -49,6 +49,28 @@ const RESULT_TO_STATUS = {
   cancelled: MissionStatus.CANCELLED,
 } as const
 
+// telemetry/battery (spec §5.2) — Robot.battery est un Int 0-100
+const batterySchema = z.object({
+  timestamp: z.string().datetime(),
+  voltage: z.number().optional(),
+  percent: z.number().int().min(0).max(100),
+  charging: z.boolean().optional(),
+})
+
+// status — le robot publie son etat applicatif (spec §5.3).
+// OFFLINE n'est pas publie par le robot lui-meme : c'est deduit du Last Will
+// sur le topic connection (cf. handleConnection).
+const statusSchema = z.object({
+  timestamp: z.string().datetime(),
+  state: z.enum(['AVAILABLE', 'BUSY', 'ERROR']),
+})
+
+// connection (spec §5.5) — Last Will retained, online:false a la coupure
+const connectionSchema = z.object({
+  timestamp: z.string().datetime(),
+  online: z.boolean(),
+})
+
 /** Actions publiables sur roblaude/{robotId}/cmd/{action}. */
 export type CmdAction =
   | 'mission'
@@ -171,12 +193,12 @@ class RobotMqttAdapter {
 
     switch (family) {
       case 'telemetry':
+        if (sub === 'battery') void this.handleBattery(robotId, data)
         // TODO #80 : sub === 'position' -> Robot.positionX/Y/heading (throttle)
-        // TODO #202 : sub === 'battery' -> Robot.battery
-        // puis relai WebSocket (position_update / battery_update)
+        // TODO websocket relay : battery_update / position_update
         break
       case 'status':
-        // TODO #202 : mettre a jour Robot.status + relai status_change
+        void this.handleStatus(robotId, data)
         break
       case 'mission':
         if (sub === 'ack') void this.handleMissionAck(robotId, data)
@@ -184,11 +206,81 @@ class RobotMqttAdapter {
         else if (sub === 'result') void this.handleMissionResult(robotId, data)
         break
       case 'connection':
-        // TODO #202 : data.online === false (Last Will) -> Robot.status = OFFLINE
+        void this.handleConnection(robotId, data)
         break
       default:
         console.warn(`[mqtt] famille de topic inconnue : ${family}`)
     }
+  }
+
+  // telemetry/battery — met a jour Robot.battery (percent 0-100).
+  // Le robot publie a ~1 Hz, on update systematiquement (negligeable en DB).
+  private async handleBattery(robotId: number, data: Record<string, unknown>) {
+    const parsed = batterySchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] telemetry/battery rejete :', parsed.error.issues)
+      return
+    }
+    try {
+      await prisma.robot.update({
+        where: { id: robotId },
+        data: { battery: parsed.data.percent },
+      })
+    } catch (err) {
+      console.error('[mqtt] update battery :',
+        err instanceof Error ? err.message : err)
+    }
+    // TODO websocket : relay battery_update aux clients
+  }
+
+  // status — etat applicatif (AVAILABLE / BUSY / ERROR).
+  // Ne touche pas a OFFLINE (gere par handleConnection via le Last Will).
+  private async handleStatus(robotId: number, data: Record<string, unknown>) {
+    const parsed = statusSchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] status rejete :', parsed.error.issues)
+      return
+    }
+    try {
+      await prisma.robot.update({
+        where: { id: robotId },
+        data: { status: parsed.data.state as RobotStatus },
+      })
+    } catch (err) {
+      console.error('[mqtt] update status :',
+        err instanceof Error ? err.message : err)
+    }
+    // TODO websocket : relay status_change aux clients
+  }
+
+  // connection — presence du robot via le Last Will MQTT.
+  // online:false (LWT) -> Robot.status = OFFLINE
+  // online:true        -> si etait OFFLINE, on restaure a AVAILABLE.
+  //   (le robot republiera son status precis juste apres, qui ecrasera)
+  private async handleConnection(robotId: number, data: Record<string, unknown>) {
+    const parsed = connectionSchema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] connection rejete :', parsed.error.issues)
+      return
+    }
+    try {
+      if (!parsed.data.online) {
+        await prisma.robot.update({
+          where: { id: robotId },
+          data: { status: RobotStatus.OFFLINE },
+        })
+      } else {
+        // Restore conditionnel : on ne touche que si robot etait OFFLINE
+        await prisma.robot.updateMany({
+          where: { id: robotId, status: RobotStatus.OFFLINE },
+          data: { status: RobotStatus.AVAILABLE },
+        })
+      }
+    } catch (err) {
+      console.error('[mqtt] update connection :',
+        err instanceof Error ? err.message : err)
+    }
+    // TODO websocket : relay robot_online / robot_offline aux clients
   }
 
   // mission/ack — accepted: on attache le robot a la mission.

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -23,7 +23,10 @@ vi.mock('mqtt', () => ({
 const { prismaMock } = vi.hoisted(() => ({
   prismaMock: {
     mission: { update: vi.fn().mockResolvedValue({}) },
-    robot: { update: vi.fn().mockResolvedValue({}) },
+    robot: {
+      update: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
     // $transaction recoit un tableau de promesses Prisma et resout dans l'ordre.
     $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
   },
@@ -313,5 +316,62 @@ describe('RobotMqttAdapter — handlers mission/result', () => {
     })
     await Promise.resolve()
     expect(prismaMock.$transaction).not.toHaveBeenCalled()
+  })
+})
+
+describe('RobotMqttAdapter — handlers telemetry/battery, status, connection (T4.2.9)', () => {
+  beforeEach(() => {
+    prismaMock.robot.update.mockClear()
+    prismaMock.robot.updateMany.mockClear()
+    robotMqtt.disconnect()
+    robotMqtt.connect()
+  })
+
+  it('telemetry/battery met a jour Robot.battery (percent)', async () => {
+    deliver('roblaude/3/telemetry/battery', { voltage: 11.7, percent: 67, charging: false })
+    await Promise.resolve()
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { battery: 67 },
+    })
+  })
+
+  it('telemetry/battery avec percent hors borne est ignore', async () => {
+    deliver('roblaude/3/telemetry/battery', { percent: 150 })
+    await Promise.resolve()
+    expect(prismaMock.robot.update).not.toHaveBeenCalled()
+  })
+
+  it('status met a jour Robot.status', async () => {
+    deliver('roblaude/3/status', { state: 'BUSY' })
+    await Promise.resolve()
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'BUSY' },
+    })
+  })
+
+  it('status avec etat inconnu est ignore', async () => {
+    deliver('roblaude/3/status', { state: 'FLYING' })
+    await Promise.resolve()
+    expect(prismaMock.robot.update).not.toHaveBeenCalled()
+  })
+
+  it('connection online:false force Robot.status a OFFLINE', async () => {
+    deliver('roblaude/3/connection', { online: false })
+    await Promise.resolve()
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'OFFLINE' },
+    })
+  })
+
+  it('connection online:true restaure AVAILABLE si etait OFFLINE', async () => {
+    deliver('roblaude/3/connection', { online: true })
+    await Promise.resolve()
+    expect(prismaMock.robot.updateMany).toHaveBeenCalledWith({
+      where: { id: 3, status: 'OFFLINE' },
+      data: { status: 'AVAILABLE' },
+    })
   })
 })


### PR DESCRIPTION
Closes #202.

## Ce qui est dans la PR

3 handlers MQTT manquants dans `web/backend/src/services/mqtt.ts` (les TODO #202 sont remplis) :

- **`telemetry/battery`** → `Robot.battery` (percent 0-100), update à chaque message (~1 Hz du robot, négligeable en DB).
- **`status`** → `Robot.status` (`AVAILABLE` / `BUSY` / `ERROR`). N'écrit pas `OFFLINE` — c'est délégué au handler `connection` (Last Will).
- **`connection`** :
  - `{online: false}` (Last Will MQTT à la coupure brutale) → `Robot.status = OFFLINE`
  - `{online: true}` → `updateMany` conditionnel (si etait `OFFLINE` → restore `AVAILABLE`). Le robot republiera son `status` precis juste après, qui écrasera.

3 schemas Zod (`batterySchema`, `statusSchema`, `connectionSchema`) avec validation `timestamp` ISO-8601 et bornes correctes.

## Hors scope (à faire plus tard)

- **WebSocket relay** (`battery_update`, `status_change`, `robot_online/offline`) — pas de serveur WS backend pour l'instant. Des `// TODO websocket` sont laissés pour pointer où.

## Tests

- 6 nouveaux tests vitest dans `mqtt.test.ts` (27/27 passent)
  - happy path battery/status/connection
  - validation : percent hors borne, état inconnu → ignoré
  - online:false → OFFLINE / online:true → restore AVAILABLE

## Validé

- `npx vitest run mqtt.test.ts` : 27/27 ✅
- `tsc --noEmit` : OK ✅