### PR TITLE
[T4.2.2 T4.2.6 T4.2.8] Endpoints commande — mission/stop/confirm-loading

### DIFF
--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -160,6 +160,17 @@ export async function createMission(req: Request, res: Response) {
     },
   })
 
+  // T4.2.2 — publie cmd/mission au robot si un robotId est present. Sans
+  // robotId, la mission reste PENDING ; un assignment ulterieur publiera.
+  if (mission.robotId) {
+    robotMqtt.publishCommand(mission.robotId, 'mission', {
+      missionId: mission.id,
+      type: mission.type,
+      fromPoint: { x: fromPoint.x, y: fromPoint.y, slug: fromPoint.slug },
+      toPoint: { x: toPoint.x, y: toPoint.y, slug: toPoint.slug },
+    })
+  }
+
   res.status(201).json({ data: mission })
 }
 
@@ -283,4 +294,117 @@ export async function resumeMission(req: Request, res: Response) {
     }
     throw err
   }
+}
+
+// états depuis lesquels on peut emergency-stop (en gros tout ce qui est actif)
+const STOPPABLE_STATUSES: MissionStatus[] = [
+  MissionStatus.PENDING,
+  MissionStatus.PAUSED,
+  MissionStatus.NAVIGATING_TO_PICKUP,
+  MissionStatus.WAITING_FOR_LOAD,
+  MissionStatus.NAVIGATING_TO_DESTINATION,
+  MissionStatus.DETECTING_OBJECT,
+  MissionStatus.GRASPING,
+  MissionStatus.TRANSPORTING,
+  MissionStatus.DEPOSITING,
+]
+
+// T4.2.6 — arret d'urgence. Publie cmd/emergency-stop et passe la mission
+// en CANCELLED. Le robot lui-meme republiera un mission/result cancelled
+// quand il aura effectivement stoppe (status terrain fait foi).
+export async function stopMission(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const reason = typeof req.body?.reason === 'string' ? req.body.reason : 'user-pressed-stop'
+
+  const mission = await prisma.mission.findUnique({ where: { id } })
+  if (!mission) {
+    res.status(404).json({ error: 'Mission introuvable' })
+    return
+  }
+  if (!STOPPABLE_STATUSES.includes(mission.status)) {
+    res.status(400).json({ error: 'Mission non arretable', status: mission.status })
+    return
+  }
+  if (!mission.robotId) {
+    res.status(400).json({ error: 'Aucun robot assigne a la mission' })
+    return
+  }
+
+  // Update local + libere robot. Le robot republiera son etat reel via
+  // mission/result quand il aura stoppe — ca ecrasera notre CANCELLED si
+  // necessaire.
+  const updated = await prisma.$transaction(async (tx) => {
+    const cancelled = await tx.mission.update({
+      where: { id },
+      data: { status: MissionStatus.CANCELLED, failureReason: reason },
+      include: {
+        fromPoint: true,
+        toPoint: true,
+        robot: { select: { id: true, name: true, status: true } },
+        user: { select: { id: true, name: true, email: true } },
+      },
+    })
+    await tx.robot.update({
+      where: { id: mission.robotId! },
+      data: { status: RobotStatus.AVAILABLE },
+    })
+    return cancelled
+  })
+
+  robotMqtt.publishCommand(mission.robotId, 'emergency-stop', {
+    missionId: id,
+    reason,
+  })
+
+  res.json({ data: updated })
+}
+
+// T4.2.8 — l'utilisateur confirme depuis l'UI que la charge est faite.
+// Publie cmd/loading-confirmed. Le robot reprendra et republiera
+// mission/status quand il bouge vers la destination.
+export async function confirmLoadingMission(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const mission = await prisma.mission.findUnique({ where: { id } })
+  if (!mission) {
+    res.status(404).json({ error: 'Mission introuvable' })
+    return
+  }
+  if (mission.status !== MissionStatus.WAITING_FOR_LOAD) {
+    res.status(400).json({
+      error: 'Mission pas en attente de chargement',
+      status: mission.status,
+    })
+    return
+  }
+  if (!mission.robotId) {
+    res.status(400).json({ error: 'Aucun robot assigne a la mission' })
+    return
+  }
+
+  robotMqtt.publishCommand(mission.robotId, 'loading-confirmed', {
+    missionId: id,
+  })
+
+  // On ne change PAS mission.status ici : le robot publiera son sous-etat
+  // suivant (NAVIGATING_TO_DESTINATION) via mission/status apres reception.
+  const refreshed = await prisma.mission.findUnique({
+    where: { id },
+    include: {
+      fromPoint: true,
+      toPoint: true,
+      robot: { select: { id: true, name: true, status: true } },
+      user: { select: { id: true, name: true, email: true } },
+    },
+  })
+  res.json({ data: refreshed })
 }

