### PR TITLE
fix(robot/nav): email maintainer Cloudflare obfusqué (bloquait catkin_pkg + hooks ament)

### DIFF
--- a/robot/roblaude_nav/package.xml
+++ b/robot/roblaude_nav/package.xml
@@ -9,7 +9,7 @@
     cartographie SLAM Toolbox, la navigation Nav2, et les outils de
     visualisation (Foxglove, web_video_server).
   </description>
-  <maintainer email="[email protected]">Wissem</maintainer>
+  <maintainer email="wissemkarboub@gmail.com">Wissem</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_python</buildtool_depend>

--- a/robot/roblaude_nav/setup.py
+++ b/robot/roblaude_nav/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=['setuptools'],
     zip_safe=True,
     maintainer='Wissem',
-    maintainer_email='[email protected]',
+    maintainer_email='wissemkarboub@gmail.com',
     description='Navigation autonome RobLaude — SLAM + Nav2 pour le ROSMASTER M3 PRO',
     license='MIT',
     tests_require=['pytest'],


### PR DESCRIPTION
Même bug que dans roblaude_mqtt (déjà fixé dans #209) — `roblaude_nav/package.xml` avait `[email protected]` (obfuscation Cloudflare via copier-coller depuis une doc web). catkin_pkg le détectait comme email invalide, traitait partiellement le package, et **les hooks ament_prefix_path.{sh,dsv,ps1} n'étaient pas générés**.

Conséquence : `ros2 pkg list` ne voyait pas `roblaude_nav` malgré l'install réussi → `ros2 run roblaude_nav mission_executor` retournait `Package not found`.

## Validé après deploy + rebuild

```
ros2 pkg list | grep roblaude
roblaude_mqtt
roblaude_nav   ← maintenant présent

ls install/roblaude_nav/share/roblaude_nav/hook/
ament_prefix_path.dsv   ← maintenant présent
ament_prefix_path.ps1
ament_prefix_path.sh
pythonpath.dsv
pythonpath.ps1
pythonpath.sh

ros2 run roblaude_nav mission_executor
[INFO] mission_executor pret — attend cmd/* via MQTT bridge
```

Fix : 2 caractères × 2 fichiers (package.xml + setup.py).