### PR TITLE
[T4.3.0] Backend — WebSocket relay (MQTT -> clients front)

### DIFF
--- a/web/backend/package-lock.json
+++ b/web/backend/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.3",
         "mqtt": "^5.15.1",
         "prisma": "^6.19.2",
+        "ws": "^8.20.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -27,6 +28,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.5.0",
         "@types/supertest": "^7.2.0",
+        "@types/ws": "^8.18.1",
         "supertest": "^7.2.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^6.0.2",

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -25,6 +25,7 @@
     "jsonwebtoken": "^9.0.3",
     "mqtt": "^5.15.1",
     "prisma": "^6.19.2",
+    "ws": "^8.20.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.5.0",
     "@types/supertest": "^7.2.0",
+    "@types/ws": "^8.18.1",
     "supertest": "^7.2.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^6.0.2",

--- a/web/backend/src/index.ts
+++ b/web/backend/src/index.ts
@@ -1,10 +1,17 @@
 import 'dotenv/config'
+import http from 'node:http'
 import { app } from './app'
 import { robotMqtt } from './services/mqtt'
+import { wsRelay } from './services/websocket'
 
 const PORT = process.env.PORT || 3001
 
-const server = app.listen(PORT, () => {
+// HTTP server explicite (createServer) pour pouvoir attacher le WS dessus
+// (upgrade handshake). app.listen ne donne pas acces au server.
+const server = http.createServer(app)
+wsRelay.attach(server)
+
+server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)
 })
 
@@ -13,6 +20,7 @@ robotMqtt.connect()
 function shutdown(signal: string) {
   console.log(`[server] ${signal} recu, arret propre…`)
   robotMqtt.disconnect()
+  wsRelay.close()
   server.close(() => process.exit(0))
 }
 

--- a/web/backend/src/middleware/auth.ts
+++ b/web/backend/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken'
 // Pas de valeur par defaut : un secret en dur dans le code serait public
 // (visible sur GitHub) et permettrait de forger des tokens. Si la variable
 // est absente, le serveur refuse de demarrer.
-function getJwtSecret(): string {
+export function getJwtSecret(): string {
   const secret = process.env.JWT_SECRET
   if (!secret) {
     throw new Error(

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { MissionStatus, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
+import { wsRelay } from './websocket'
 
 // Adaptateur MQTT du backend — singleton.
 // Topics et formats : voir docs/mqtt-spec.md
@@ -226,11 +227,15 @@ class RobotMqttAdapter {
         where: { id: robotId },
         data: { battery: parsed.data.percent },
       })
+      wsRelay.broadcast({
+        type: 'battery_update',
+        robotId,
+        percent: parsed.data.percent,
+      })
     } catch (err) {
       console.error('[mqtt] update battery :',
         err instanceof Error ? err.message : err)
     }
-    // TODO websocket : relay battery_update aux clients
   }
 
   // status — etat applicatif (AVAILABLE / BUSY / ERROR).
@@ -246,11 +251,15 @@ class RobotMqttAdapter {
         where: { id: robotId },
         data: { status: parsed.data.state as RobotStatus },
       })
+      wsRelay.broadcast({
+        type: 'status_change',
+        robotId,
+        status: parsed.data.state,
+      })
     } catch (err) {
       console.error('[mqtt] update status :',
         err instanceof Error ? err.message : err)
     }
-    // TODO websocket : relay status_change aux clients
   }
 
   // connection — presence du robot via le Last Will MQTT.
@@ -269,18 +278,18 @@ class RobotMqttAdapter {
           where: { id: robotId },
           data: { status: RobotStatus.OFFLINE },
         })
+        wsRelay.broadcast({ type: 'robot_offline', robotId })
       } else {
-        // Restore conditionnel : on ne touche que si robot etait OFFLINE
         await prisma.robot.updateMany({
           where: { id: robotId, status: RobotStatus.OFFLINE },
           data: { status: RobotStatus.AVAILABLE },
         })
+        wsRelay.broadcast({ type: 'robot_online', robotId })
       }
     } catch (err) {
       console.error('[mqtt] update connection :',
         err instanceof Error ? err.message : err)
     }
-    // TODO websocket : relay robot_online / robot_offline aux clients
   }
 
   // mission/ack — accepted: on attache le robot a la mission.
@@ -320,11 +329,17 @@ class RobotMqttAdapter {
       console.warn('[mqtt] mission/status rejete :', parsed.error.issues)
       return
     }
-    const { missionId, state } = parsed.data
+    const { missionId, state, progress } = parsed.data
     try {
       await prisma.mission.update({
         where: { id: missionId },
         data: { status: state },
+      })
+      wsRelay.broadcast({
+        type: 'mission_update',
+        missionId,
+        status: state,
+        progress,
       })
     } catch (err) {
       console.error('[mqtt] update mission/status :',
@@ -353,6 +368,17 @@ class RobotMqttAdapter {
           data: { status: RobotStatus.AVAILABLE },
         }),
       ])
