### PR TITLE
fix(robot/nav): slam.launch.py pointe /scan_multi (au lieu de /scan_stamped sans publisher)

### DIFF
--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -36,7 +36,7 @@ def generate_launch_description():
                 'odom_frame': 'odom',
                 'base_frame': 'base_link',
                 'map_frame': 'map',
-                'scan_topic': '/scan_stamped',   # timestamps reparees par scan_restamper
+                'scan_topic': '/scan_multi',     # fusion /scan0+/scan1 par ira_laser_tools (lance par base_bringup)
                 'mode': 'mapping',               # 'mapping' ou 'localization'
                 'resolution': 0.05,              # 5 cm par pixel
                 'max_laser_range': 8.0,          # metres (YDLidar)


### PR DESCRIPTION
Fix du briefing du 21 mai : slam.launch.py utilisait /scan_stamped (notre topic scan_restamper) mais sur ce robot dual-LiDAR, le vrai topic est /scan_multi (fusion /scan0+/scan1 par ira_laser_tools de Yahboom). Sans ça, slam_toolbox subscribe mais 0 publisher → carte vide.