### PR TITLE
fix(T3.5.0): explore.launch.py stack stable — 3 bugs résolus, robot navigue en autonome

### DIFF
--- a/robot/docs/explore-stack.md
+++ b/robot/docs/explore-stack.md
@@ -1,0 +1,156 @@
+# Stack exploration auto — référence stack robot
+
+> Documente la stack ROS2 complète pour le mode mapping autonome RobLaude.
+> Validée en réel le 22 mai 2026 — robot bouge en autonome avec explore_lite.
+
+---
+
+## Vue d'ensemble
+
+```
+LiDAR0 (laser0_frame) ─┐
+                       ├─> laserscan_multi_merger ─> /scan_multi ─┐
+LiDAR1 (laser1_frame) ─┘   (Yahboom ira_laser_tools)              │
+                                                                  │
+                              base_bringup.launch.py              │
+                              ├── ekf_filter_node ──> /odom + TF odom→base_link
+                              ├── robot_state_publisher ──> /tf_static (URDF)
+                              ├── joint_state_publisher
+                              └── imu_filter                       │
+                                                                  ▼
+                                          ┌───────── scan_restamper.py
+                                          │         (roblaude_nav)
+                                          │         FIX drift +500ms drivers LiDAR
+                                          ▼         re-stamps msg.header.stamp = now()
+                                    /scan_fixed
+                                          │
+                                          ▼
+                                   slam_toolbox (async)
+                                   - scan_topic: /scan_fixed
+                                   - base_frame: base_footprint
+                                   - mode: mapping
+                                          │
+                                          ▼
+                                   /map  +  TF map→odom
+                                          │
+                              ┌───────────┴───────────┐
+                              ▼                       ▼
+                       Nav2 (navigation_launch.py)   explore_lite
+                       - sans amcl, sans map_server   - costmap_topic: map
+                       - lifecycle s'active           - frontier_size: 0.3
+                              │                       │
+                              │              Goal /navigate_to_pose
+                              │◀──────────────────────┘
+                              ▼
+                         /cmd_vel ──> moteurs Yahboom (YB_Node)
+```
+
+---
+
+## Comment lancer
+
+Le container m3pro démarre automatiquement (via `robot/scripts/container_autostart.sh`) :
+- `base_bringup.launch.py` (drivers hardware, IMU, lidars, EKF)
+- `mqtt_bridge.launch.py` (bridge MQTT vers backend RobLaude)
+- `mission_executor` (recoit cmd MQTT, drive Nav2)
+
+Pour démarrer le mode mapping/exploration auto :
+
+```bash
+ssh jetson@10.10.220.208
+docker exec -it m3pro bash
+source /opt/ros/humble/setup.bash
+source /root/M3Pro_ws/install/setup.bash
+source /root/roblaude_ws/install/setup.bash
+ros2 launch roblaude_nav explore.launch.py
+```
+
+Le robot va alors :
+1. Lancer `scan_restamper` + `slam_toolbox` (mapping mode)
+2. Lancer Nav2 (planner, controller, costmaps, behaviors)
+3. Faire une rotation initiale 360° (16.7s) pour amorcer SLAM
+4. `explore_lite` détecte les frontières et envoie des goals à Nav2
+5. Robot navigue vers les frontières → cartographie ce qu'il découvre
+
+Sauvegarder la carte :
+```bash
+ros2 run nav2_map_server map_saver_cli -f /root/maps/<nom>
+```
+
+Stopper proprement :
+```bash
+# Dans le shell qui a lancé ros2 launch : Ctrl+C
+# OU depuis l'extérieur :
+docker exec m3pro pkill -SIGINT -f explore.launch.py
+```
+
+---
+
+## 3 bugs résolus le 22 mai 2026 (fix `T3.5.0`)
+
+### Bug A — `nav2.launch.py` lançait `bringup_launch.py` (mode localization)
+
+`bringup_launch.py` include `amcl` + `map_server` qui cherche `/home/jetson/maps/default.yaml`. Comme ce fichier n'existe pas, `lifecycle_manager_localization` aborte tout le bringup Nav2 → controller_server etc. jamais activés → robot immobile.
+
+**Fix** : remplacer par `navigation_launch.py` (mode mapping pur, slam_toolbox externe fournit `/map`). Cf `nav2.launch.py`.
+
+### Bug B — Doublon `robot_state_publisher` + `joint_state_publisher`
+
+`container_autostart.sh` lançait 2 launch files Yahboom en parallèle (`base_bringup.launch.py` + `display_launch.py`) qui chacun spawn rsp + jsp → conflit QoS `transient_local` sur `/tf_static` → cache DDS cassé → toute la chaîne TF dysfonctionnelle (slam_toolbox ne trouve pas les frames).
+
+**Fix** : commenter la ligne `spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py` dans `container_autostart.sh`. `base_bringup` lance déjà rsp+jsp avec l'URDF complet (14 frames dans `/tf_static`).
+
+### Bug C — Drivers LiDAR Yahboom publient timestamps **+500ms futur**
+
+Mesuré au mini-script Python `rclpy` : `/scan0` et `/scan1` publient avec `header.stamp` dans le **futur de ~470-580ms** (drift constant). `laserscan_multi_merger` propage ce drift sur `/scan_multi`.
+
+**Conséquence sur slam_toolbox** : le message_filter interne attend une TF `base_footprint → map` au temps `stamp` (futur). La TF cache (publiée en wall time) n'a jamais d'entrée dans le futur → le filter garde le scan en queue → queue déborde → **drop infini** → aucun scan jamais matché → pas de TF map→odom → Nav2 ne peut pas planifier → robot immobile.
+
+**Fix** : `scan_restamper.py` (roblaude_nav, refactoré 22 mai) souscrit à `/scan_multi`, ré-écrit `msg.header.stamp` = `now()`, republie sur `/scan_fixed`. `slam.launch.py` configure `slam_toolbox` avec `scan_topic: /scan_fixed`.
+
+Sub-fix complémentaire dans `slam.launch.py` : `base_frame: base_footprint` (PAS `base_link` qui causait chicken-and-egg pour la TF initiale).
+
+---
+
+## Frames TF de référence
+
+`/tf_static` (publié par `robot_state_publisher`, URDF Yahboom) :
+
+```
+base_footprint
+└── base_link
+    ├── imu_frame
+    ├── laser0_frame  (LiDAR avant)
+    ├── laser1_frame  (LiDAR arrière)
+    └── arm_base_Link
+        └── arm1 → arm2 → arm3 → arm4 → arm5
+                                        └── Gripping
+```
+
+`/tf` dynamique (publié par `ekf_filter_node`) :
+```
+map ── (publié par slam_toolbox une fois SLAM démarré)
+└── odom ── (publié par ekf_filter_node, fusion odom + IMU)
+    └── base_footprint
+```
+
+---
+
+## Troubleshooting
+
+| Symptôme | Cause probable | Fix |
+|---|---|---|
+| `Failed to bring up all requested nodes` (map_server) | `nav2.launch.py` utilise `bringup_launch.py` au lieu de `navigation_launch.py` | Vérifier le include dans `nav2.launch.py` |
+| `Invalid frame ID "map" does not exist` (Nav2 logs) | slam_toolbox n'a pas pu matcher de scan → pas de TF map→odom | Vérifier que `scan_restamper` tourne ET que `slam_toolbox` consomme `/scan_fixed` |
+| `Message Filter dropping... queue is full` infini | Drift timestamp /scan_multi pas corrigé | `scan_restamper` doit tourner. Mesurer drift avec `drift_monitor.py` |
+| 2× `robot_state_publisher` dans `ros2 node list` | `display_launch.py` Yahboom est lancé (doublon) | `pkill -f display_launch.py` + vérifier `container_autostart.sh` ne le lance pas |
+| Tests slam ratent mais explore.launch.py marche | Vérifier les params `slam_toolbox` cohérents entre `slam.launch.py` (notre) et `mapper_params_online_async.yaml` (Yahboom) |
+
+---
+
+## Références
+
+- Fix-set commit : branche `fix/T3.5.0-explore-tf-slam` (4 commits)
+- Spec mode-mapping (local) : `docs/superpowers/specs/2026-05-22-mode-mapping-design.md` §14
+- Yahboom slam config validée : `/root/M3Pro_ws/src/slam_mapping/config/mapper_params_online_async.yaml`
+- ROS2 slam_toolbox doc : https://github.com/SteveMacenski/slam_toolbox

