### PR TITLE
[T4.4.1] Infra — Mosquitto auth + ACL (#203)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,11 @@ services:
     ports:
       - "1883:1883"
     volumes:
-      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ./infra/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./infra/mosquitto/passwd:/mosquitto/config/passwd:ro
+      - ./infra/mosquitto/acl:/mosquitto/config/acl:ro
+      - mosquitto_data:/mosquitto/data
 
 volumes:
   mysql_data:
+  mosquitto_data:

--- a/infra/mosquitto/README.md
+++ b/infra/mosquitto/README.md
@@ -1,0 +1,74 @@
+# Mosquitto — auth + ACL
+
+Le broker refuse les connexions anonymes (`allow_anonymous false`) et isole
+chaque robot via un ACL (cf. `docs/mqtt-spec.md` §7).
+
+## Premier setup (une seule fois par dev)
+
+Générer le fichier `passwd` (gitignored) :
+
+```bash
+touch infra/mosquitto/passwd
+
+# Backend — broker
+docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
+    mosquitto_passwd -b /m/passwd backend backend-CHANGE-ME
+
+# Robot 1 — broker
+docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
+    mosquitto_passwd -b /m/passwd robot-1 robot1-CHANGE-ME
+```
+
+Remplacer `*-CHANGE-ME` par des mots de passe forts. Reporter ces
+credentials dans :
+
+- `web/backend/.env` :
+  ```
+  MQTT_USERNAME=backend
+  MQTT_PASSWORD=<backend-CHANGE-ME>
+  ```
+- Côté robot, dans `mqtt_bridge.yaml` ou via env :
+  ```yaml
+  mqtt_user: 'robot-1'
+  mqtt_password: '<robot1-CHANGE-ME>'
+  ```
+
+## Ajouter un robot
+
+Pour chaque nouveau robot, créer un user dédié et étendre l'ACL :
+
+```bash
+docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
+    mosquitto_passwd -b /m/passwd robot-2 robot2-pwd
+```
+
+Puis ajouter dans `infra/mosquitto/acl` :
+
+```
+user robot-2
+topic write roblaude/2/telemetry/#
+topic write roblaude/2/status
+topic write roblaude/2/connection
+topic write roblaude/2/mission/ack
+topic write roblaude/2/mission/status
+topic write roblaude/2/mission/result
+topic read roblaude/2/cmd/#
+```
+
+Reload : `docker compose restart mosquitto`.
+
+## Tester l'ACL
+
+```bash
+# Doit etre refuse : client anonyme
+docker run --rm --network=host eclipse-mosquitto:2 mosquitto_sub \
+    -h localhost -t 'roblaude/#' -W 2
+
+# Doit etre refuse : robot-1 publie sur robot-2
+docker run --rm --network=host eclipse-mosquitto:2 mosquitto_pub \
+    -h localhost -u robot-1 -P <pwd> -t 'roblaude/2/status' -m '{}'
+
+# Doit passer : backend ecoute tout
+docker run --rm --network=host eclipse-mosquitto:2 mosquitto_sub \
+    -h localhost -u backend -P <pwd> -t 'roblaude/#' -C 1 -W 3
+```

--- a/infra/mosquitto/acl
+++ b/infra/mosquitto/acl
@@ -1,0 +1,21 @@
+# ACL Mosquitto — spec §7
+# Convention : 1 user par identité fonctionnelle (backend, robot-N).
+# Le backend a acces lecture+ecriture a tout. Chaque robot est cantonne
+# a son namespace roblaude/{id}/# pour la publication et a son
+# roblaude/{id}/cmd/# en lecture seule.
+
+# Backend : tous les droits sur le namespace roblaude
+user backend
+topic readwrite roblaude/#
+
+# Robot 1 — modele a dupliquer pour chaque robot ajoute
+user robot-1
+# Le robot publie sa telemetrie et son etat
+topic write roblaude/1/telemetry/#
+topic write roblaude/1/status
+topic write roblaude/1/connection
+topic write roblaude/1/mission/ack
+topic write roblaude/1/mission/status
+topic write roblaude/1/mission/result
+# Le robot lit les commandes du backend
+topic read roblaude/1/cmd/#

--- a/infra/mosquitto/mosquitto.conf
+++ b/infra/mosquitto/mosquitto.conf
@@ -1,0 +1,15 @@
+listener 1883
+
+# Authentification obligatoire (T4.4.1 — fini les connexions anonymes)
+# Le fichier passwd contient des hash bcrypt generes par mosquitto_passwd.
+# Genere localement (jamais commit) — voir infra/mosquitto/README.md.
+allow_anonymous false
+password_file /mosquitto/config/passwd
+
+# Restriction par topic : un robot ne peut publier que sur ses propres
+# topics, le backend a acces a tout roblaude/#.
+acl_file /mosquitto/config/acl
+
+# Persistance des messages retained / sessions QoS 1+2 (cf docs/mqtt-spec.md §6)
+persistence true
+persistence_location /mosquitto/data/

--- a/infra/mosquitto/passwd.example
+++ b/infra/mosquitto/passwd.example
@@ -1,0 +1,14 @@
+# Format Mosquitto passwd (apres `mosquitto_passwd -U`) : user:hash_bcrypt
+# Genere avec :
+#   touch infra/mosquitto/passwd
+#   docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
+#       mosquitto_passwd -b /m/passwd backend backend-CHANGE-ME
+#   docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
+#       mosquitto_passwd -b /m/passwd robot-1 robot1-CHANGE-ME
+#
+# Le fichier passwd reel est gitignored. Ne commit JAMAIS les vrais hashes
+# ni les mots de passe en clair.
+
+# Exemple de structure (hashes factices) :
+backend:$7$101$fakebackendhash$fakefakefakefake
+robot-1:$7$101$fakerobot1hash$fakefakefakefake

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,2 +1,0 @@
-listener 1883
-allow_anonymous true


### PR DESCRIPTION
Closes #203.

## Ce qui change

- **`infra/mosquitto/mosquitto.conf`** : `allow_anonymous false`, `password_file`, `acl_file`, persistance activee.
- **`infra/mosquitto/acl`** : ACL par identite. `backend` → readwrite sur `roblaude/#`. `robot-1` → write sur ses propres topics + read sur `roblaude/1/cmd/#` uniquement.
- **`infra/mosquitto/passwd.example`** : template du fichier passwd (le vrai est gitignored).
- **`infra/mosquitto/README.md`** : procedure setup, ajout d'un robot, tests ACL.
- **`docker-compose.yml`** : monte les 3 fichiers + volume persistance `mosquitto_data`.
- **`.gitignore`** : ajoute `infra/mosquitto/passwd` (jamais commit les vrais hashes).
- **Supprime** `mosquitto.conf` racine (remplace par `infra/mosquitto/mosquitto.conf`).

## Setup developer (une seule fois)

Voir `infra/mosquitto/README.md`. En résumé :

```bash
touch infra/mosquitto/passwd
docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
    mosquitto_passwd -b /m/passwd backend STRONG-PASSWORD
docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
    mosquitto_passwd -b /m/passwd robot-1 STRONG-PASSWORD
docker compose restart mosquitto
```

Reporter les credentials dans `web/backend/.env` (`MQTT_USERNAME`, `MQTT_PASSWORD`) et dans le `mqtt_bridge.yaml` côté robot (`mqtt_user`, `mqtt_password` deja supportes).

## Tests acceptance (manuels — necessite mosquitto live)

- [x] Client anonyme refuse : `mosquitto_sub -t '#'` sans creds → 'Connection Refused: not authorised'
- [x] `robot-1` ne peut pas publier sur `roblaude/2/...`
- [x] `backend` lit tout

## Hors scope

- Migration TLS (1883 → 8883 + certificats) — Sprint 8 sécurité prod
- Rotation des secrets — Sprint 9