### PR TITLE
[T4.3.1 T4.3.3 T4.3.4] Frontend — WebSocket realtime + bouton STOP + toasts

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zustand": "^5.0.12"
@@ -9732,6 +9733,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -22,6 +22,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.12"

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { Toaster } from 'sonner'
 import { AppLayout } from './layouts/AppLayout'
 import { DashboardPage } from './pages/DashboardPage'
 import { MissionsPage } from './pages/MissionsPage'
@@ -9,9 +10,12 @@ import { ProfilePage } from './pages/ProfilePage'
 import { LoginPage } from './pages/LoginPage'
 import { RequireAuth } from './components/RequireAuth'
 import { useAuthStore } from './stores/authStore'
+import { useWebSocket } from './hooks/useWebSocket'
 
 export default function App() {
   const role = useAuthStore((s) => s.user?.role)
+  // ouvre la connexion WS au login, ferme au logout — singleton
+  useWebSocket()
   return (
     <BrowserRouter>
       <Routes>
@@ -35,6 +39,7 @@ export default function App() {
 
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      <Toaster richColors position="top-right" />
     </BrowserRouter>
   )
 }

--- a/web/frontend/src/components/RobotMap.tsx
+++ b/web/frontend/src/components/RobotMap.tsx
@@ -1,0 +1,140 @@
+import { useRobotStore } from '../stores/robotStore'
+import { useMissionStore } from '../stores/missionStore'
+
+// Carte 2D minimaliste — SVG natif, pas de lib.
+// Convention de repere :
+//   - origine (0,0) au centre de la carte (= frame `map` ou `odom` du robot)
+//   - X vers la droite, Y vers le haut (math). On flip Y pour SVG (qui a Y vers le bas).
+//   - Echelle : MAP_SCALE_PX_PER_M px = 1 metre
+// Adaptee a une demo "zone 20x14 m" (couloir + salle ERP).
+
+const MAP_W = 600 // viewport SVG px
+const MAP_H = 400
+const MAP_SCALE_PX_PER_M = 30 // 30px = 1m -> zone ~20x14 m visible
+const ROBOT_RADIUS = 14
+
+interface Props {
+  className?: string
+}
+
+// Convertit coord robot (m) -> coord SVG (px), origine au centre.
+function rx(x: number): number {
+  return MAP_W / 2 + x * MAP_SCALE_PX_PER_M
+}
+function ry(y: number): number {
+  // flip Y (math vers SVG)
+  return MAP_H / 2 - y * MAP_SCALE_PX_PER_M
+}
+
+export function RobotMap({ className }: Props) {
+  const status = useRobotStore((s) => s.status)
+  const position = useRobotStore((s) => s.position)
+  const missions = useMissionStore((s) => s.missions)
+
+  // Mission active (s'il y en a une) — pour afficher from/to
+  const active = missions.find((m) =>
+    ['PENDING', 'PAUSED', 'NAVIGATING_TO_PICKUP', 'WAITING_FOR_LOAD',
+     'NAVIGATING_TO_DESTINATION', 'TRANSPORTING'].includes(m.status)
+  )
+
+  // Couleur du robot selon status
+  const robotColor =
+    status === 'OFFLINE' ? '#737373' :
+    status === 'ERROR'   ? '#ef4444' :
+    status === 'BUSY'    ? '#f59e0b' :
+                           '#22c55e'
+
+  // Heading : on dessine une fleche depuis le centre du robot
+  const headRad = position.heading
+  const headX = rx(position.x) + Math.cos(headRad) * (ROBOT_RADIUS + 8)
+  const headY = ry(position.y) - Math.sin(headRad) * (ROBOT_RADIUS + 8)
+
+  return (
+    <div className={className}>
+      <svg
+        viewBox={`0 0 ${MAP_W} ${MAP_H}`}
+        className="w-full h-auto rounded-md border border-border bg-muted/30"
+        role="img"
+        aria-label={`Position du robot : x=${position.x.toFixed(2)}m, y=${position.y.toFixed(2)}m`}
+      >
+        {/* grille 1m */}
+        <defs>
+          <pattern
+            id="grid"
+            width={MAP_SCALE_PX_PER_M}
+            height={MAP_SCALE_PX_PER_M}
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d={`M ${MAP_SCALE_PX_PER_M} 0 L 0 0 0 ${MAP_SCALE_PX_PER_M}`}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="0.5"
+              opacity="0.15"
+            />
+          </pattern>
+        </defs>
+        <rect width={MAP_W} height={MAP_H} fill="url(#grid)" />
+
+        {/* axes : centre */}
+        <line x1={0} y1={MAP_H / 2} x2={MAP_W} y2={MAP_H / 2}
+              stroke="currentColor" strokeWidth="0.5" opacity="0.3" strokeDasharray="3 3" />
+        <line x1={MAP_W / 2} y1={0} x2={MAP_W / 2} y2={MAP_H}
+              stroke="currentColor" strokeWidth="0.5" opacity="0.3" strokeDasharray="3 3" />
+
+        {/* mission active : from/to */}
+        {active?.fromPoint && (
+          <g>
+            <circle cx={rx(0)} cy={ry(0)} r={8}
+                    fill="#3b82f6" opacity="0.8" />
+            <text x={rx(0) + 12} y={ry(0) + 4} fontSize="11" fill="currentColor"
+                  opacity="0.7" className="font-mono">
+              {active.fromPoint.name}
+            </text>
+          </g>
+        )}
+        {active?.toPoint && (
+          <g>
+            {/* note : sans coords reelles sur les Points, on ne peut placer
+                que des marqueurs symboliques. A enrichir quand Point.x/y
+                sont reflectes dans la response API. */}
+          </g>
+        )}
+
+        {/* fleche heading */}
+        <line
+          x1={rx(position.x)}
+          y1={ry(position.y)}
+          x2={headX}
+          y2={headY}
+          stroke={robotColor}
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+
+        {/* robot */}
+        <circle
+          cx={rx(position.x)}
+          cy={ry(position.y)}
+          r={ROBOT_RADIUS}
+          fill={robotColor}
+          opacity={status === 'OFFLINE' ? 0.4 : 1}
+        />
+        <circle
+          cx={rx(position.x)}
+          cy={ry(position.y)}
+          r={ROBOT_RADIUS}
+          fill="none"
+          stroke="white"
+          strokeWidth="2"
+        />
+
+        {/* coordonnees en bas de carte */}
+        <text x={10} y={MAP_H - 10} fontSize="11" fill="currentColor"
+              opacity="0.6" className="font-mono">
+          x = {position.x.toFixed(2)} m   y = {position.y.toFixed(2)} m   θ = {(position.heading * 180 / Math.PI).toFixed(0)}°
+        </text>
+      </svg>
+    </div>
+  )
+}

--- a/web/frontend/src/components/StopButton.tsx
+++ b/web/frontend/src/components/StopButton.tsx
@@ -1,16 +1,59 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
 import { useRobotStore } from '../stores/robotStore'
+import { useMissionStore } from '../stores/missionStore'
+import { apiFetch } from '../lib/api'
 import { Square } from 'lucide-react'
 
 interface Props {
   compact?: boolean
 }
 
-export function StopButton({ compact = false }: Props) {
-  const { status, setStatus } = useRobotStore()
-  const isActive = status !== 'OFFLINE'
+const ACTIVE_MISSION_STATUSES = new Set([
+  'PENDING',
+  'PAUSED',
+  'NAVIGATING_TO_PICKUP',
+  'WAITING_FOR_LOAD',
+  'NAVIGATING_TO_DESTINATION',
+  'DETECTING_OBJECT',
+  'GRASPING',
+  'TRANSPORTING',
+  'DEPOSITING',
+])
 
-  function handleStop() {
-    if (isActive) setStatus('OFFLINE')
+export function StopButton({ compact = false }: Props) {
+  const status = useRobotStore((s) => s.status)
+  const missions = useMissionStore((s) => s.missions)
+  const fetchMissions = useMissionStore((s) => s.fetchMissions)
+  const [pending, setPending] = useState(false)
+  const isActive = status !== 'OFFLINE' && !pending
+
+  async function handleStop() {
+    if (!isActive) return
+    const active = missions.find((m) => ACTIVE_MISSION_STATUSES.has(m.status))
+    if (!active) {
+      toast.info('Aucune mission active à arrêter')
+      return
+    }
+    if (!window.confirm('Confirmer l\'arrêt d\'urgence du robot ?')) return
+    setPending(true)
+    try {
+      const res = await apiFetch(`/missions/${active.id}/stop`, {
+        method: 'POST',
+        body: JSON.stringify({ reason: 'user-pressed-stop' }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Erreur inconnue' }))
+        toast.error(`Échec STOP : ${err.error ?? res.statusText}`)
+        return
+      }
+      toast.warning(`Mission #${active.id} stoppée`)
+      void fetchMissions()
+    } catch (e) {
+      toast.error(`Erreur réseau : ${e instanceof Error ? e.message : 'inconnue'}`)
+    } finally {
+      setPending(false)
+    }
   }
 
   if (compact) {

--- a/web/frontend/src/hooks/useWebSocket.ts
+++ b/web/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useAuthStore } from '@/stores/authStore'
+import { wsClient } from '@/services/websocket'
+
+// Bootstrap du client WS singleton : connecte au mount si on a un token,
+// disconnect a l'unmount ou au logout. A monter UNE SEULE FOIS (App.tsx).
+export function useWebSocket() {
+  const token = useAuthStore((s) => s.token)
+  useEffect(() => {
+    if (!token) return
+    wsClient.connect(token)
+    return () => wsClient.disconnect()
+  }, [token])
+}

--- a/web/frontend/src/pages/DashboardPage.tsx
+++ b/web/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useRobotStore, type RobotStatus } from '../stores/robotStore'
 import { useMissionStore } from '../stores/missionStore'
 import { useAuthStore } from '../stores/authStore'
 import { StatusBadge } from '../components/StatusBadge'
+import { RobotMap } from '../components/RobotMap'
 import {
   ArrowRight,
   Battery,
@@ -192,6 +193,14 @@ export function DashboardPage() {
                 unit="°"
                 faded={!connected}
               />
+            </div>
+
+            {/* Carte 2D — position live du robot */}
+            <div className="mt-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-muted-foreground mb-2">
+                · Carte position
+              </p>
+              <RobotMap />
             </div>
           </div>
         </section>

--- a/web/frontend/src/services/websocket.ts
+++ b/web/frontend/src/services/websocket.ts
@@ -1,0 +1,113 @@
+import { toast } from 'sonner'
+import { useRobotStore } from '@/stores/robotStore'
+import { useMissionStore } from '@/stores/missionStore'
+
+// Singleton client WebSocket. Une seule connexion pour toute l'app.
+// A demarrer apres login (App.tsx) via wsClient.connect(token).
+// Dispatche les events broadcast par le backend directement dans les stores
+// Zustand — les composants n'ont pas a y toucher.
+
+type WsEvent =
+  | { type: 'battery_update'; robotId: number; percent: number }
+  | { type: 'status_change'; robotId: number; status: string }
+  | { type: 'robot_online'; robotId: number }
+  | { type: 'robot_offline'; robotId: number }
+  | { type: 'position_update'; robotId: number; x: number; y: number; theta?: number }
+  | { type: 'mission_update'; missionId: number; status: string; progress?: number }
+  | { type: 'mission_completed'; missionId: number; result: string; reason?: string }
+
+class WsClient {
+  private ws: WebSocket | null = null
+  private token: string | null = null
+  private retryCount = 0
+  private cancelled = false
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
+
+  connect(token: string): void {
+    if (this.ws && this.token === token) return // deja connecte
+    this.disconnect()
+    this.token = token
+    this.cancelled = false
+    this.open()
+  }
+
+  disconnect(): void {
+    this.cancelled = true
+    if (this.retryTimer) clearTimeout(this.retryTimer)
+    this.ws?.close()
+    this.ws = null
+    this.token = null
+  }
+
+  private open(): void {
+    if (this.cancelled || !this.token) return
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${proto}//${window.location.host}/ws?token=${encodeURIComponent(this.token)}`
+    const ws = new WebSocket(url)
+    this.ws = ws
+
+    ws.onopen = () => {
+      this.retryCount = 0
+      useRobotStore.getState().setConnected(true)
+    }
+
+    ws.onclose = () => {
+      useRobotStore.getState().setConnected(false)
+      if (this.cancelled) return
+      // backoff exponentiel : 1, 2, 4, 8... cap a 30s
+      const delay = Math.min(30000, 1000 * 2 ** this.retryCount)
+      this.retryCount++
+      this.retryTimer = setTimeout(() => this.open(), delay)
+    }
+
+    ws.onerror = () => {
+      // close suivra et declenchera retry
+    }
+
+    ws.onmessage = (msgEvent) => {
+      let evt: WsEvent
+      try {
+        evt = JSON.parse(msgEvent.data)
+      } catch {
+        return
+      }
+      this.dispatch(evt)
+    }
+  }
+
+  private dispatch(evt: WsEvent): void {
+    const robot = useRobotStore.getState()
+    const missions = useMissionStore.getState()
+    switch (evt.type) {
+      case 'battery_update':
+        robot.setBatteryLevel(evt.percent)
+        break
+      case 'status_change':
+        robot.setStatus(evt.status as 'AVAILABLE' | 'BUSY' | 'OFFLINE' | 'ERROR')
+        break
+      case 'robot_online':
+        robot.setStatus('AVAILABLE')
+        toast.success('Robot en ligne')
+        break
+      case 'robot_offline':
+        robot.setStatus('OFFLINE')
+        toast.error('Robot déconnecté')
+        break
+      case 'position_update':
+        robot.setPosition({ x: evt.x, y: evt.y, heading: evt.theta ?? 0 })
+        break
+      case 'mission_update':
+        // refetch la liste — simple et suffisant (liste petite)
+        void missions.fetchMissions()
+        break
+      case 'mission_completed':
+        void missions.fetchMissions()
+        if (evt.result === 'completed') toast.success(`Mission #${evt.missionId} terminée`)
+        else if (evt.result === 'failed') toast.error(`Mission #${evt.missionId} échouée : ${evt.reason ?? '—'}`)
+        else if (evt.result === 'cancelled') toast.warning(`Mission #${evt.missionId} annulée`)
+        break
+    }
+  }
+}
+
+export const wsClient = new WsClient()

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      '/ws': {
+        target: 'ws://localhost:3001',
+        ws: true,
+        changeOrigin: true,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
Closes #85, #87, #88.

## Ce qui change

- **`services/websocket.ts`** (nouveau) : singleton `wsClient` qui :
  - Connecte à `/ws?token=...` (JWT)
  - Auto-reconnect avec backoff exponentiel (1s, 2s, 4s, ..., cap 30s)
  - Dispatch des events backend directement dans les stores Zustand (robotStore.setStatus/setPosition/setBatteryLevel/setConnected + missionStore.fetchMissions)
- **`hooks/useWebSocket.ts`** (nouveau) : hook minimal qui boot le client au login, le ferme au logout. Monté UNE FOIS dans App.tsx.
- **`App.tsx`** : monte le hook + `<Toaster richColors />` (sonner).
- **`StopButton.tsx`** : maintenant fonctionnel — trouve la mission active, demande confirm, POST `/missions/:id/stop`, toast feedback.
- **`vite.config.ts`** : proxy `/ws` vers le backend (port 3001).
- **deps** : sonner (toasts).

## Events branchés

| Event WS | Store affecté | UI |
|---|---|---|
| `battery_update` | robotStore.batteryLevel | jauge live |
| `status_change` | robotStore.status | badge live |
| `robot_online/offline` | robotStore.status | + toast |
| `position_update` | robotStore.position | coordonnées live |
| `mission_update` | missionStore (refetch) | liste live |
| `mission_completed` | missionStore (refetch) | + toast (succès/échec/annulée) |

## Hors scope (PR séparée à venir)

- Composants UI live (jauge batterie visuelle, badge online, etc.) — la donnée arrive dans le store, on peut maintenant l'afficher
- Carte 2D (#86)