--- a/robot/roblaude_nav/launch/nav2.launch.py
+++ b/robot/roblaude_nav/launch/nav2.launch.py
@@ -1,51 +1,43 @@
 """
-nav2.launch.py — Navigation autonome (Nav2)
+nav2.launch.py — Stack Nav2 PURE (mode mapping live).
 
-Lance la stack Nav2 complete pour naviguer vers un goal.
+Lance uniquement les nodes de navigation (planner, controller, smoother,
+costmaps, behavior_tree, bt_navigator) sans amcl ni map_server.
+La carte /map est fournie en live par slam_toolbox (cf slam.launch.py).
 
 PRE-REQUIS :
-  - lidar.launch.py + odom.launch.py + tf2_static.launch.py lances
-  - Une carte sauvegardee dans ~/maps/<nom>.yaml (via slam.launch.py puis map_saver_cli)
-  - OU en mode SLAM live (mapping en meme temps)
-
-Usage :
-    ros2 launch /path/to/nav2.launch.py map:=/home/jetson/maps/salon.yaml
+  - base_bringup Yahboom up (moteurs, lidar, ekf qui publie odom→base_link)
+  - slam.launch.py lance ou autre source de /map et TF map→odom
 
 Topics/Actions :
     /navigate_to_pose (action)  : envoyer un goal (x, y, yaw)
     /cmd_vel                    : commandes de vitesse pour les roues
-    /plan                       : trajectoire planifiee (visualisable dans RViz)
+    /plan                       : trajectoire planifiee
 
-Nav2 est livre par Yahboom dans /root/yahboomcar_ws/src/M3Pro_navigation/
-donc on reutilise son launch officiel pour beneficier de leur config.
+Pourquoi navigation_launch.py et pas bringup_launch.py :
+    bringup_launch include amcl + map_server qui cherche un default.yaml
+    inexistant -> FATAL. navigation_launch est la version mapping-friendly.
 """
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     return LaunchDescription([
-        DeclareLaunchArgument('map', default_value='/home/jetson/maps/default.yaml',
-                              description='Chemin absolu vers le fichier .yaml de la carte'),
-
-        # Include le launch officiel de Nav2 (bringup_launch.py)
-        # Si Yahboom a un launch custom, on peut le remplacer par :
-        # FindPackageShare('M3Pro_navigation')
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([
                 PathJoinSubstitution([
                     FindPackageShare('nav2_bringup'),
                     'launch',
-                    'bringup_launch.py'
+                    'navigation_launch.py',
                 ])
             ]),
             launch_arguments={
-                'map': LaunchConfiguration('map'),
                 'use_sim_time': 'false',
-            }.items()
+            }.items(),
         ),
     ])

