### PR TITLE
fix(explore): Humble compat (tf2_ros/*.h) + deploy auto-detect packages

### DIFF
--- a/robot/m-explore-ros2/explore/include/explore/costmap_client.h
+++ b/robot/m-explore-ros2/explore/include/explore/costmap_client.h
@@ -38,8 +38,8 @@
 #ifndef COSTMAP_CLIENT_
 #define COSTMAP_CLIENT_
 
-#include <tf2_ros/buffer.hpp>
-#include <tf2_ros/transform_listener.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>

--- a/robot/m-explore-ros2/explore/include/explore/explore.h
+++ b/robot/m-explore-ros2/explore/include/explore/explore.h
@@ -41,7 +41,7 @@
 #include <explore/costmap_client.h>
 #include <explore/frontier_search.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <tf2_ros/transform_listener.hpp>
+#include <tf2_ros/transform_listener.h>
 
 #include <chrono>
 #include <cmath>

--- a/robot/scripts/deploy_to_robot.sh
+++ b/robot/scripts/deploy_to_robot.sh
@@ -44,13 +44,22 @@ echo "━━━ Deploy RobLaude → $ROBOT_USER@$ROBOT_IP:$WS_HOST ━━━"
 $SSH "mkdir -p $WS_HOST/src $WS_HOST/scripts"
 
 # 2) Push des packages ROS (delete-after pour nettoyer fichiers supprimes)
+# Auto-detect : tout dossier dans robot/ qui contient un package.xml (a
+# n'importe quelle profondeur 1-2) OU qui est un workspace de packages.
 echo "▶ rsync packages..."
-for pkg in roblaude_nav roblaude_mqtt; do
-    if [ -d "$REPO_ROOT/robot/$pkg" ]; then
+for dir in "$REPO_ROOT"/robot/*/; do
+    name=$(basename "$dir")
+    [ "$name" = "scripts" ] && continue
+    [ "$name" = "_stub_local" ] && continue
+    # On rsync si le dossier contient un package.xml direct OU au moins
+    # un sous-dossier avec package.xml (workspace de packages — colcon
+    # explorera recursivement).
+    if [ -f "$dir/package.xml" ] || find "$dir" -maxdepth 2 -name 'package.xml' -print -quit | grep -q .; then
         rsync -avz --delete-after -e "$RSYNC_E" \
             --exclude '__pycache__' --exclude '*.pyc' --exclude '.pytest_cache' \
-            "$REPO_ROOT/robot/$pkg/" \
-            "$ROBOT_USER@$ROBOT_IP:$WS_HOST/src/$pkg/"
+            --exclude '.git' --exclude 'build' --exclude 'install' --exclude 'log' \
+            "$dir" \
+            "$ROBOT_USER@$ROBOT_IP:$WS_HOST/src/$name/"
     fi
 done
 


### PR DESCRIPTION
Suite de la PR #233.

## Bugs corrigés

- **m-explore-ros2** : les includes `<tf2_ros/buffer.hpp>` ne compilent pas sur Humble (le `.hpp` n'existe qu'à partir d'Iron/Jazzy). Patch sed sur `costmap_client.h` + `explore.h` → `tf2_ros/buffer.h`. `explore_lite` compile maintenant.

- **`deploy_to_robot.sh`** : la boucle hardcodait `roblaude_nav roblaude_mqtt` — ne syncait pas les nouveaux packages (m-explore-ros2). Auto-detection : tout dossier dans `robot/` contenant un `package.xml` (à profondeur 1 ou 2) est synchronisé.

## Validé sur robot

```
ros2 pkg list | grep -E roblaude\|explore
explore_lite
explore_lite_msgs
roblaude_mqtt
roblaude_nav
```