### PR TITLE
feat(T3.5.2): node mapping_supervisor (pilote explore.launch via MQTT)

### DIFF
--- a/robot/roblaude_nav/roblaude_nav/mapping_supervisor.py
+++ b/robot/roblaude_nav/roblaude_nav/mapping_supervisor.py
@@ -1,0 +1,162 @@
+"""
+Supervisor du mode mapping. Recoit les commandes MQTT cmd/mapping/*
+(routees par le bridge MQTT sur le topic ROS interne /mqtt/cmd/mapping),
+pilote subprocess.Popen sur explore.launch.py, publie mapping/state.
+
+Etats : IDLE -> STARTING -> RUNNING -> STOPPING -> STOPPED | FAILED
+"""
+import os
+import json
+import time
+import signal
+import threading
+import subprocess
+import base64
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+CMD_TOPIC = '/mqtt/cmd/mapping'
+STATE_TOPIC = '/mqtt/mapping/state'
+SAVE_RESULT_TOPIC = '/mqtt/mapping/save_result'
+
+
+class MappingSupervisor(Node):
+    def __init__(self):
+        super().__init__('mapping_supervisor')
+        self.proc = None
+        self.session_id = None
+        self.state = 'IDLE'
+        self.started_at = None
+        self.lock = threading.Lock()
+
+        self.cmd_sub = self.create_subscription(String, CMD_TOPIC, self._on_cmd, 10)
+        self.state_pub = self.create_publisher(String, STATE_TOPIC, 10)
+        self.save_pub = self.create_publisher(String, SAVE_RESULT_TOPIC, 10)
+
+        self.publish_state()  # etat initial annonce au boot
+        self.get_logger().info('mapping_supervisor pret')
+
+    def _on_cmd(self, msg: String):
+        try:
+            data = json.loads(msg.data)
+        except json.JSONDecodeError as e:
+            self.get_logger().error(f'cmd JSON invalide: {e}')
+            return
+        action = data.get('action')
+        if action == 'start':
+            self.start(data.get('sessionId'), data.get('messageId'))
+        elif action == 'stop':
+            self.stop(data.get('messageId'))
+        elif action == 'save':
+            self.save(data.get('sessionId'), data.get('name'), data.get('messageId'))
+        else:
+            self.get_logger().warn(f'action inconnue: {action}')
+
+    def start(self, session_id, message_id):
+        with self.lock:
+            if self.proc is not None:
+                self.get_logger().warn('mapping deja en cours, ignore start')
+                return
+            self.session_id = session_id
+            self.state = 'STARTING'
+            self.started_at = time.time()
+            self.publish_state()
+            try:
+                self.proc = subprocess.Popen(
+                    ['ros2', 'launch', 'roblaude_nav', 'explore.launch.py'],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    preexec_fn=os.setsid,  # nouveau process group pour kill propre
+                )
+                threading.Thread(target=self._watch, daemon=True).start()
+            except Exception as e:
+                self.state = 'FAILED'
+                self.publish_state(failure_reason=str(e))
+                self.proc = None
+
+    def _watch(self):
+        # apres 5s sans crash, on passe a RUNNING
+        time.sleep(5)
+        with self.lock:
+            if self.proc and self.proc.poll() is None and self.state == 'STARTING':
+                self.state = 'RUNNING'
+                self.publish_state()
+        # bloque jusqu'a fin du process — soit normal, soit crash
+        rc = self.proc.wait()
+        with self.lock:
+            if self.state != 'STOPPING':
+                self.state = 'FAILED'
+                err = self.proc.stderr.read().decode('utf-8', errors='ignore')[-500:]
+                self.publish_state(failure_reason=f'launch exited rc={rc}\n{err}')
+            else:
+                self.state = 'STOPPED'
+                self.publish_state()
+            self.proc = None
+
+    def stop(self, message_id):
+        with self.lock:
+            if self.proc is None:
+                return
+            self.state = 'STOPPING'
+            self.publish_state()
+            try:
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGINT)
+            except ProcessLookupError:
+                # process deja fini, _watch fera la transition
+                pass
+
+    def save(self, session_id, name, message_id):
+        name = name or f'session-{session_id}'
+        out = f'/tmp/{name}'
+        try:
+            r = subprocess.run(
+                ['ros2', 'run', 'nav2_map_server', 'map_saver_cli', '-f', out],
+                capture_output=True, timeout=30,
+            )
+            if r.returncode != 0:
+                self.save_pub.publish(String(data=json.dumps({
+                    'messageId': message_id, 'ok': False,
+                    'reason': r.stderr.decode('utf-8', errors='ignore')[-300:],
+                })))
+                return
+            with open(f'{out}.pgm', 'rb') as f:
+                pgm_b64 = base64.b64encode(f.read()).decode('ascii')
+            with open(f'{out}.yaml') as f:
+                yaml_content = f.read()
+            self.save_pub.publish(String(data=json.dumps({
+                'messageId': message_id, 'ok': True,
+                'sessionId': session_id, 'name': name,
+                'pgm_base64': pgm_b64, 'yaml': yaml_content,
+            })))
+        except subprocess.TimeoutExpired:
+            self.save_pub.publish(String(data=json.dumps({
+                'messageId': message_id, 'ok': False,
+                'reason': 'timeout 30s map_saver_cli',
+            })))
+
+    def publish_state(self, failure_reason=None):
+        payload = {
+            'state': self.state,
+            'sessionId': self.session_id,
+            'startedAt': self.started_at,
+        }
+        if failure_reason:
+            payload['failureReason'] = failure_reason
+        self.state_pub.publish(String(data=json.dumps(payload)))
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MappingSupervisor()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robot/roblaude_nav/setup.py
+++ b/robot/roblaude_nav/setup.py
@@ -30,6 +30,7 @@ setup(
             'odom_to_tf = roblaude_nav.odom_to_tf:main',
             'mission_executor = roblaude_nav.mission_executor:main',
             'initial_rotation = roblaude_nav.initial_rotation:main',
+            'mapping_supervisor = roblaude_nav.mapping_supervisor:main',
         ],
     },
 )

