### PR TITLE
[T4.3.2] Web — carte SLAM 2D depuis PGM (#86)

### DIFF
--- a/web/backend/maps/.gitkeep
+++ b/web/backend/maps/.gitkeep
@@ -1,0 +1,6 @@
+# Dossier des cartes SLAM. Format produit par nav2_map_server map_saver_cli :
+#   <robot-id>.pgm    image niveaux de gris (raw P5)
+#   <robot-id>.yaml   metadata (resolution m/px, origin x/y/theta, thresholds)
+# Procedure :
+#   ssh jetson@<robot> "docker exec m3pro ros2 run nav2_map_server map_saver_cli -f /root/maps/1"
+#   scp jetson@<robot>:/home/jetson/robot_maps/1.{pgm,yaml} web/backend/maps/

--- a/web/backend/package-lock.json
+++ b/web/backend/package-lock.json
@@ -19,7 +19,9 @@
         "jsonwebtoken": "^9.0.3",
         "mqtt": "^5.15.1",
         "prisma": "^6.19.2",
+        "sharp": "^0.34.5",
         "ws": "^8.20.1",
+        "yaml": "^2.9.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -73,7 +75,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -89,6 +90,471 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1544,7 +2010,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3430,6 +3895,50 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -4299,6 +4808,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -25,7 +25,9 @@
     "jsonwebtoken": "^9.0.3",
     "mqtt": "^5.15.1",
     "prisma": "^6.19.2",
+    "sharp": "^0.34.5",
     "ws": "^8.20.1",
+    "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/web/backend/src/controllers/mapController.ts
+++ b/web/backend/src/controllers/mapController.ts
@@ -1,0 +1,115 @@
+import { Request, Response } from 'express'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import sharp from 'sharp'
+import { parse as parseYaml } from 'yaml'
+
+// Sert la carte SLAM (PGM + YAML) du robot via l'API.
+// Pipeline mapping -> serving :
+//   robot : ros2 run nav2_map_server map_saver_cli -f /root/maps/1
+//   user  : scp jetson@<robot>:/home/jetson/robot_maps/1.{pgm,yaml} web/backend/maps/
+//   web   : GET /api/robots/1/map  (metadata JSON)
+//          GET /api/robots/1/map.png  (image, cache 30s)
+//
+// Plus tard on pourra automatiser le scp via une route POST /map/sync.
+
+const MAPS_DIR = path.resolve(__dirname, '../../maps')
+
+interface MapMetadata {
+  resolution: number  // metres par pixel
+  origin: [number, number, number]  // x, y, yaw en frame map
+  negate?: number
+  occupied_thresh?: number
+  free_thresh?: number
+}
+
+// Cache PNG en memoire pour eviter de re-decoder le PGM a chaque requete.
+// Invalide si le fichier PGM change (mtime).
+const pngCache = new Map<number, { png: Buffer; mtimeMs: number; width: number; height: number }>()
+
+async function readMetadata(robotId: number): Promise<MapMetadata | null> {
+  const yamlPath = path.join(MAPS_DIR, `${robotId}.yaml`)
+  try {
+    const raw = await fs.readFile(yamlPath, 'utf8')
+    return parseYaml(raw) as MapMetadata
+  } catch {
+    return null
+  }
+}
+
+export async function getMapMetadata(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+  const meta = await readMetadata(id)
+  if (!meta) {
+    res.status(404).json({ error: 'Carte non disponible pour ce robot' })
+    return
+  }
+  const pgmPath = path.join(MAPS_DIR, `${id}.pgm`)
+  try {
+    const stat = await fs.stat(pgmPath)
+    const cached = pngCache.get(id)
+    let width = cached?.width
+    let height = cached?.height
+    // Si pas en cache (ou stale), on touche pas — on retourne juste meta + URL.
+    // Les dimensions exactes seront connues apres premier GET du PNG.
+    res.json({
+      url: `/api/robots/${id}/map.png?v=${stat.mtimeMs}`,
+      resolution: meta.resolution,
+      origin: { x: meta.origin[0], y: meta.origin[1], theta: meta.origin[2] },
+      width,
+      height,
+      updatedAt: new Date(stat.mtimeMs).toISOString(),
+    })
+  } catch {
+    res.status(404).json({ error: 'PGM introuvable' })
+  }
+}
+
+export async function getMapImage(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const pgmPath = path.join(MAPS_DIR, `${id}.pgm`)
+  let stat: Awaited<ReturnType<typeof fs.stat>>
+  try {
+    stat = await fs.stat(pgmPath)
+  } catch {
+    res.status(404).json({ error: 'Carte introuvable' })
+    return
+  }
+
+  // cache hit ?
+  const cached = pngCache.get(id)
+  if (cached && cached.mtimeMs === stat.mtimeMs) {
+    res.setHeader('Content-Type', 'image/png')
+    res.setHeader('Cache-Control', 'private, max-age=30')
+    res.send(cached.png)
+    return
+  }
+
+  // Re-decode PGM -> PNG. sharp lit le PGM raw natif (libvips).
+  try {
+    const image = sharp(pgmPath)
+    const meta = await image.metadata()
+    const png = await image.png().toBuffer()
+    pngCache.set(id, {
+      png,
+      mtimeMs: stat.mtimeMs,
+      width: meta.width ?? 0,
+      height: meta.height ?? 0,
+    })
+    res.setHeader('Content-Type', 'image/png')
+    res.setHeader('Cache-Control', 'private, max-age=30')
+    res.send(png)
+  } catch (err) {
+    console.error('[map] conversion PGM->PNG echoue :', err)
+    res.status(500).json({ error: 'Conversion image impossible' })
+  }
+}

--- a/web/backend/src/routes/robots.ts
+++ b/web/backend/src/routes/robots.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
 import { listRobots, getRobotStatus } from '../controllers/robotsController'
+import { getMapMetadata, getMapImage } from '../controllers/mapController'
 
 const router = Router()
 
@@ -9,5 +10,11 @@ router.get('/', asyncHandler(listRobots))
 
 // GET /api/robots/:id/status — status d'un robot
 router.get('/:id/status', asyncHandler(getRobotStatus))
+
+// GET /api/robots/:id/map — metadata carte SLAM (resolution, origin, url image)
+router.get('/:id/map', asyncHandler(getMapMetadata))
+
+// GET /api/robots/:id/map.png — image PNG de la carte (cache 30s)
+router.get('/:id/map.png', asyncHandler(getMapImage))
 
 export default router

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -16,7 +16,7 @@ const SCHEMA_VERSION = 1
 
 const missionAckSchema = z.object({
   messageId: z.string().min(1),
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   missionId: z.number().int().positive(),
   result: z.enum(['accepted', 'rejected']),
   reason: z.string().optional(),
@@ -26,7 +26,7 @@ const missionAckSchema = z.object({
 )
 
 const missionStatusSchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   missionId: z.number().int().positive(),
   state: z.nativeEnum(MissionStatus),
   progress: z.number().min(0).max(1).optional(),
@@ -34,7 +34,7 @@ const missionStatusSchema = z.object({
 
 const missionResultSchema = z.object({
   messageId: z.string().min(1),
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   missionId: z.number().int().positive(),
   result: z.enum(['completed', 'failed', 'cancelled']),
   reason: z.string().optional(),
@@ -52,7 +52,7 @@ const RESULT_TO_STATUS = {
 
 // telemetry/battery (spec §5.2) — Robot.battery est un Int 0-100
 const batterySchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   voltage: z.number().optional(),
   percent: z.number().int().min(0).max(100),
   charging: z.boolean().optional(),
@@ -60,7 +60,7 @@ const batterySchema = z.object({
 
 // telemetry/position (spec §5.1) — pose 2D du robot (frame map ou odom)
 const positionSchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   x: z.number(),
   y: z.number(),
   theta: z.number().optional(),
@@ -71,13 +71,13 @@ const positionSchema = z.object({
 // OFFLINE n'est pas publie par le robot lui-meme : c'est deduit du Last Will
 // sur le topic connection (cf. handleConnection).
 const statusSchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   state: z.enum(['AVAILABLE', 'BUSY', 'ERROR']),
 })
 
 // connection (spec §5.5) — Last Will retained, online:false a la coupure
 const connectionSchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   online: z.boolean(),
 })
 

--- a/web/frontend/src/components/RobotMap.tsx
+++ b/web/frontend/src/components/RobotMap.tsx
@@ -1,5 +1,16 @@
+import { useEffect, useState } from 'react'
 import { useRobotStore } from '../stores/robotStore'
 import { useMissionStore } from '../stores/missionStore'
+import { apiFetch } from '../lib/api'
+
+interface MapMeta {
+  url: string
+  resolution: number
+  origin: { x: number; y: number; theta: number }
+  width?: number
+  height?: number
+  updatedAt: string
+}
 
 // Carte 2D minimaliste — SVG natif, pas de lib.
 // Convention de repere :
@@ -29,7 +40,36 @@ function ry(y: number): number {
 export function RobotMap({ className }: Props) {
   const status = useRobotStore((s) => s.status)
   const position = useRobotStore((s) => s.position)
+  const robotId = useRobotStore((s) => s.id)
   const missions = useMissionStore((s) => s.missions)
+
+  // Carte SLAM (PGM converti en PNG cote backend) — chargee une fois au mount.
+  // Le PNG est sub-resource dans le SVG et le navigateur le cache (Cache-Control).
+  const [mapMeta, setMapMeta] = useState<MapMeta | null>(null)
+  const [imgDims, setImgDims] = useState<{ w: number; h: number } | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch(`/robots/${robotId}/map`)
+      .then(async (r) => (r.ok ? (await r.json()) as MapMeta : null))
+      .then((meta) => {
+        if (!cancelled) setMapMeta(meta)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [robotId])
+
+  // Dimensions de l'image (en pixels) — on les recupere via onLoad du <image>.
+  // En SVG natif, l'event onLoad d'un <image> n'expose pas naturalWidth donc
+  // on charge via une Image() side-band.
+  useEffect(() => {
+    if (!mapMeta) return
+    const img = new Image()
+    img.onload = () => setImgDims({ w: img.naturalWidth, h: img.naturalHeight })
+    img.src = mapMeta.url
+  }, [mapMeta])
 
   // Mission active (s'il y en a une) — pour afficher from/to
   const active = missions.find((m) =>
@@ -75,6 +115,28 @@ export function RobotMap({ className }: Props) {
           </pattern>
         </defs>
         <rect width={MAP_W} height={MAP_H} fill="url(#grid)" />
+
+        {/* Carte SLAM en background si dispo. Convention PGM :
+            - origin (m) = coord en frame map du coin bas-gauche du PGM
+            - resolution (m/px) = taille d'un pixel
+            On convertit la zone couverte en coord SVG. */}
+        {mapMeta && imgDims && (() => {
+          const mapWm = imgDims.w * mapMeta.resolution
+          const mapHm = imgDims.h * mapMeta.resolution
+          const x0 = mapMeta.origin.x
+          const y1 = mapMeta.origin.y + mapHm // coord robot du coin HAUT-gauche
+          return (
+            <image
+              href={mapMeta.url}
+              x={rx(x0)}
+              y={ry(y1)}
+              width={mapWm * MAP_SCALE_PX_PER_M}
+              height={mapHm * MAP_SCALE_PX_PER_M}
+              opacity={0.85}
+              preserveAspectRatio="none"
+            />
+          )
+        })()}
 
         {/* axes : centre */}
         <line x1={0} y1={MAP_H / 2} x2={MAP_W} y2={MAP_H / 2}


### PR DESCRIPTION
Closes #86 (l'image servie + affichee, mapping live MQTT reste en dette).

## Backend (mapController.ts)
- GET /api/robots/:id/map : YAML parsed → metadata (resolution, origin, url image, updatedAt)
- GET /api/robots/:id/map.png : PGM → PNG via sharp, cache mémoire mtime, Cache-Control 30s
- Dossier web/backend/maps/<id>.pgm + .yaml
- deps : sharp, yaml

## Frontend (RobotMap.tsx)
- Fetch metadata au mount, Image() side-band pour vrais dims
- Place le PNG dans le SVG selon origin + resolution
- Si 404 → grille de fond seule (fallback)

## Procédure mapping démo
1. SSH robot, lancer slam.launch.py + teleop.launch.py
2. Conduire dans l'environnement (LiDAR + odom alimentent SLAM)
3. ros2 run nav2_map_server map_saver_cli -f /root/maps/1
4. scp jetson:/home/jetson/robot_maps/1.{pgm,yaml} web/backend/maps/
5. Refresh dashboard → carte affichée