### PR TITLE
feat(T3.5.1): tables Prisma mapping (MappingSession, MapSnapshot, Annotation, SshAuditLog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,22 @@ jobs:
       run:
         working-directory: web/backend
     env:
-      DATABASE_URL: mysql://root:root@localhost:3306/roblaude
+      DATABASE_URL: mysql://root:root@127.0.0.1:3306/roblaude
       JWT_SECRET: ci-test-secret-pas-pour-la-prod
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: roblaude
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
 
     steps:
       - uses: actions/checkout@v4
@@ -54,5 +68,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      # cree les tables a partir du schema Prisma (test d'integration mapping-db)
+      - run: npx prisma db push --skip-generate
       - run: npm test -- --passWithNoTests
 

--- a/web/backend/prisma/schema.prisma
+++ b/web/backend/prisma/schema.prisma
@@ -15,6 +15,9 @@ model User {
   role      Role      @default(USER)
   createdAt DateTime  @default(now())
   missions  Mission[]
+  mappingSessions MappingSession[]
+  annotations     Annotation[]
+  sshAuditLogs    SshAuditLog[]
 }
 
 model Robot {
@@ -27,6 +30,9 @@ model Robot {
   battery   Int         @default(100)
   createdAt DateTime    @default(now())
   missions  Mission[]
+  mappingSessions MappingSession[]
+  mapSnapshots    MapSnapshot[]
+  sshAuditLogs    SshAuditLog[]
 }
 
 model Point {
@@ -102,4 +108,96 @@ enum RobotStatus {
   BUSY
   OFFLINE
   ERROR
+}
+
+enum MappingState {
+  STARTING
+  RUNNING
+  STOPPING
+  STOPPED
+  FAILED
+}
+
+enum SshMode {
+  ALLOWLIST
+  ELEVATED
+}
+
+model MappingSession {
+  id            Int             @id @default(autoincrement())
+  robotId       Int
+  robot         Robot           @relation(fields: [robotId], references: [id])
+  startedById   Int
+  startedBy     User            @relation(fields: [startedById], references: [id])
+  state         MappingState
+  failureReason String?
+  startedAt     DateTime        @default(now())
+  endedAt       DateTime?
+  coverageM2    Float?
+  durationSec   Int?
+  snapshots     MapSnapshot[]
+  annotations   Annotation[]
+
+  @@index([robotId, startedAt])
+}
+
+model MapSnapshot {
+  id           Int             @id @default(autoincrement())
+  sessionId    Int
+  session      MappingSession  @relation(fields: [sessionId], references: [id])
+  robotId      Int
+  robot        Robot           @relation(fields: [robotId], references: [id])
+  name         String
+  pgmPath      String
+  yamlPath     String
+  pngPath      String
+  widthPx      Int
+  heightPx     Int
+  resolutionM  Float
+  originX      Float
+  originY      Float
+  originTheta  Float
+  sizeBytes    Int
+  isCurrent    Boolean         @default(false)
+  createdAt    DateTime        @default(now())
+  annotations  Annotation[]
+
+  @@index([robotId, createdAt])
+  @@index([robotId, isCurrent])
+}
+
+model Annotation {
+  id            Int              @id @default(autoincrement())
+  mapSnapshotId Int
+  mapSnapshot   MapSnapshot      @relation(fields: [mapSnapshotId], references: [id])
+  sessionId     Int?
+  session       MappingSession?  @relation(fields: [sessionId], references: [id])
+  label         String
+  icon          String?
+  color         String           @default("#3b82f6")
+  x             Float
+  y             Float
+  createdById   Int
+  createdBy     User             @relation(fields: [createdById], references: [id])
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+
+  @@index([mapSnapshotId])
+}
+
+model SshAuditLog {
+  id         Int       @id @default(autoincrement())
+  robotId    Int
+  robot      Robot     @relation(fields: [robotId], references: [id])
+  userId     Int
+  user       User      @relation(fields: [userId], references: [id])
+  mode       SshMode
+  command    String    @db.Text
+  exitCode   Int?
+  durationMs Int?
+  ipAddr     String?
+  createdAt  DateTime  @default(now())
+
+  @@index([robotId, createdAt])
+  @@index([userId, createdAt])
 }

--- a/web/backend/src/test/mapping-db.test.ts
+++ b/web/backend/src/test/mapping-db.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PrismaClient, MappingState, SshMode, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+
+const prisma = new PrismaClient()
+
+let userId: number
+let robotId: number
+
+beforeAll(async () => {
+  const user = await prisma.user.create({
+    data: { email: `test-mapping-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'test', role: Role.ADMIN },
+  })
+  userId = user.id
+  const robot = await prisma.robot.create({ data: { name: `bot-${Date.now()}` } })
+  robotId = robot.id
+})
+
+afterAll(async () => {
+  await prisma.sshAuditLog.deleteMany({ where: { robotId } })
+  await prisma.annotation.deleteMany({ where: { mapSnapshot: { robotId } } })
+  await prisma.mapSnapshot.deleteMany({ where: { robotId } })
+  await prisma.mappingSession.deleteMany({ where: { robotId } })
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('Mapping DB schema', () => {
+  it('crée une MappingSession avec relation user et robot', async () => {
+    const s = await prisma.mappingSession.create({
+      data: { robotId, startedById: userId, state: MappingState.STARTING },
+      include: { robot: true, startedBy: true },
+    })
+    expect(s.id).toBeGreaterThan(0)
+    expect(s.robot.id).toBe(robotId)
+    expect(s.startedBy.id).toBe(userId)
+    expect(s.state).toBe(MappingState.STARTING)
+  })
+
+  it('crée un MapSnapshot lié à une session puis une Annotation lié au snapshot', async () => {
+    const session = await prisma.mappingSession.create({
+      data: { robotId, startedById: userId, state: MappingState.RUNNING },
+    })
+    const snap = await prisma.mapSnapshot.create({
+      data: {
+        sessionId: session.id, robotId, name: 'demo',
+        pgmPath: '/tmp/x.pgm', yamlPath: '/tmp/x.yaml', pngPath: '/tmp/x.png',
+        widthPx: 400, heightPx: 280, resolutionM: 0.05,
+        originX: -10, originY: -7, originTheta: 0, sizeBytes: 1024,
+      },
+    })
+    const a = await prisma.annotation.create({
+      data: { mapSnapshotId: snap.id, sessionId: session.id, label: 'bureau 201', x: 1.5, y: 2.0, createdById: userId },
+      include: { mapSnapshot: true, createdBy: true },
+    })
+    expect(a.mapSnapshot.id).toBe(snap.id)
+    expect(a.createdBy.id).toBe(userId)
+    expect(a.color).toBe('#3b82f6')
+  })
+
+  it('crée un SshAuditLog ALLOWLIST', async () => {
+    const log = await prisma.sshAuditLog.create({
+      data: { robotId, userId, mode: SshMode.ALLOWLIST, command: 'ros2 topic list', exitCode: 0, durationMs: 120 },
+    })
+    expect(log.id).toBeGreaterThan(0)
+    expect(log.mode).toBe(SshMode.ALLOWLIST)
+  })
+
+  it('back-relation : Robot.mappingSessions renvoie les sessions du robot', async () => {
+    const r = await prisma.robot.findUnique({ where: { id: robotId }, include: { mappingSessions: true } })
+    expect(r?.mappingSessions.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/web/backend/vitest.config.ts
+++ b/web/backend/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
     environment: 'node',
     // ne scanne que les sources — sinon vitest ramasse les .js compiles dans dist/
     include: ['src/**/*.test.ts'],
+    // dotenv/config charge .env avant les tests (sinon JWT_SECRET manque a l'import auth.ts)
+    setupFiles: ['dotenv/config'],
   },
 })


### PR DESCRIPTION
## Summary

Plan 1 / Vague 1 — fondation DB pour le mode mapping. 4 nouvelles tables + 2 enums + back-relations sur Robot et User. Indépendant du robot, prêt à être consommé par T3.5.5 (controllers REST) et T3.5.6 (annotations).

## Changes
- `prisma/schema.prisma` : +`MappingSession`, `MapSnapshot`, `Annotation`, `SshAuditLog` + enums `MappingState`, `SshMode`
- Back-relations sur `User` (mappingSessions, annotations, sshAuditLogs) et `Robot` (mappingSessions, mapSnapshots, sshAuditLogs)
- `vitest.config.ts` : ajout `setupFiles: ['dotenv/config']` pour que `.env` soit chargé en tests (sinon `JWT_SECRET` manque à l'import `app.ts`, casse 3 fichiers de tests existants)
- Nouveau `src/test/mapping-db.test.ts` : 4 tests d'intégration (CRUD + back-relation Robot.mappingSessions)

## Test plan

- [x] `npm test` : **54/54 tests verts** (avant : 31 verts + 3 fichiers cassés à cause de JWT_SECRET)
- [x] `npm run build` : pas d'erreur TypeScript
- [x] `npx prisma db push` : schéma appliqué sans erreur en DB locale MySQL
- [ ] Migration formelle `prisma migrate dev --name mapping_foundation` : bloquée par perm shadow DB sur le user MySQL local, sera générée par Maxime quand il aura accès root (ou on configure SHADOW_DATABASE_URL). Schema cohérent en attendant via db push.