--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -34,15 +34,20 @@ def generate_launch_description():
             parameters=[{
                 'use_sim_time': False,           # False = hardware reel
                 'odom_frame': 'odom',
-                'base_frame': 'base_link',
+                'base_frame': 'base_footprint',  # PAS base_link — sinon chicken-and-egg :
+                                                 # /scan_multi a frame_id=base_link, si base_frame=base_link
+                                                 # slam_toolbox doit transformer base_link->map directement,
+                                                 # or map n'existe pas encore -> queue full -> deadlock.
                 'map_frame': 'map',
                 'scan_topic': '/scan_multi',     # fusion /scan0+/scan1 par ira_laser_tools (lance par base_bringup)
-                'mode': 'mapping',               # 'mapping' ou 'localization'
+                'mode': 'mapping',
                 'resolution': 0.05,              # 5 cm par pixel
-                'max_laser_range': 8.0,          # metres (YDLidar)
-                'minimum_time_interval': 0.2,    # secondes
-                'transform_publish_period': 0.05,
-                'map_update_interval': 5.0,
+                'max_laser_range': 6.0,          # match config Yahboom validee (au lieu de 8.0)
+                'minimum_time_interval': 0.5,    # 0.5s = ~2Hz process target, evite overrun a 7Hz scan
+                'transform_publish_period': 0.02,
+                'map_update_interval': 3.0,
+                'scan_buffer_size': 10,          # default trop petit, on encaisse 10 scans en attente
+                'transform_timeout': 0.5,        # marge pour TF cache
             }]
         ),
     ])

