### PR TITLE
refactor(T3.5.4): WsRouter + mqttEvents — découple mqtt.ts des relays

### DIFF
--- a/web/backend/src/index.ts
+++ b/web/backend/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import http from 'node:http'
 import { app } from './app'
 import { robotMqtt } from './services/mqtt'
+import { wsRouter } from './services/wsRouter'
 import { wsRelay } from './services/websocket'
 
 const PORT = process.env.PORT || 3001
@@ -9,7 +10,10 @@ const PORT = process.env.PORT || 3001
 // HTTP server explicite (createServer) pour pouvoir attacher le WS dessus
 // (upgrade handshake). app.listen ne donne pas acces au server.
 const server = http.createServer(app)
-wsRelay.attach(server)
+// wsRouter prend la main sur l'event 'upgrade' (un seul listener).
+// wsRelay s'enregistre comme handler du path /ws via wsRouter.
+wsRouter.attach(server)
+wsRelay.register()
 
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { MissionStatus, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
-import { wsRelay } from './websocket'
+import { mqttEvents } from './mqttEvents'
 
 // Adaptateur MQTT du backend — singleton.
 // Topics et formats : voir docs/mqtt-spec.md
@@ -252,8 +252,7 @@ class RobotMqttAdapter {
         where: { id: robotId },
         data: { battery: parsed.data.percent },
       })
-      wsRelay.broadcast({
-        type: 'battery_update',
+      mqttEvents.emit('battery_update', {
         robotId,
         percent: parsed.data.percent,
       })
@@ -280,8 +279,7 @@ class RobotMqttAdapter {
           heading: parsed.data.theta ?? null,
         },
       })
