### PR TITLE
fix: review Copilot Sprint 4 — payload MQTT, types WS, broadcast, ACL

### DIFF
--- a/infra/mosquitto/README.md
+++ b/infra/mosquitto/README.md
@@ -12,11 +12,11 @@ touch infra/mosquitto/passwd
 
 # Backend — broker
 docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
-    mosquitto_passwd -b /m/passwd backend backend-CHANGE-ME
+    mosquitto_passwd -b -H sha512 /m/passwd backend backend-CHANGE-ME
 
 # Robot 1 — broker
 docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
-    mosquitto_passwd -b /m/passwd robot-1 robot1-CHANGE-ME
+    mosquitto_passwd -b -H sha512 /m/passwd robot-1 robot1-CHANGE-ME
 ```
 
 Remplacer `*-CHANGE-ME` par des mots de passe forts. Reporter ces
@@ -39,7 +39,7 @@ Pour chaque nouveau robot, créer un user dédié et étendre l'ACL :
 
 ```bash
 docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
-    mosquitto_passwd -b /m/passwd robot-2 robot2-pwd
+    mosquitto_passwd -b -H sha512 /m/passwd robot-2 robot2-pwd
 ```
 
 Puis ajouter dans `infra/mosquitto/acl` :

--- a/infra/mosquitto/acl
+++ b/infra/mosquitto/acl
@@ -10,12 +10,11 @@ topic readwrite roblaude/#
 
 # Robot 1 — modele a dupliquer pour chaque robot ajoute
 user robot-1
-# Le robot publie sa telemetrie et son etat
+# Le robot publie sa telemetrie, son etat, sa presence, et toutes les
+# reponses mission (ack/status/result + futurs sous-topics) — spec §7
 topic write roblaude/1/telemetry/#
 topic write roblaude/1/status
 topic write roblaude/1/connection
-topic write roblaude/1/mission/ack
-topic write roblaude/1/mission/status
-topic write roblaude/1/mission/result
+topic write roblaude/1/mission/#
 # Le robot lit les commandes du backend
 topic read roblaude/1/cmd/#

--- a/infra/mosquitto/mosquitto.conf
+++ b/infra/mosquitto/mosquitto.conf
@@ -1,7 +1,8 @@
 listener 1883
 
 # Authentification obligatoire (T4.4.1 — fini les connexions anonymes)
-# Le fichier passwd contient des hash bcrypt generes par mosquitto_passwd.
+# Le fichier passwd contient des hashes generes par mosquitto_passwd (sha512
+# pbkdf2 par defaut sur mosquitto v2).
 # Genere localement (jamais commit) — voir infra/mosquitto/README.md.
 allow_anonymous false
 password_file /mosquitto/config/passwd

--- a/infra/mosquitto/passwd.example
+++ b/infra/mosquitto/passwd.example
@@ -1,14 +1,15 @@
-# Format Mosquitto passwd (apres `mosquitto_passwd -U`) : user:hash_bcrypt
-# Genere avec :
+# Format Mosquitto passwd : user:hash_pbkdf2_sha512
+# Generation locale (jamais commit le vrai fichier passwd) :
 #   touch infra/mosquitto/passwd
 #   docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
-#       mosquitto_passwd -b /m/passwd backend backend-CHANGE-ME
+#       mosquitto_passwd -b -H sha512 /m/passwd backend backend-CHANGE-ME
 #   docker run --rm -v $(pwd)/infra/mosquitto:/m eclipse-mosquitto:2 \
-#       mosquitto_passwd -b /m/passwd robot-1 robot1-CHANGE-ME
+#       mosquitto_passwd -b -H sha512 /m/passwd robot-1 robot1-CHANGE-ME
 #
-# Le fichier passwd reel est gitignored. Ne commit JAMAIS les vrais hashes
-# ni les mots de passe en clair.
+# Format reel d'une ligne (mosquitto v2 sha512-pbkdf2) :
+#   <user>:$7$<iterations>$<base64-salt>$<base64-hash>
+# Le fichier passwd reel est gitignored (.gitignore l'exclut).
 
-# Exemple de structure (hashes factices) :
-backend:$7$101$fakebackendhash$fakefakefakefake
-robot-1:$7$101$fakerobot1hash$fakefakefakefake
+# Squelette factice — ne PAS utiliser ces hashes, regenere-les localement :
+backend:$7$101$AAAAAAAAAAAAAAAA$BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+robot-1:$7$101$CCCCCCCCCCCCCCCC$DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD

--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -162,12 +162,15 @@ export async function createMission(req: Request, res: Response) {
 
   // T4.2.2 — publie cmd/mission au robot si un robotId est present. Sans
   // robotId, la mission reste PENDING ; un assignment ulterieur publiera.
+  // Payload conforme spec MQTT §5.1 (theta obligatoire dans les points,
+  // objectId nullable pour TRANSPORT).
   if (mission.robotId) {
     robotMqtt.publishCommand(mission.robotId, 'mission', {
       missionId: mission.id,
       type: mission.type,
-      fromPoint: { x: fromPoint.x, y: fromPoint.y, slug: fromPoint.slug },
-      toPoint: { x: toPoint.x, y: toPoint.y, slug: toPoint.slug },
+      fromPoint: { x: fromPoint.x, y: fromPoint.y, theta: fromPoint.theta, slug: fromPoint.slug },
+      toPoint: { x: toPoint.x, y: toPoint.y, theta: toPoint.theta, slug: toPoint.slug },
+      objectId: mission.objectId,
     })
   }
 
@@ -356,10 +359,9 @@ export async function stopMission(req: Request, res: Response) {
     return cancelled
   })
 
-  robotMqtt.publishCommand(mission.robotId, 'emergency-stop', {
-    missionId: id,
-    reason,
-  })
+  // emergency-stop est GLOBAL (spec §5.1 — pas de missionId, le robot arrete
+  // ce qu'il fait quoi qu'il arrive). On garde reason pour traçabilité.
+  robotMqtt.publishCommand(mission.robotId, 'emergency-stop', { reason })
 
   res.json({ data: updated })
 }

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -68,11 +68,12 @@ const positionSchema = z.object({
 })
 
 // status — le robot publie son etat applicatif (spec §5.3).
-// OFFLINE n'est pas publie par le robot lui-meme : c'est deduit du Last Will
-// sur le topic connection (cf. handleConnection).
+// On accepte tous les RobotStatus Prisma — y compris OFFLINE au cas ou le
+// robot voudrait l'annoncer explicitement (sinon c'est deduit du Last Will
+// sur connection, cf. handleConnection).
 const statusSchema = z.object({
   timestamp: z.string().datetime({ offset: true }),
-  state: z.enum(['AVAILABLE', 'BUSY', 'ERROR']),
+  state: z.nativeEnum(RobotStatus),
 })
 
 // connection (spec §5.5) — Last Will retained, online:false a la coupure
@@ -101,6 +102,11 @@ class RobotMqttAdapter {
   // Map<messageId, expireAt>. TTL pour eviter fuite memoire sur long uptime
   // (bug Copilot #218 — la demo soutenance tournera 8h).
   private seenMessageIds = new Map<string, number>()
+
+  /** Vide le cache d'idempotence — utile pour les tests. */
+  resetSeenMessageIds(): void {
+    this.seenMessageIds.clear()
+  }
 
   /** Purge les messageIds expires. Appele a chaque add. */
   private purgeExpiredMessageIds(now: number = Date.now()): void {
@@ -167,20 +173,31 @@ class RobotMqttAdapter {
    * Backend -> Robot. Publie sur roblaude/{robotId}/cmd/{action} en QoS 2.
    * L'enveloppe (schemaVersion, messageId, timestamp) est ajoutee ici.
    */
-  publishCommand(robotId: number, action: CmdAction, body: object): void {
-    if (!this.client) throw new Error('[mqtt] adaptateur non connecte')
-
+  publishCommand(robotId: number, action: CmdAction, body: object): boolean {
+    // Retourne true si le publish a ete envoye, false si pas connecte ou
+    // si une erreur survient. Le controller decide s'il rollback ou non
+    // (en pratique on ne rollback pas — on a deja committe en DB).
+    if (!this.client) {
+      console.warn('[mqtt] publishCommand : adaptateur non connecte')
+      return false
+    }
     const message = {
       schemaVersion: SCHEMA_VERSION,
       messageId: randomUUID(),
       timestamp: new Date().toISOString(),
       ...body,
     }
-    this.client.publish(
-      `roblaude/${robotId}/cmd/${action}`,
-      JSON.stringify(message),
-      { qos: 2, retain: false },
-    )
+    try {
+      this.client.publish(
+        `roblaude/${robotId}/cmd/${action}`,
+        JSON.stringify(message),
+        { qos: 2, retain: false },
+      )
+      return true
+    } catch (err) {
+      console.error('[mqtt] publishCommand erreur :', err instanceof Error ? err.message : err)
+      return false
+    }
   }
 
   /** Robot -> Backend. Parse l'enveloppe puis route vers le bon traitement. */

--- a/web/backend/src/services/websocket.ts
+++ b/web/backend/src/services/websocket.ts
@@ -1,6 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws'
 import type { Server as HttpServer, IncomingMessage } from 'node:http'
 import jwt from 'jsonwebtoken'
+import { MissionStatus, RobotStatus } from '@prisma/client'
 import { getJwtSecret } from '../middleware/auth'
 
 // Service relay : MQTT/Prisma -> WebSocket -> clients frontend.
@@ -8,14 +9,16 @@ import { getJwtSecret } from '../middleware/auth'
 // Auth : JWT en query param `?token=...` (impossible de mettre un header
 // custom dans le constructeur WebSocket cote navigateur).
 
+// Types stricts : on s'aligne sur les enums Prisma pour eviter qu'un broadcast
+// erronne (ex. status_change avec status='WUT') corrompe le store frontend.
 export type WsEvent =
   | { type: 'battery_update'; robotId: number; percent: number }
-  | { type: 'status_change'; robotId: number; status: string }
+  | { type: 'status_change'; robotId: number; status: RobotStatus }
   | { type: 'robot_online'; robotId: number }
   | { type: 'robot_offline'; robotId: number }
   | { type: 'position_update'; robotId: number; x: number; y: number; theta?: number }
-  | { type: 'mission_update'; missionId: number; status: string; progress?: number }
-  | { type: 'mission_completed'; missionId: number; result: string; reason?: string }
+  | { type: 'mission_update'; missionId: number; status: MissionStatus; progress?: number }
+  | { type: 'mission_completed'; missionId: number; result: 'completed' | 'failed' | 'cancelled'; reason?: string }
   | { type: 'map_update'; robotId: number; mapData: string }
 
 class WebSocketRelay {
@@ -29,10 +32,14 @@ class WebSocketRelay {
     this.wss = new WebSocketServer({ noServer: true })
 
     httpServer.on('upgrade', (req, socket, head) => {
-      if (!req.url || !req.url.startsWith('/ws')) return socket.destroy()
-
-      // Auth JWT obligatoire en query param
+      // Match strict /ws (pas /wsfoo) — pathname exact
+      if (!req.url) return socket.destroy()
       const url = new URL(req.url, `http://${req.headers.host}`)