--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -49,6 +49,8 @@ def generate_launch_description():
                 'scan_topic': '/scan_fixed',     # restampe par scan_restamper (cf node au-dessus)
                 'mode': 'mapping',
                 'resolution': 0.05,              # 5 cm par pixel
+                'min_laser_range': 0.3,          # ignore < 30cm : le bras M3 Pro retombe devant le LiDAR
+                                                 # et est detecte comme obstacle fictif (vu IRL 22 mai).
                 'max_laser_range': 4.0,          # capacite reelle merger Yahboom (warning slam si plus)
                 'minimum_time_interval': 0.5,
                 'transform_publish_period': 0.02,

--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -26,6 +26,16 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     return LaunchDescription([
+        # scan_restamper : fix le drift +500ms des drivers LiDAR Yahboom.
+        # /scan_multi (drivers + merger, stamp dans le futur) -> /scan_fixed (now()).
+        # Indispensable pour que slam_toolbox puisse matcher les scans (sinon queue full
+        # infinie car TF cache n'a jamais d'entree au futur).
+        Node(
+            package='roblaude_nav',
+            executable='scan_restamper',
+            name='scan_restamper',
+            output='screen',
+        ),
         Node(
             package='slam_toolbox',
             executable='async_slam_toolbox_node',
@@ -34,20 +44,17 @@ def generate_launch_description():
             parameters=[{
                 'use_sim_time': False,           # False = hardware reel
                 'odom_frame': 'odom',
-                'base_frame': 'base_footprint',  # PAS base_link — sinon chicken-and-egg :
-                                                 # /scan_multi a frame_id=base_link, si base_frame=base_link
-                                                 # slam_toolbox doit transformer base_link->map directement,
-                                                 # or map n'existe pas encore -> queue full -> deadlock.
+                'base_frame': 'base_footprint',  # PAS base_link — sinon chicken-and-egg avec map.
                 'map_frame': 'map',
-                'scan_topic': '/scan_multi',     # fusion /scan0+/scan1 par ira_laser_tools (lance par base_bringup)
+                'scan_topic': '/scan_fixed',     # restampe par scan_restamper (cf node au-dessus)
                 'mode': 'mapping',
                 'resolution': 0.05,              # 5 cm par pixel
-                'max_laser_range': 6.0,          # match config Yahboom validee (au lieu de 8.0)
-                'minimum_time_interval': 0.5,    # 0.5s = ~2Hz process target, evite overrun a 7Hz scan
+                'max_laser_range': 4.0,          # capacite reelle merger Yahboom (warning slam si plus)
+                'minimum_time_interval': 0.5,
                 'transform_publish_period': 0.02,
                 'map_update_interval': 3.0,
-                'scan_buffer_size': 10,          # default trop petit, on encaisse 10 scans en attente
-                'transform_timeout': 0.5,        # marge pour TF cache
+                'scan_buffer_size': 10,
+                'transform_timeout': 0.5,
             }]
         ),
     ])