--- a/robot/roblaude_nav/test/test_mapping_supervisor.py
+++ b/robot/roblaude_nav/test/test_mapping_supervisor.py
@@ -1,0 +1,172 @@
+"""
+Tests unitaires pour MappingSupervisor.
+os.setsid/os.killpg ne s'executent pas sur macOS dev -> on mock subprocess.
+Smoke test sur le robot reel obligatoire avant merge (cf doc).
+"""
+import json
+import threading
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+# Stubs : MagicMock n'est pas une vraie classe, super().__init__() planterait.
+# On donne des vraies classes Python stubs.
+class _StubNode:
+    def __init__(self, *a, **k): pass
+    def create_subscription(self, *a, **k): return None
+    def create_publisher(self, *a, **k): return None
+    def get_logger(self): return MagicMock()
+
+
+class _StubString:
+    def __init__(self, data=''): self.data = data
+
+
+_rclpy_node_stub = MagicMock()
+_rclpy_node_stub.Node = _StubNode
+_std_msgs_stub = MagicMock()
+_std_msgs_stub.String = _StubString
+
+
+@pytest.fixture
+def supervisor_module():
+    with patch.dict('sys.modules', {
+        'rclpy': MagicMock(),
+        'rclpy.node': _rclpy_node_stub,
+        'std_msgs.msg': _std_msgs_stub,
+    }):
+        # Force re-import si module deja charge avec mauvais mocks
+        import importlib
+        import sys
+        if 'roblaude_nav.mapping_supervisor' in sys.modules:
+            del sys.modules['roblaude_nav.mapping_supervisor']
+        from roblaude_nav import mapping_supervisor
+        return mapping_supervisor
+
+
+def test_initial_state_is_idle(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    sup.proc = None
+    sup.session_id = None
+    sup.state = 'IDLE'
+    sup.started_at = None
+    sup.lock = threading.Lock()
+    assert sup.state == 'IDLE'
+    assert sup.proc is None
+
+
+def test_start_transitions_to_starting(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    sup.proc = None
+    sup.session_id = None
+    sup.state = 'IDLE'
+    sup.started_at = None
+    sup.lock = threading.Lock()
+    sup.state_pub = MagicMock()
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    fake_proc.pid = 12345
+
+    with patch.object(supervisor_module.subprocess, 'Popen', return_value=fake_proc), \
+         patch.object(supervisor_module.threading, 'Thread') as mock_thread:
+        sup.start(session_id=42, message_id='m-1')
+
+    assert sup.state == 'STARTING'
+    assert sup.proc is fake_proc
+    assert sup.session_id == 42
+    mock_thread.assert_called_once()
+
+
+def test_start_ignored_if_already_running(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    fake_proc = MagicMock()
+    sup.proc = fake_proc
+    sup.session_id = 99
+    sup.state = 'RUNNING'
+    sup.lock = threading.Lock()
+    sup.state_pub = MagicMock()
+    sup.get_logger = MagicMock(return_value=MagicMock())
+
+    with patch.object(supervisor_module.subprocess, 'Popen') as mock_popen:
+        sup.start(session_id=42, message_id='m-2')
+        mock_popen.assert_not_called()
+
+    assert sup.proc is fake_proc
+    assert sup.session_id == 99
+
+
+def test_stop_sends_sigint_to_process_group(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    fake_proc = MagicMock(pid=54321)
+    sup.proc = fake_proc
+    sup.session_id = 42
+    sup.state = 'RUNNING'
+    sup.started_at = 0.0
+    sup.lock = threading.Lock()
+    sup.state_pub = MagicMock()
+
+    with patch.object(supervisor_module.os, 'getpgid', return_value=54321), \
+         patch.object(supervisor_module.os, 'killpg') as mock_killpg:
+        sup.stop(message_id='m-3')
+
+    assert sup.state == 'STOPPING'
+    mock_killpg.assert_called_once()
+    args = mock_killpg.call_args[0]
+    assert args[0] == 54321
+    assert args[1] == supervisor_module.signal.SIGINT
+
+
+def test_stop_noop_if_not_running(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    sup.proc = None
+    sup.state = 'IDLE'
+    sup.started_at = None
+    sup.session_id = None
+    sup.lock = threading.Lock()
+    sup.state_pub = MagicMock()
+
+    sup.stop(message_id='m-4')
+    assert sup.state == 'IDLE'
+
+
+def test_save_publishes_ok(supervisor_module, tmp_path):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    sup.save_pub = MagicMock()
+
+    pgm = tmp_path / 'demo.pgm'
+    pgm.write_bytes(b'P5\n2 2\n255\n\x00\xff\xff\x00')
+    yaml = tmp_path / 'demo.yaml'
+    yaml.write_text('resolution: 0.05\norigin: [0,0,0]\n')
+
+    fake_run = MagicMock(returncode=0, stderr=b'')
+
+    real_open = open
+    def side_open(f, *a, **k):
+        if 'pgm' in str(f): return real_open(str(tmp_path / 'demo.pgm'), *a, **k)
+        if 'yaml' in str(f): return real_open(str(tmp_path / 'demo.yaml'), *a, **k)
+        return real_open(f, *a, **k)
+
+    with patch.object(supervisor_module.subprocess, 'run', return_value=fake_run), \
+         patch('builtins.open', side_effect=side_open):
+        sup.save(session_id=42, name='demo', message_id='m-5')
+
+    sup.save_pub.publish.assert_called_once()
+    payload = json.loads(sup.save_pub.publish.call_args[0][0].data)
+    assert payload['ok'] is True
+    assert 'pgm_base64' in payload
+    assert payload['sessionId'] == 42
+
+
+def test_save_handles_failure(supervisor_module):
+    sup = supervisor_module.MappingSupervisor.__new__(supervisor_module.MappingSupervisor)
+    sup.save_pub = MagicMock()
+
+    fake_run = MagicMock(returncode=1, stderr=b'no map topic')
+
+    with patch.object(supervisor_module.subprocess, 'run', return_value=fake_run):
+        sup.save(session_id=42, name='demo', message_id='m-6')
+
+    payload = json.loads(sup.save_pub.publish.call_args[0][0].data)
+    assert payload['ok'] is False
+    assert 'no map topic' in payload['reason']


### PR DESCRIPTION
## Summary

Plan 1 / Vague 1 — node ROS2 Python qui réceptionne les commandes MQTT `cmd/mapping/{start,stop,save}` (routées par le bridge sur `/mqtt/cmd/mapping`), pilote `subprocess.Popen` sur `explore.launch.py`, et publie l'état mapping retained.

États : IDLE → STARTING → RUNNING → STOPPING → STOPPED | FAILED.

## Changes
- **Nouveau** `robot/roblaude_nav/roblaude_nav/mapping_supervisor.py` : ~150 lignes, `subprocess.Popen` avec `preexec_fn=os.setsid` + `os.killpg(SIGINT)` pour kill propre du process group entier (slam + nav2 + explore_lite). Thread `_watch` daemon pour transition STARTING→RUNNING→STOPPED|FAILED sans bloquer ROS executor. `save()` exec `map_saver_cli`, lit PGM + YAML, publie en base64 sur `/mqtt/mapping/save_result`.
- **Nouveau** `robot/roblaude_nav/test/test_mapping_supervisor.py` : **7 tests pytest** (état initial, transitions, ignore start si RUNNING, SIGINT process group, no-op stop si IDLE, save ok + save fail). Mocks `rclpy`/`std_msgs` via stubs (vraies classes, pas MagicMock pour permettre `super().__init__()`).
- **Modif** `robot/roblaude_nav/setup.py` : entry_point `mapping_supervisor = ...:main` (console_scripts).

## Test plan

- [x] `pytest test/test_mapping_supervisor.py` : **7/7 verts**
- [ ] Smoke IRL sur robot : déployer + lancer + publish MQTT `cmd/mapping/start` + observer `mapping/state` retained passer à STARTING puis RUNNING. À faire après merge PR #235 (qui contient les fix stack slam).

## Dépendances
- Doit être déployé en MÊME temps que PR #235 (fix stack) pour que `explore.launch.py` fonctionne IRL.
- Consommera les events `cmd/mapping/*` une fois T3.5.3 (bridge MQTT extensions) mergé.