-      wsRelay.broadcast({
-        type: 'position_update',
+      mqttEvents.emit('position_update', {
         robotId,
         x: parsed.data.x,
         y: parsed.data.y,
@@ -306,8 +304,7 @@ class RobotMqttAdapter {
         where: { id: robotId },
         data: { status: parsed.data.state as RobotStatus },
       })
-      wsRelay.broadcast({
-        type: 'status_change',
+      mqttEvents.emit('status_change', {
         robotId,
         status: parsed.data.state,
       })
@@ -333,13 +330,13 @@ class RobotMqttAdapter {
           where: { id: robotId },
           data: { status: RobotStatus.OFFLINE },
         })
-        wsRelay.broadcast({ type: 'robot_offline', robotId })
+        mqttEvents.emit('robot_offline', { robotId })
       } else {
         await prisma.robot.updateMany({
           where: { id: robotId, status: RobotStatus.OFFLINE },
           data: { status: RobotStatus.AVAILABLE },
         })
-        wsRelay.broadcast({ type: 'robot_online', robotId })
+        mqttEvents.emit('robot_online', { robotId })
       }
     } catch (err) {
       console.error('[mqtt] update connection :',
@@ -390,8 +387,7 @@ class RobotMqttAdapter {
         where: { id: missionId },
         data: { status: state },
       })
-      wsRelay.broadcast({
-        type: 'mission_update',
+      mqttEvents.emit('mission_update', {
         missionId,
         status: state,
         progress,
@@ -423,14 +419,12 @@ class RobotMqttAdapter {
           data: { status: RobotStatus.AVAILABLE },
         }),
       ])
-      wsRelay.broadcast({
-        type: 'mission_completed',
+      mqttEvents.emit('mission_completed', {
         missionId,
         result,
         reason,
       })
-      wsRelay.broadcast({
-        type: 'status_change',
+      mqttEvents.emit('status_change', {
         robotId,
         status: RobotStatus.AVAILABLE,
       })

--- a/web/backend/src/services/mqttEvents.ts
+++ b/web/backend/src/services/mqttEvents.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'node:events'
+import type { MissionStatus, RobotStatus } from '@prisma/client'
+
+// Catalogue de tous les events emis par mqtt.ts.
+// Chaque WS relay (wsRelay, et plus tard wsTelemetry/wsTf/...) s'abonne aux events qui le concernent.
+// Decouple mqtt <-> relays — resout la dette tech mentionnee dans le journal #218.
+
+export type MqttEvents = {
+  battery_update: { robotId: number; percent: number }
+  status_change:  { robotId: number; status: RobotStatus }
+  robot_online:   { robotId: number }
+  robot_offline:  { robotId: number }
+  position_update: { robotId: number; x: number; y: number; theta?: number }
+  mission_update: { missionId: number; status: MissionStatus; progress?: number }
+  mission_completed: { missionId: number; result: 'completed'|'failed'|'cancelled'; reason?: string }
+  // Les events mapping (map, scan, plan, ...) seront ajoutes en T3.5.5.
+}
+
+class TypedMqttEvents extends EventEmitter {
+  emit<K extends keyof MqttEvents>(event: K, payload: MqttEvents[K]): boolean {
+    return super.emit(event, payload)
+  }
+  on<K extends keyof MqttEvents>(event: K, listener: (payload: MqttEvents[K]) => void): this {
+    return super.on(event, listener)
+  }
+}
+
+export const mqttEvents = new TypedMqttEvents()

--- a/web/backend/src/services/websocket.ts
+++ b/web/backend/src/services/websocket.ts
@@ -1,8 +1,8 @@
 import { WebSocketServer, WebSocket } from 'ws'
-import type { Server as HttpServer, IncomingMessage } from 'node:http'
-import jwt from 'jsonwebtoken'
+import type { IncomingMessage } from 'node:http'
 import { MissionStatus, RobotStatus } from '@prisma/client'
-import { getJwtSecret } from '../middleware/auth'
+import { wsRouter } from './wsRouter'
+import { mqttEvents } from './mqttEvents'
 
 // Service relay : MQTT/Prisma -> WebSocket -> clients frontend.
 // Singleton, attache sur le meme HTTP server qu'Express.
@@ -25,35 +25,14 @@ class WebSocketRelay {
   private wss: WebSocketServer | null = null
   private clients = new Set<WebSocket>()
 
-  /** Attache le WS server sur l'instance HTTP d'Express (path /ws). */
-  attach(httpServer: HttpServer): void {
-    if (this.wss) return // singleton
+  /** S'enregistre comme handler du path /ws sur le router commun.
+   * Aussi : s'abonne aux mqttEvents pour rebroadcaster aux clients. */
+  register(): void {
+    if (this.wss) return
 
     this.wss = new WebSocketServer({ noServer: true })
 
-    httpServer.on('upgrade', (req, socket, head) => {
-      // Match strict /ws (pas /wsfoo) — pathname exact
-      if (!req.url) return socket.destroy()
-      const url = new URL(req.url, `http://${req.headers.host}`)
-      if (url.pathname !== '/ws') return socket.destroy()
-
-      // Auth JWT en query param (limitation browser : pas de header
-      // custom au moment de l'open WS). Connu : le token peut apparaitre
-      // dans des logs reverse-proxy — durcir TLS + log filtering en prod.
-      const token = url.searchParams.get('token')
-      if (!token) {
-        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
-        socket.destroy()
-        return
-      }
-      try {
-        jwt.verify(token, getJwtSecret())
-      } catch {
-        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
-        socket.destroy()
-        return
-      }
-
+    wsRouter.register('/ws', ({ req, socket, head }) => {
       this.wss!.handleUpgrade(req, socket, head, (ws) => {
         this.wss!.emit('connection', ws, req)
       })
@@ -68,7 +47,16 @@ class WebSocketRelay {
       })
     })
 
-    console.log('[ws] WebSocket relay attache sur /ws')
+    // Re-broadcast mqttEvents -> clients /ws
+    mqttEvents.on('battery_update', (e) => this.broadcast({ type: 'battery_update', ...e }))
+    mqttEvents.on('status_change',  (e) => this.broadcast({ type: 'status_change', ...e }))
+    mqttEvents.on('robot_online',   (e) => this.broadcast({ type: 'robot_online', ...e }))
+    mqttEvents.on('robot_offline',  (e) => this.broadcast({ type: 'robot_offline', ...e }))
+    mqttEvents.on('position_update',(e) => this.broadcast({ type: 'position_update', ...e }))
+    mqttEvents.on('mission_update', (e) => this.broadcast({ type: 'mission_update', ...e }))
+    mqttEvents.on('mission_completed', (e) => this.broadcast({ type: 'mission_completed', ...e }))
+
+    console.log('[ws] WebSocket relay /ws enregistre')
   }
 
   /** Diffuse un evenement a tous les clients connectes (qui sont OPEN).

--- a/web/backend/src/services/wsRouter.ts
+++ b/web/backend/src/services/wsRouter.ts
@@ -1,0 +1,92 @@
+import type { Server as HttpServer, IncomingMessage } from 'node:http'
+import type { Duplex } from 'node:stream'
+import jwt from 'jsonwebtoken'
+import { getJwtSecret } from '../middleware/auth'
+
+// Factorise l'upgrade WS pour les multiples paths (a venir : /ws, /ws/robots/:id/telemetry, /tf, /topics, /logs, /ssh).
+// Auth JWT centralisee. Chaque path s'enregistre via register(pattern, handler).
+// Pattern simple : '/ws' (exact) ou '/ws/robots/:id/telemetry' (params nommes).
+//
+// Le `wsRelay` global et les futurs relays appellent `wsRouter.register(...)`
+// pour s'enregistrer comme handler de leur path.
+
+type HandlerCtx = {
+  req: IncomingMessage
+  socket: Duplex
+  head: Buffer
+  params: Record<string, string>
+  token: string
+  decodedToken: jwt.JwtPayload | string
+}
+export type WsPathHandler = (ctx: HandlerCtx) => void
+
+interface Route {
+  regex: RegExp
+  paramNames: string[]
+  handler: WsPathHandler
+  requireAuth: boolean
+}
+
+class WsRouter {
+  private routes: Route[] = []
+  private attached = false
+
+  /** Enregistre un handler pour un pattern. Ordre = priorite (premier match gagne). */
+  register(pattern: string, handler: WsPathHandler, opts: { requireAuth?: boolean } = {}): void {
+    const paramNames: string[] = []
+    const regexStr = pattern.replace(/:([a-zA-Z_]+)/g, (_, name) => {
+      paramNames.push(name)
+      return '([^/]+)'
+    })
+    this.routes.push({
+      regex: new RegExp('^' + regexStr + '$'),
+      paramNames,
+      handler,
+      requireAuth: opts.requireAuth ?? true,
+    })
+  }
+
+  /** Attache le router sur le HTTP server — un seul listener 'upgrade'. */
+  attach(server: HttpServer): void {
+    if (this.attached) return
+    this.attached = true
+    server.on('upgrade', (req, socket, head) => {
+      if (!req.url) return socket.destroy()
+      const url = new URL(req.url, `http://${req.headers.host}`)
+      const route = this.routes.find((r) => r.regex.test(url.pathname))
+
+      if (!route) {
+        socket.write('HTTP/1.1 404 Not Found\r\n\r\n')
+        socket.destroy()
+        return
+      }
+
+      let decoded: jwt.JwtPayload | string = ''
+      const token = url.searchParams.get('token') ?? ''
+
+      if (route.requireAuth) {
+        if (!token) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+          socket.destroy()
+          return
+        }
+        try {
+          decoded = jwt.verify(token, getJwtSecret())
+        } catch {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+          socket.destroy()
+          return
+        }
+      }
+
+      // Extrait params nommes (:id, etc.)
+      const match = url.pathname.match(route.regex)!
+      const params: Record<string, string> = {}
+      route.paramNames.forEach((n, i) => { params[n] = match[i + 1] })
+
+      route.handler({ req, socket, head, params, token, decodedToken: decoded })
+    })
+  }
+}
+
+export const wsRouter = new WsRouter()

--- a/web/backend/src/test/mqttEvents.test.ts
+++ b/web/backend/src/test/mqttEvents.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mqttEvents } from '../services/mqttEvents'
+
+describe('mqttEvents', () => {
+  beforeEach(() => mqttEvents.removeAllListeners())
+
+  it('émet un event avec payload typé', () => {
+    const seen: unknown[] = []
+    mqttEvents.on('battery_update', (e) => seen.push(e))
+    mqttEvents.emit('battery_update', { robotId: 1, percent: 75 })
+    expect(seen).toEqual([{ robotId: 1, percent: 75 }])
+  })
+
+  it('peut avoir plusieurs listeners sur le même event', () => {
+    const a: unknown[] = []
+    const b: unknown[] = []
+    mqttEvents.on('status_change', (e) => a.push(e))
+    mqttEvents.on('status_change', (e) => b.push(e))
+    mqttEvents.emit('status_change', { robotId: 2, status: 'AVAILABLE' })
+    expect(a.length).toBe(1)
+    expect(b.length).toBe(1)
+  })
+})

--- a/web/backend/src/test/wsRouter.test.ts
+++ b/web/backend/src/test/wsRouter.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'node:http'
+import { wsRouter } from '../services/wsRouter'
+import { wsRelay } from '../services/websocket'
+import jwt from 'jsonwebtoken'
+import { getJwtSecret } from '../middleware/auth'
+import type { AddressInfo } from 'node:net'
+
+let server: http.Server
+let port: number
+
+beforeAll(async () => {
+  // App minimale pour le handshake
+  server = http.createServer((_req, res) => res.end('ok'))
+  wsRouter.attach(server)
+  wsRelay.register()
+  await new Promise<void>((r) => server.listen(0, () => r()))
+  port = (server.address() as AddressInfo).port
+})
+
+afterAll(() => {
+  wsRelay.close()
+  server.close()
+})
+
+function rawUpgrade(path: string, token: string | null): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      'Upgrade': 'websocket',
+      'Connection': 'Upgrade',
+      'Sec-WebSocket-Version': '13',
+      'Sec-WebSocket-Key': Buffer.from(Array(16).fill(0)).toString('base64'),
+    }
+    const url = token ? `${path}?token=${token}` : path
+    const req = http.request({ host: 'localhost', port, path: url, method: 'GET', headers })
+    req.on('upgrade', () => resolve({ status: 101 }))
+    req.on('response', (res) => resolve({ status: res.statusCode || 0 }))
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('wsRouter', () => {
+  it('refuse 401 si pas de token', async () => {
+    const r = await rawUpgrade('/ws', null)
+    expect(r.status).toBe(401)
+  })
+
+  it('accepte un upgrade /ws avec token valide', async () => {
+    const token = jwt.sign({ userId: 1 }, getJwtSecret(), { expiresIn: '5m' })
+    const r = await rawUpgrade('/ws', token)
+    expect(r.status).toBe(101)
+  })
+
+  it('refuse 404 sur un path inconnu', async () => {
+    const token = jwt.sign({ userId: 1 }, getJwtSecret(), { expiresIn: '5m' })
+    const r = await rawUpgrade('/ws/unknown', token)
+    expect(r.status).toBe(404)
+  })
+})

--- a/web/backend/vitest.config.ts
+++ b/web/backend/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
     environment: 'node',
     // ne scanne que les sources — sinon vitest ramasse les .js compiles dans dist/
     include: ['src/**/*.test.ts'],
+    // dotenv/config charge .env avant les tests (sinon JWT_SECRET manque a l'import auth.ts)
+    setupFiles: ['dotenv/config'],
   },
 })


### PR DESCRIPTION
## Summary

Plan 1 / Vague 1 — fondation backend WS pour le mode mapping. Refactor le pattern actuel \`mqtt.ts -> wsRelay.broadcast(...)\` en \`mqtt.ts -> mqttEvents.emit(...) -> wsRelay.on(...)\`. Permet ensuite à T3.5.6 (wsTelemetry), T3.5.7 (wsTf, wsTopics), T3.5.12 (wsLogs, wsSsh) de s'enregistrer comme handlers d'autres paths sans toucher à mqtt.ts.

Résout la dette tech mentionnée dans le journal (#218 couplage mqtt.ts ↔ wsRelay).

## Changes
- **Nouveau** `src/services/mqttEvents.ts` : EventEmitter typé via map `MqttEvents` (battery_update, status_change, robot_online/offline, position_update, mission_update, mission_completed)
- **Nouveau** `src/services/wsRouter.ts` : factorise `httpServer.on('upgrade')`. Auth JWT centralisée. `register(pattern, handler)` accepte des params nommés (\`/ws/robots/:id/telemetry\`). 401 si pas de token, 404 si path inconnu. Prêt pour les 5 paths des prochains tickets.
- **Refacto** `src/services/mqtt.ts` : 8 \`wsRelay.broadcast(...)\` → \`mqttEvents.emit(...)\`. Plus aucun import wsRelay.
- **Refacto** `src/services/websocket.ts` : `attach(httpServer)` → `register()` qui s'enregistre via wsRouter + s'abonne à 7 mqttEvents pour rebroadcaster aux clients \`/ws\`. Contrat externe `broadcast()` inchangé (pas de régression frontend).
- **Modif** `src/index.ts` : ajout `wsRouter.attach(server) + wsRelay.register()` (1 seul listener upgrade).
- **Nouveau** `src/test/mqttEvents.test.ts` : 2 tests (emit/on typé + multi-listener).
- **Nouveau** `src/test/wsRouter.test.ts` : 3 tests (401 sans token, 101 upgrade valide, 404 path inconnu).
- **Fix bonus** `vitest.config.ts` : ajout `setupFiles: ['dotenv/config']` pour charger \`.env\` (sinon JWT_SECRET cause crash 3 fichiers tests existants).

## Test plan

- [x] \`npm test\` : **55/55 tests verts** (6 files OK)
- [x] \`npm run build\` : pas d'erreur TS
- [x] Smoke manuel : \`npm run dev\` démarre sans erreur, log \`[ws] WebSocket relay /ws enregistre\`