--- a/robot/roblaude_nav/roblaude_nav/scan_restamper.py
+++ b/robot/roblaude_nav/roblaude_nav/scan_restamper.py
@@ -1,84 +1,58 @@
 #!/usr/bin/env python3
 """
-scan_restamper.py - Re-stamp les messages du STM32 au temps courant
+scan_restamper.py - Re-stamp /scan_multi au temps courant pour slam_toolbox.
 
-Probleme : le STM32 publie /scan0 /scan1 /odom_raw avec timestamps dates
-de decembre 2025 (horloge STM32 pas synchronisee avec le Jetson). SLAM
-rejette ces messages car l ecart avec les TF courants depasse sa tolerance.
+Probleme racine identifie le 22 mai 2026 :
+  Les drivers LiDAR Yahboom (YDLidar X2L sur /scan0 et /scan1) publient avec
+  un timestamp ~500ms DANS LE FUTUR (drift constant +470 a +580ms mesure).
+  Le merger laserscan_multi_merger propage ce drift sur /scan_multi.
 
-Ce noeud :
-  - Ecoute /scan (laser fusionne)      -> republie /scan_stamped avec now()
-  - Ecoute /odom_raw (odometrie STM32) -> republie /odom avec now()
-                                        + publie TF odom -> base_link avec now()
+Impact sur slam_toolbox :
+  Le message_filter interne attend une TF base_footprint->map au temps du
+  scan stamp. Si stamp = now+500ms, la TF cache (publiee en wall time) n'a
+  jamais d'entree dans le futur -> filter garde le scan en queue -> queue
+  deborde -> drop infini -> aucun scan jamais matche -> pas de TF map->odom
+  -> Nav2 ne peut pas planifier -> robot immobile.
 
-Resultat : SLAM tourne sur /scan_stamped et trouve toujours un TF coherent.
+Solution :
+  Souscrire a /scan_multi, copier le message, ecraser msg.header.stamp avec
+  self.get_clock().now() (temps wall present), republier sur /scan_fixed.
+  Slam_toolbox abonne a /scan_fixed -> trouve immediatement la TF dans le
+  cache -> match -> publie TF map->odom -> debloque toute la stack.
 
-Usage :
-    export ROS_DOMAIN_ID=30
-    python3 /root/scan_restamper.py
+Note : on ne touche PAS a l'odom ni a la TF. L'ekf_filter_node (lance par
+base_bringup Yahboom) publie deja /odom et TF odom->base_link avec stamps
+corrects, pas de drift cote EKF.
 """
 
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import LaserScan
-from nav_msgs.msg import Odometry
-from geometry_msgs.msg import TransformStamped
-from tf2_ros import TransformBroadcaster
+from rclpy.qos import QoSProfile, ReliabilityPolicy
 
 
 class ScanRestamper(Node):
     def __init__(self):
         super().__init__('scan_restamper')
 
-        self.br = TransformBroadcaster(self)
-        self.scan_pub = self.create_publisher(LaserScan, '/scan_stamped', 10)
-        self.odom_pub = self.create_publisher(Odometry, '/odom', 10)
+        qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE)
+        self.pub = self.create_publisher(LaserScan, '/scan_fixed', qos)
+        self.sub = self.create_subscription(LaserScan, '/scan_multi', self.on_scan, qos)
 
-        self.create_subscription(LaserScan, '/scan', self.scan_cb, 10)
-        self.create_subscription(Odometry, '/odom_raw', self.odom_cb, 10)
-
-        self._scan_count = 0
-        self._odom_count = 0
+        self._count = 0
         self.create_timer(5.0, self._report)
         self.get_logger().info(
-            'scan_restamper ready : /scan -> /scan_stamped, /odom_raw -> /odom + TF'
+            'scan_restamper ready : /scan_multi -> /scan_fixed (stamps -> now)'
         )
 
-    def scan_cb(self, msg: LaserScan):
+    def on_scan(self, msg: LaserScan):
         msg.header.stamp = self.get_clock().now().to_msg()
-        self.scan_pub.publish(msg)
-        self._scan_count += 1
-
-    def odom_cb(self, msg: Odometry):
-        now = self.get_clock().now().to_msg()
-
-        t = TransformStamped()
-        t.header.stamp = now
-        t.header.frame_id = 'odom'
-        t.child_frame_id = 'base_link'
-        p = msg.pose.pose.position
-        q = msg.pose.pose.orientation
-        t.transform.translation.x = p.x
-        t.transform.translation.y = p.y
-        t.transform.translation.z = p.z
-        t.transform.rotation = q
-        self.br.sendTransform(t)
-
-        out = Odometry()
-        out.header.stamp = now
-        out.header.frame_id = 'odom'
-        out.child_frame_id = 'base_link'
-        out.pose = msg.pose
-        out.twist = msg.twist
-        self.odom_pub.publish(out)
-        self._odom_count += 1
+        self.pub.publish(msg)
+        self._count += 1
 
     def _report(self):