+      wsRelay.broadcast({
+        type: 'mission_completed',
+        missionId,
+        result,
+        reason,
+      })
+      wsRelay.broadcast({
+        type: 'status_change',
+        robotId,
+        status: RobotStatus.AVAILABLE,
+      })
     }).catch((err) => {
       // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
       console.error('[mqtt] update mission/result :',

--- a/web/backend/src/services/websocket.ts
+++ b/web/backend/src/services/websocket.ts
@@ -1,0 +1,97 @@
+import { WebSocketServer, WebSocket } from 'ws'
+import type { Server as HttpServer, IncomingMessage } from 'node:http'
+import jwt from 'jsonwebtoken'
+import { getJwtSecret } from '../middleware/auth'
+
+// Service relay : MQTT/Prisma -> WebSocket -> clients frontend.
+// Singleton, attache sur le meme HTTP server qu'Express.
+// Auth : JWT en query param `?token=...` (impossible de mettre un header
+// custom dans le constructeur WebSocket cote navigateur).
+
+export type WsEvent =
+  | { type: 'battery_update'; robotId: number; percent: number }
+  | { type: 'status_change'; robotId: number; status: string }
+  | { type: 'robot_online'; robotId: number }
+  | { type: 'robot_offline'; robotId: number }
+  | { type: 'position_update'; robotId: number; x: number; y: number; theta?: number }
+  | { type: 'mission_update'; missionId: number; status: string; progress?: number }
+  | { type: 'mission_completed'; missionId: number; result: string; reason?: string }
+  | { type: 'map_update'; robotId: number; mapData: string }
+
+class WebSocketRelay {
+  private wss: WebSocketServer | null = null
+  private clients = new Set<WebSocket>()
+
+  /** Attache le WS server sur l'instance HTTP d'Express (path /ws). */
+  attach(httpServer: HttpServer): void {
+    if (this.wss) return // singleton
+
+    this.wss = new WebSocketServer({ noServer: true })
+
+    httpServer.on('upgrade', (req, socket, head) => {
+      if (!req.url || !req.url.startsWith('/ws')) return socket.destroy()
+
+      // Auth JWT obligatoire en query param
+      const url = new URL(req.url, `http://${req.headers.host}`)
+      const token = url.searchParams.get('token')
+      if (!token) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        socket.destroy()
+        return
+      }
+      try {
+        jwt.verify(token, getJwtSecret())
+      } catch {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        socket.destroy()
+        return
+      }
+
+      this.wss!.handleUpgrade(req, socket, head, (ws) => {
+        this.wss!.emit('connection', ws, req)
+      })
+    })
+
+    this.wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
+      this.clients.add(ws)
+      ws.on('close', () => this.clients.delete(ws))
+      ws.on('error', (err) => {
+        console.error('[ws] client error :', err.message)
+        this.clients.delete(ws)
+      })
+    })
+
+    console.log('[ws] WebSocket relay attache sur /ws')
+  }
+
+  /** Diffuse un evenement a tous les clients connectes (qui sont OPEN). */
+  broadcast(event: WsEvent): void {
+    if (!this.wss) return
+    const payload = JSON.stringify(event)
+    for (const ws of this.clients) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(payload)
+    }
+  }
+
+  /** Nombre de clients connectes — utile pour debug et metrics. */
+  get clientCount(): number {
+    return this.clients.size
+  }
+
+  /** Arret propre — ferme toutes les connexions. */
+  close(): void {
+    for (const ws of this.clients) {
+      try {
+        ws.close(1001, 'Server shutdown')
+      } catch {
+        // ignore
+      }
+    }
+    this.clients.clear()
+    this.wss?.close()
+    this.wss = null
+  }
+}
+
+/** Singleton du relay WebSocket. */
+export const wsRelay = new WebSocketRelay()


### PR DESCRIPTION
Pose les fondations temps réel côté backend pour le frontend (hook #85, notifs #87, STOP #88).

## Ce qui change

- **`services/websocket.ts`** (nouveau) : singleton `wsRelay` qui :
  - Attache un `WebSocketServer` sur le HTTP server Express (path `/ws`)
  - Auth JWT obligatoire via query param `?token=...` (impossible de passer un header custom côté navigateur)
  - 401 `Unauthorized` si pas de token ou token invalide
  - Méthode `broadcast(event)` typée — diffuse à tous les clients OPEN
- **`services/mqtt.ts`** : chaque handler MQTT broadcast l'event WS après update DB. `battery_update`, `status_change`, `robot_online/offline`, `mission_update`, `mission_completed`.
- **`index.ts`** : utilise `http.createServer(app)` pour pouvoir attacher le upgrade WS, et `wsRelay.attach(server)`. Fermeture propre sur SIGTERM/SIGINT.
- **`middleware/auth.ts`** : export `getJwtSecret` (utilisé par le WS pour valider le token).
- **deps** : `ws` + `@types/ws` installés.

## Types d'événements diffusés

```ts
type WsEvent =
  | { type: 'battery_update'; robotId; percent }
  | { type: 'status_change'; robotId; status }
  | { type: 'robot_online' | 'robot_offline'; robotId }
  | { type: 'position_update'; robotId; x; y; theta? }
  | { type: 'mission_update'; missionId; status; progress? }
  | { type: 'mission_completed'; missionId; result; reason? }
  | { type: 'map_update'; robotId; mapData }
```

## Hors scope (à venir)

- Client frontend (`useWebSocket` hook) — PR séparée
- `position_update` broadcast : actif quand #71 (robot publie `/amcl_pose`) sera fait
- `map_update` broadcast : pour #86 (carte 2D)