--- a/web/backend/src/routes/missions.ts
+++ b/web/backend/src/routes/missions.ts
@@ -1,6 +1,14 @@
 import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
-import { listMissions, getMission, createMission, cancelMission, resumeMission } from '../controllers/missionsController'
+import {
+  listMissions,
+  getMission,
+  createMission,
+  cancelMission,
+  resumeMission,
+  stopMission,
+  confirmLoadingMission,
+} from '../controllers/missionsController'
 
 const router = Router()
 
@@ -13,10 +21,16 @@ router.get('/:id', asyncHandler(getMission))
 // POST /api/missions
 router.post('/', asyncHandler(createMission))
 
-// POST /api/missions/:id/cancel
+// POST /api/missions/:id/cancel — annulation logique (mission PENDING/active)
 router.post('/:id/cancel', asyncHandler(cancelMission))
 
 // POST /api/missions/:id/resume — relance une mission PAUSED
 router.post('/:id/resume', asyncHandler(resumeMission))
+
+// POST /api/missions/:id/stop — arret d'urgence (cmd/emergency-stop au robot)
+router.post('/:id/stop', asyncHandler(stopMission))
+
+// POST /api/missions/:id/confirm-loading — l'user confirme la charge (cmd/loading-confirmed)
+router.post('/:id/confirm-loading', asyncHandler(confirmLoadingMission))
 
 export default router

--- a/web/backend/src/test/routes.test.ts
+++ b/web/backend/src/test/routes.test.ts
@@ -42,6 +42,16 @@ describe('Routes protegees (sans token = 401)', () => {
     const res = await request(app).post('/api/missions/1/resume').send({})
     expect(res.status).toBe(401)
   })
+
+  it('POST /api/missions/1/stop → 401', async () => {
+    const res = await request(app).post('/api/missions/1/stop').send({})
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/missions/1/confirm-loading → 401', async () => {
+    const res = await request(app).post('/api/missions/1/confirm-loading').send({})
+    expect(res.status).toBe(401)
+  })
 })
 
 describe('Routes publiques', () => {


### PR DESCRIPTION
Closes #78, #82, #84.

3 endpoints commande backend pour boucler la chaîne web → robot via MQTT :

- **POST /api/missions** : publie maintenant `cmd/mission` au robot si `robotId` présent à la création (sinon mission reste PENDING jusqu'à assignment futur).
- **POST /api/missions/:id/stop** : arrêt d'urgence. Publie `cmd/emergency-stop`, passe la mission en CANCELLED, libère le robot. `reason` optionnelle dans le body.
- **POST /api/missions/:id/confirm-loading** : confirme la charge depuis l'UI. Publie `cmd/loading-confirmed`. Ne change pas `mission.status` (le robot publiera son sous-état suivant via `mission/status`).

Tests routes 401 ajoutés pour les 2 nouveaux endpoints (les 200/400/404 restent en dette comme pour /resume — nécessite JWT_SECRET de test).