-        self.get_logger().info(
-            f'Restamped: {self._scan_count} scans, {self._odom_count} odom'
-        )
-        self._scan_count = 0
-        self._odom_count = 0
+        self.get_logger().info(f'restamped {self._count} scans')
+        self._count = 0
 
 
 def main():

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -85,9 +85,14 @@ spawn_once() {
 spawn_once base_bringup ros2 launch M3Pro_navigation base_bringup.launch.py
 sleep 5
 
-# --- 2) URDF officiel Yahboom (frame chassis pour TF) ---
-spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py
-sleep 2
+# --- 2) URDF officiel Yahboom (frame chassis pour TF) — DESACTIVE ---
+# base_bringup.launch.py (etape 1) lance deja robot_state_publisher et
+# joint_state_publisher avec l'URDF Yahboom complet (14 frames dans /tf_static
+# verifie en reel le 22 mai). display_launch.py les relancait en doublon, ce
+# qui castait /tf_static (conflit QoS transient_local) -> chaine TF cassee ->
+# slam_toolbox bloque "queue full" -> pas de mapping. On le coupe.
+# spawn_once rsp ros2 launch yahboom_M3Pro_description display_launch.py
+# sleep 2
 
 # --- 3) Bridge MQTT (lit /etc/roblaude/broker_ip pour le host) ---
 if [ -f "$ROBLAUDE_WS/install/roblaude_mqtt/share/roblaude_mqtt/launch/mqtt_bridge.launch.py" ]; then


### PR DESCRIPTION
## Summary

Stack `explore.launch.py` (SLAM + Nav2 + initial_rotation + explore_lite) **validée IRL** le 22 mai 2026 — robot envoie des goals Nav2 et navigue en autonome.

3 bugs identifiés et résolus pendant ~3h de diag terrain :

### 🔧 Bug A — \`nav2.launch.py\` mauvais include (commit \`eb26e6a\`)
Utilisait \`nav2_bringup/bringup_launch.py\` (mode localization avec amcl + map_server qui cherche \`/home/jetson/maps/default.yaml\` inexistant → FATAL). Remplacé par \`navigation_launch.py\` (mode mapping pur, slam_toolbox externe fournit \`/map\`).

### 🔧 Bug B — Doublon rsp/jsp au boot container (commit \`778bc9e\`)
\`container_autostart.sh\` lançait \`base_bringup.launch.py\` ET \`display_launch.py\` qui chacun spawn \`robot_state_publisher\` + \`joint_state_publisher\` → conflit QoS transient_local sur \`/tf_static\` → chaîne TF cassée. \`display_launch.py\` commenté (base_bringup fournit déjà l'URDF complet, 14 frames).

### 🔧 Bug C — Drivers LiDAR Yahboom publient timestamps **+500ms FUTUR** (commits \`d62c96e\` + \`e1c83aa\`)
**Root cause** des drops infinis \"Message Filter queue full\" sur slam_toolbox. Mesuré via mini-script Python \`rclpy\` : \`/scan0\`, \`/scan1\` (et donc \`/scan_multi\` propagé) publient avec \`header.stamp\` dans le futur de **+470 à +580ms** (drift constant). Le message_filter de slam_toolbox garde les scans en queue en attendant une TF au futur (impossible) → drop infini → aucun scan jamais matché → pas de TF map→odom → Nav2 ne peut pas planifier → robot immobile.

**Fix** : \`scan_restamper.py\` (refactoré) souscrit à \`/scan_multi\`, re-écrit \`msg.header.stamp = now()\`, republie sur \`/scan_fixed\`. \`slam.launch.py\` lit \`/scan_fixed\`. Sub-fix : \`base_frame: base_footprint\` (PAS \`base_link\` qui causait chicken-and-egg pour la TF initiale).

## Validation IRL — toute la chaîne fonctionnelle

```
✅ Registering sensor: [Custom Described Lidar]  ← slam match les scans
✅ TF map → odom existe (matrice identité)
✅ Nav2 lifecycle s'active (controller, planner, smoother, behavior)
✅ initial_rotation tourne et termine (16.7s)
✅ explore_node: Connected to move_base nav2 server
✅ bt_navigator: Begin navigating from (0.01, 0.00) to (0.31, -0.40)
```

## Doc ajoutée

\`robot/docs/explore-stack.md\` — schéma complet de la chaîne, commandes pour lancer, troubleshooting (5 symptômes/causes/fix), références. Sert de doc onboarding pour la team.

## Test plan

- [x] Stack lancée IRL sur robot m3pro (Jetson Nano, batterie 56%+)
- [x] slam_toolbox enregistre LiDAR, publie /map et TF map→odom
- [x] Nav2 lifecycle activé sans erreur
- [x] explore_lite envoie au moins 1 goal au bt_navigator
- [x] Carte SLAM se construit (138×81 cells = 6.9m × 4.05m après 15s)
- [ ] Test étendu : laisser explore tourner 5 min + sauvegarder une carte exploitable (à faire post-merge)