+      if (url.pathname !== '/ws') return socket.destroy()
+
+      // Auth JWT en query param (limitation browser : pas de header
+      // custom au moment de l'open WS). Connu : le token peut apparaitre
+      // dans des logs reverse-proxy — durcir TLS + log filtering en prod.
       const token = url.searchParams.get('token')
       if (!token) {
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
@@ -64,13 +71,25 @@ class WebSocketRelay {
     console.log('[ws] WebSocket relay attache sur /ws')
   }
 
-  /** Diffuse un evenement a tous les clients connectes (qui sont OPEN). */
+  /** Diffuse un evenement a tous les clients connectes (qui sont OPEN).
+   * Nettoie automatiquement les sockets KO/closed pour eviter une fuite. */
   broadcast(event: WsEvent): void {
     if (!this.wss) return
     const payload = JSON.stringify(event)
+    const dead: WebSocket[] = []
     for (const ws of this.clients) {
-      if (ws.readyState === WebSocket.OPEN) ws.send(payload)
+      if (ws.readyState !== WebSocket.OPEN) {
+        dead.push(ws)
+        continue
+      }
+      try {
+        ws.send(payload)
+      } catch (err) {
+        console.warn('[ws] send echoue, drop client :', err instanceof Error ? err.message : err)
+        dead.push(ws)
+      }
     }
+    for (const ws of dead) this.clients.delete(ws)
   }
 
   /** Nombre de clients connectes — utile pour debug et metrics. */

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -50,12 +50,11 @@ describe('RobotMqttAdapter — transport', () => {
   beforeEach(() => {
     fakeClient.publish.mockClear()
     fakeClient.subscribe.mockClear()
-    robotMqtt.disconnect()
+    robotMqtt.disconnect(); robotMqtt.resetSeenMessageIds()
   })
 
-  it('publishCommand throw si pas connecte', () => {
-    expect(() => robotMqtt.publishCommand(1, 'mission', { missionId: 42 }))
-      .toThrow(/non connecte/)
+  it('publishCommand retourne false si pas connecte', () => {
+    expect(robotMqtt.publishCommand(1, 'mission', { missionId: 42 })).toBe(false)
   })
 
   it('s abonne aux topics robot a la connexion', () => {
@@ -101,7 +100,7 @@ describe('RobotMqttAdapter — transport', () => {
 describe('RobotMqttAdapter — handlers mission/ack & mission/status', () => {
   beforeEach(() => {
     prismaMock.mission.update.mockClear()
-    robotMqtt.disconnect()
+    robotMqtt.disconnect(); robotMqtt.resetSeenMessageIds()
     robotMqtt.connect()
   })
 
@@ -216,7 +215,7 @@ describe('RobotMqttAdapter — handlers mission/result', () => {
     prismaMock.mission.update.mockClear()
     prismaMock.robot.update.mockClear()
     prismaMock.$transaction.mockClear()
-    robotMqtt.disconnect()
+    robotMqtt.disconnect(); robotMqtt.resetSeenMessageIds()
     robotMqtt.connect()
   })
 
@@ -323,7 +322,7 @@ describe('RobotMqttAdapter — handlers telemetry/battery, status, connection (T
   beforeEach(() => {
     prismaMock.robot.update.mockClear()
     prismaMock.robot.updateMany.mockClear()
-    robotMqtt.disconnect()
+    robotMqtt.disconnect(); robotMqtt.resetSeenMessageIds()
     robotMqtt.connect()
   })
 


### PR DESCRIPTION
Adresse les **15 remarques Copilot** des PRs #220 #221 #222 #223.

## Critiques (cassent le contrat MQTT)
- **`cmd/mission`** inclut `theta` dans Points + `objectId` (spec §5.1)
- **`cmd/emergency-stop`** : retire `missionId` (spec §5.1, arret global)
- **`statusSchema`** accepte tout `RobotStatus` Prisma (y compris OFFLINE)

## Sécurité / robustesse
- WS upgrade match strict `/ws` (plus de `/wsfoo` accepté)
- `broadcast()` gère erreurs `ws.send()` + drop sockets KO
- `publishCommand` retourne `boolean` au lieu de throw (controllers peuvent décider)
- `resetSeenMessageIds()` exposé pour les tests (évite état partagé)

## Types
- `WsEvent.status` typé `RobotStatus` (au lieu de `string`)
- `WsEvent.mission_update.status` typé `MissionStatus`
- `WsEvent.mission_completed.result` typé enum littéral

## Infra Mosquitto
- ACL : `mission/#` au lieu de `mission/ack|status|result` (spec §7)
- Commandes `mosquitto_passwd -H sha512` explicites
- `passwd.example` avec format réaliste (v2 pbkdf2 sha512)
- Commentaires mosquitto.conf corrigés (sha512, plus de `bcrypt` faux)

## Tests
- 27/27 passent (mqtt.test.ts)
- Test `publishCommand throw` adapté → `expect(false)`

## Reste en dette (issue à créer)
- JWT en query string : limitation browser, durcir via TLS + filtering proxy en prod
- Couplage `mqtt.ts → wsRelay` : refacto event emitter, sprint 5
- Tests vérifiant les WS broadcasts effectifs (vi.spy sur wsRelay)