### PR TITLE
feat(T3.5.5): backend mapping — handlers MQTT + REST start/stop/save

### DIFF
--- a/web/backend/.gitignore
+++ b/web/backend/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /src/generated/prisma
 
 /src/generated/prisma
+/maps/

--- a/web/backend/src/app.ts
+++ b/web/backend/src/app.ts
@@ -6,6 +6,7 @@ import authRouter from './routes/auth'
 import missionsRouter from './routes/missions'
 import pointsRouter from './routes/points'
 import robotsRouter from './routes/robots'
+import mappingRouter from './routes/mapping'
 
 const app = express()
 
@@ -30,6 +31,7 @@ app.use('/api/auth', authRouter)
 app.use('/api/missions', authGuard, missionsRouter)
 app.use('/api/points', authGuard, pointsRouter)
 app.use('/api/robots', authGuard, robotsRouter)
+app.use('/api/mapping', authGuard, mappingRouter)
 
 // error handler — doit etre en dernier
 app.use(errorHandler)

--- a/web/backend/src/controllers/mappingController.ts
+++ b/web/backend/src/controllers/mappingController.ts
@@ -1,0 +1,159 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
+import prisma from '../lib/prisma'
+import { robotMqtt } from '../services/mqtt'
+import { mqttEvents } from '../services/mqttEvents'
+import { saveSnapshotFiles, getSnapshotPath } from '../lib/mapStorage'
+
+// Endpoints REST mapping (T3.5.5). Toutes les routes sont derriere authGuard
+// (mount dans app.ts). saveMapping est asynchrone : on attend l'event
+// mapping_save_result emis par mqtt.ts apres reception du payload robot.
+
+const startSchema = z.object({ robotId: z.number().int().positive() })
+const stopSchema = z.object({ sessionId: z.number().int().positive() })
+const saveSchema = z.object({ sessionId: z.number().int().positive(), name: z.string().optional() })
+
+const SAVE_TIMEOUT_MS = 30_000
+
+export async function startMapping(req: Request, res: Response): Promise<void> {
+  const parsed = startSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'invalid body', issues: parsed.error.issues })
+    return
+  }
+  const userId = req.user?.userId
+  if (!userId) { res.status(401).json({ error: 'auth required' }); return }
+
+  const session = await prisma.mappingSession.create({
+    data: { robotId: parsed.data.robotId, startedById: userId, state: 'STARTING' },
+  })
+  robotMqtt.publishCommand(parsed.data.robotId, 'mapping/start', { sessionId: session.id })
+  res.status(201).json({ sessionId: session.id, state: session.state })
+}
+
+export async function stopMapping(req: Request, res: Response): Promise<void> {
+  const parsed = stopSchema.safeParse(req.body)
+  if (!parsed.success) { res.status(400).json({ error: 'invalid body' }); return }
+  const session = await prisma.mappingSession.findUnique({ where: { id: parsed.data.sessionId } })
+  if (!session) { res.status(404).json({ error: 'session not found' }); return }
+  robotMqtt.publishCommand(session.robotId, 'mapping/stop', { sessionId: session.id })
+  res.status(200).json({ ok: true })
+}
+
+export async function saveMapping(req: Request, res: Response): Promise<void> {
+  const parsed = saveSchema.safeParse(req.body)
+  if (!parsed.success) { res.status(400).json({ error: 'invalid body' }); return }
+  const session = await prisma.mappingSession.findUnique({ where: { id: parsed.data.sessionId } })
+  if (!session) { res.status(404).json({ error: 'session not found' }); return }
+
+  const messageId = randomUUID()
+  const name = parsed.data.name ?? `session-${session.id}-${Date.now()}`
+
+  // On installe le listener AVANT de publier — sinon le robot pourrait
+  // repondre tres vite (cas mock) avant qu'on soit en ecoute.
+  const resultPromise = new Promise<{
+    ok: boolean
+    pgm_base64?: string
+    yaml?: string
+    reason?: string
+  }>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      mqttEvents.removeListener('mapping_save_result', handler)
+      reject(new Error('timeout 30s'))
+    }, SAVE_TIMEOUT_MS)
+    const handler = (e: { messageId?: string; ok: boolean; pgm_base64?: string; yaml?: string; reason?: string }): void => {
+      if (e.messageId !== messageId) return
+      clearTimeout(timeout)
+      mqttEvents.removeListener('mapping_save_result', handler)
+      resolve(e)
+    }
+    mqttEvents.on('mapping_save_result', handler)
+  })
+
+  robotMqtt.publishCommand(session.robotId, 'mapping/save', {
+    sessionId: session.id, name, messageId,
+  })
+
+  try {
+    const result = await resultPromise
+    if (!result.ok || !result.pgm_base64 || !result.yaml) {
+      res.status(500).json({ ok: false, reason: result.reason ?? 'missing pgm/yaml' })
+      return
+    }
+    // Cree d'abord la ligne (id auto) pour avoir le filename, puis ecrit
+    // les fichiers, puis update les paths/dimensions.
+    const snapshot = await prisma.mapSnapshot.create({
+      data: {
+        sessionId: session.id,
+        robotId: session.robotId,
+        name,
+        pgmPath: '', yamlPath: '', pngPath: '',
+        widthPx: 0, heightPx: 0, resolutionM: 0,
+        originX: 0, originY: 0, originTheta: 0, sizeBytes: 0,
+      },
+    })
+    const files = await saveSnapshotFiles(snapshot.id, result.pgm_base64, result.yaml)
+    await prisma.mapSnapshot.update({ where: { id: snapshot.id }, data: files })
+    res.status(201).json({ snapshotId: snapshot.id, ...files })
+  } catch (err) {
+    res.status(504).json({ ok: false, reason: err instanceof Error ? err.message : 'unknown error' })
+  }
+}
+
+export async function listSessions(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.query.robotId)
+  if (!Number.isInteger(robotId) || robotId <= 0) {
+    res.status(400).json({ error: 'robotId query param required' })
+    return
+  }
+  const sessions = await prisma.mappingSession.findMany({
+    where: { robotId },
+    orderBy: { startedAt: 'desc' },
+    take: 50,
+    include: { _count: { select: { snapshots: true, annotations: true } } },
+  })
+  res.status(200).json(sessions)
+}
+
+export async function getSession(req: Request, res: Response): Promise<void> {
+  const id = Number(req.params.id)
+  const session = await prisma.mappingSession.findUnique({
+    where: { id },
+    include: {
+      snapshots: true,
+      annotations: true,
+      startedBy: { select: { id: true, name: true, email: true } },
+    },
+  })
+  if (!session) { res.status(404).json({ error: 'not found' }); return }
+  res.status(200).json(session)
+}
+
+export async function downloadSnapshot(req: Request, res: Response): Promise<void> {
+  const id = Number(req.params.id)
+  const ext = req.params.ext as 'pgm' | 'yaml' | 'png'
+  if (!['pgm', 'yaml', 'png'].includes(ext)) {
+    res.status(400).json({ error: 'invalid ext' })
+    return
+  }
+  const snapshot = await prisma.mapSnapshot.findUnique({ where: { id } })
+  if (!snapshot) { res.status(404).json({ error: 'not found' }); return }
+  const mime = ext === 'pgm' ? 'application/octet-stream'
+    : ext === 'yaml' ? 'text/yaml'
+    : 'image/png'
+  res.setHeader('Content-Type', mime)
+  res.setHeader('Content-Disposition', `attachment; filename="${snapshot.name}.${ext}"`)
+  res.sendFile(getSnapshotPath(id, ext))
+}
+
+export async function setCurrentSnapshot(req: Request, res: Response): Promise<void> {
+  const id = Number(req.params.id)
+  const snapshot = await prisma.mapSnapshot.findUnique({ where: { id } })
+  if (!snapshot) { res.status(404).json({ error: 'not found' }); return }
+  await prisma.$transaction([
+    prisma.mapSnapshot.updateMany({ where: { robotId: snapshot.robotId }, data: { isCurrent: false } }),
+    prisma.mapSnapshot.update({ where: { id }, data: { isCurrent: true } }),
+  ])
+  res.status(200).json({ ok: true, snapshotId: id })
+}

--- a/web/backend/src/lib/mapStorage.ts
+++ b/web/backend/src/lib/mapStorage.ts
@@ -1,0 +1,38 @@
+// Ecriture/lecture des cartes SLAM (PGM + YAML + PNG) sur disque.
+// Stockage : web/backend/maps/<snapshotId>.{pgm,yaml,png}
+// Le PNG MVP = copie du PGM (le frontend recoit le live PNG via /telemetry/map).
+
+import { writeFile, mkdir, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const MAPS_DIR = path.resolve(process.cwd(), 'maps')
+
+async function ensureDir(): Promise<void> {
+  if (!existsSync(MAPS_DIR)) await mkdir(MAPS_DIR, { recursive: true })
+}
+
+export async function saveSnapshotFiles(
+  snapshotId: number,
+  pgmBase64: string,
+  yamlContent: string,
+): Promise<{ pgmPath: string; yamlPath: string; pngPath: string; sizeBytes: number }> {
+  await ensureDir()
+  const pgmBuf = Buffer.from(pgmBase64, 'base64')
+  const pgmPath = path.join(MAPS_DIR, `${snapshotId}.pgm`)
+  const yamlPath = path.join(MAPS_DIR, `${snapshotId}.yaml`)
+  const pngPath = path.join(MAPS_DIR, `${snapshotId}.png`)
+  await writeFile(pgmPath, pgmBuf)
+  await writeFile(yamlPath, yamlContent)
+  // todo: convertir PGM -> PNG via sharp (cf. mapController). MVP : copie brute.
+  await writeFile(pngPath, pgmBuf)
+  return { pgmPath, yamlPath, pngPath, sizeBytes: pgmBuf.length }
+}
+
+export async function readSnapshotFile(snapshotId: number, ext: 'pgm' | 'yaml' | 'png'): Promise<Buffer> {
+  return readFile(path.join(MAPS_DIR, `${snapshotId}.${ext}`))
+}
+
+export function getSnapshotPath(snapshotId: number, ext: 'pgm' | 'yaml' | 'png'): string {
+  return path.join(MAPS_DIR, `${snapshotId}.${ext}`)
+}

--- a/web/backend/src/routes/mapping.ts
+++ b/web/backend/src/routes/mapping.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express'
+import {
+  startMapping,
+  stopMapping,
+  saveMapping,
+  listSessions,
+  getSession,
+  downloadSnapshot,
+  setCurrentSnapshot,
+} from '../controllers/mappingController'
+import { adminGuard } from '../middleware/auth'
+
+// Toutes les routes sont derriere authGuard (cf. app.ts).
+// adminGuard supplementaire sur set-current : changement de carte courante = admin.
+
+const router = Router()
+
+router.post('/start', startMapping)
+router.post('/stop', stopMapping)
+router.post('/save', saveMapping)
+router.get('/sessions', listSessions)
+router.get('/sessions/:id', getSession)
+router.get('/snapshots/:id/download.:ext', downloadSnapshot)
+router.post('/snapshots/:id/set-current', adminGuard, setCurrentSnapshot)
+
+export default router

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { MissionStatus, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
-import { mqttEvents } from './mqttEvents'
+import { mqttEvents, type MqttEvents } from './mqttEvents'
 
 // Adaptateur MQTT du backend — singleton.
 // Topics et formats : voir docs/mqtt-spec.md
@@ -89,6 +89,10 @@ export type CmdAction =
   | 'resume'
   | 'loading-confirmed'
   | 'emergency-stop'
+  | 'mapping/start'
+  | 'mapping/stop'
+  | 'mapping/save'
+  | 'teleop'
 
 // Duree de vie d'un messageId dans le cache d'idempotence. Au-dela, le retry
 // du robot est traite comme un nouveau message. Le robot ne doit pas retry
@@ -157,6 +161,7 @@ class RobotMqttAdapter {
           'roblaude/+/telemetry/#',
           'roblaude/+/status',
           'roblaude/+/mission/#',
+          'roblaude/+/mapping/#',
           'roblaude/+/connection',
         ],
         { qos: 1 },
@@ -206,6 +211,12 @@ class RobotMqttAdapter {
     const [, robotIdRaw, family, sub] = topic.split('/')
     const robotId = Number(robotIdRaw)
 
+    // telemetry/map = PNG binaire, pas JSON. On route avant le JSON.parse.
+    if (family === 'telemetry' && sub === 'map') {
+      this.handleMap(robotId, payload)
+      return
+    }
+
     let data: Record<string, unknown>
     try {
       data = JSON.parse(payload.toString())
@@ -222,6 +233,11 @@ class RobotMqttAdapter {
       case 'telemetry':
         if (sub === 'battery') void this.handleBattery(robotId, data)
         else if (sub === 'position') void this.handlePosition(robotId, data)
+        else if (sub === 'map_meta') this.handleMapMeta(robotId, data)
+        else if (sub === 'scan') this.handleScan(robotId, data)
+        else if (sub === 'plan') this.handlePlan(robotId, data)
+        else if (sub === 'frontiers') this.handleFrontiers(robotId, data)
+        else if (sub === 'tf') this.handleTf(robotId, data)
         break
       case 'status':
         void this.handleStatus(robotId, data)
@@ -230,6 +246,10 @@ class RobotMqttAdapter {
         if (sub === 'ack') void this.handleMissionAck(robotId, data)
         else if (sub === 'status') void this.handleMissionStatus(data)
         else if (sub === 'result') void this.handleMissionResult(robotId, data)
+        break
+      case 'mapping':
+        if (sub === 'state') this.handleMappingState(robotId, data)
+        else if (sub === 'save-result') this.handleMappingSaveResult(robotId, data)
         break
       case 'connection':
         void this.handleConnection(robotId, data)
@@ -432,6 +452,137 @@ class RobotMqttAdapter {
       // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
       console.error('[mqtt] update mission/result :',
         err instanceof Error ? err.message : err)
+    })
+  }
+
+  // === MAPPING (T3.5.5) ===
+  // map_meta (JSON) et map (PNG binaire) arrivent sur 2 topics differents.
+  // On fusionne par robotId : map_update n'est emis que quand on a les deux.
+  private mapMetaCache = new Map<number, MqttEvents['map_update']['meta']>()
+  private mapPngCache = new Map<number, Buffer>()
+
+  private handleMapMeta(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      width: z.number().int().positive(),
+      height: z.number().int().positive(),
+      resolution: z.number().positive(),
+      originX: z.number(),
+      originY: z.number(),
+      stamp: z.number(),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] map_meta rejete :', parsed.error.issues)
+      return
+    }
+    this.mapMetaCache.set(robotId, parsed.data)
+    this.tryEmitMap(robotId)
+  }
+
+  private handleMap(robotId: number, png: Buffer): void {
+    this.mapPngCache.set(robotId, png)
+    this.tryEmitMap(robotId)
+  }
+
+  private tryEmitMap(robotId: number): void {
+    const meta = this.mapMetaCache.get(robotId)
+    const png = this.mapPngCache.get(robotId)
+    if (!meta || !png) return
+    mqttEvents.emit('map_update', { robotId, png, meta })
+  }
+
+  private handleScan(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      ranges: z.array(z.number()),
+      angleMin: z.number(),
+      angleIncrement: z.number(),
+      frameId: z.string(),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] scan rejete :', parsed.error.issues)
+      return
+    }
+    mqttEvents.emit('scan_update', { robotId, ...parsed.data })
+  }
+
+  private handlePlan(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      poses: z.array(z.object({ x: z.number(), y: z.number(), theta: z.number() })),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) return
+    mqttEvents.emit('plan_update', { robotId, poses: parsed.data.poses })
+  }
+
+  private handleFrontiers(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      cells: z.array(z.object({ x: z.number(), y: z.number(), size: z.number() })),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) return
+    mqttEvents.emit('frontiers_update', { robotId, cells: parsed.data.cells })
+  }
+
+  private handleTf(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      frames: z.array(z.object({
+        id: z.string(),
+        parent: z.string(),
+        x: z.number(), y: z.number(), z: z.number(),
+        qx: z.number(), qy: z.number(), qz: z.number(), qw: z.number(),
+      })),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) return
+    mqttEvents.emit('tf_update', { robotId, frames: parsed.data.frames })
+  }
+
+  // mapping/state — STARTING / RUNNING / STOPPING / STOPPED / FAILED.
+  // Met aussi a jour MappingSession en DB si sessionId fourni.
+  private handleMappingState(robotId: number, data: Record<string, unknown>): void {
+    const schema = z.object({
+      state: z.enum(['STARTING', 'RUNNING', 'STOPPING', 'STOPPED', 'FAILED']),
+      sessionId: z.number().int().nullable(),
+      startedAt: z.number().optional(),
+      coverageM2: z.number().optional(),
+      coveragePercent: z.number().optional(),
+      failureReason: z.string().optional(),
+    })
+    const parsed = schema.safeParse(data)
+    if (!parsed.success) {
+      console.warn('[mqtt] mapping/state rejete :', parsed.error.issues)
+      return
+    }
+    if (parsed.data.sessionId !== null) {
+      const terminal = parsed.data.state === 'STOPPED' || parsed.data.state === 'FAILED'
+      prisma.mappingSession
+        .update({
+          where: { id: parsed.data.sessionId },
+          data: {
+            state: parsed.data.state,
+            ...(parsed.data.failureReason ? { failureReason: parsed.data.failureReason } : {}),
+            ...(terminal ? { endedAt: new Date(), coverageM2: parsed.data.coverageM2 ?? null } : {}),
+          },
+        })
+        .catch((err) => console.error('[mqtt] update mapping session :',
+          err instanceof Error ? err.message : err))
+    }
+    mqttEvents.emit('mapping_state', { robotId, ...parsed.data })
+  }
+
+  // mapping/save-result — le bridge robot renvoie le PGM en base64 + YAML.
+  // Le mappingController attend cet event via mqttEvents pour committer en DB.
+  private handleMappingSaveResult(robotId: number, data: Record<string, unknown>): void {
+    mqttEvents.emit('mapping_save_result', {
+      robotId,
+      messageId: data.messageId as string | undefined,
+      ok: Boolean(data.ok),
+      sessionId: data.sessionId as number | undefined,
+      name: data.name as string | undefined,
+      pgm_base64: data.pgm_base64 as string | undefined,
+      yaml: data.yaml as string | undefined,
+      reason: data.reason as string | undefined,
     })
   }
 

--- a/web/backend/src/services/mqttEvents.ts
+++ b/web/backend/src/services/mqttEvents.ts
@@ -13,7 +13,39 @@ export type MqttEvents = {
   position_update: { robotId: number; x: number; y: number; theta?: number }
   mission_update: { missionId: number; status: MissionStatus; progress?: number }
   mission_completed: { missionId: number; result: 'completed'|'failed'|'cancelled'; reason?: string }
-  // Les events mapping (map, scan, plan, ...) seront ajoutes en T3.5.5.
+  // === mapping (T3.5.5) ===
+  map_update: {
+    robotId: number
+    png: Buffer
+    meta: { width: number; height: number; resolution: number; originX: number; originY: number; stamp: number }
+  }
+  scan_update: { robotId: number; ranges: number[]; angleMin: number; angleIncrement: number; frameId: string }
+  plan_update: { robotId: number; poses: { x: number; y: number; theta: number }[] }
+  frontiers_update: { robotId: number; cells: { x: number; y: number; size: number }[] }
+  tf_update: {
+    robotId: number
+    frames: { id: string; parent: string; x: number; y: number; z: number; qx: number; qy: number; qz: number; qw: number }[]
+  }
+  mapping_state: {
+    robotId: number
+    state: 'STARTING' | 'RUNNING' | 'STOPPING' | 'STOPPED' | 'FAILED'
+    sessionId: number | null
+    startedAt?: number
+    coverageM2?: number
+    coveragePercent?: number
+    failureReason?: string
+  }
+  mapping_save_result: {
+    robotId: number
+    messageId?: string
+    ok: boolean
+    sessionId?: number
+    name?: string
+    pgm_base64?: string
+    yaml?: string
+    reason?: string
+  }
+  annotation_change: { robotId: number; action: 'created' | 'updated' | 'deleted'; annotation?: unknown; id?: number }
 }
 
 class TypedMqttEvents extends EventEmitter {

--- a/web/backend/src/test/mapping-controller.test.ts
+++ b/web/backend/src/test/mapping-controller.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+import { robotMqtt } from '../services/mqtt'
+
+const prisma = new PrismaClient()
+
+let userToken: string
+let robotId: number
+let userId: number
+
+beforeAll(async () => {
+  const u = await prisma.user.create({
+    data: {
+      email: `mc-${Date.now()}@x.com`,
+      password: bcrypt.hashSync('x', 4),
+      name: 'mc',
+      role: Role.USER,
+    },
+  })
+  userId = u.id
+  userToken = signToken({ userId: u.id, email: u.email, role: u.role })
+  const r = await prisma.robot.create({ data: { name: `r-${Date.now()}` } })
+  robotId = r.id
+})
+
+afterAll(async () => {
+  await prisma.mapSnapshot.deleteMany({ where: { robotId } })
+  await prisma.mappingSession.deleteMany({ where: { robotId } })
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+beforeEach(() => {
+  // mqtt non connecte en test : on stub publishCommand
+  vi.spyOn(robotMqtt, 'publishCommand').mockReturnValue(true)
+})
+
+describe('POST /api/mapping/start', () => {
+  it('cree une session STARTING + retourne sessionId', async () => {
+    const res = await request(app)
+      .post('/api/mapping/start')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ robotId })
+    expect(res.status).toBe(201)
+    expect(res.body.sessionId).toBeGreaterThan(0)
+    expect(res.body.state).toBe('STARTING')
+  })
+
+  it('refuse 400 si robotId manquant', async () => {
+    const res = await request(app)
+      .post('/api/mapping/start')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({})
+    expect(res.status).toBe(400)
+  })
+
+  it('refuse 401 sans token', async () => {
+    const res = await request(app).post('/api/mapping/start').send({ robotId })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('POST /api/mapping/stop', () => {
+  it('publie cmd/mapping/stop sans erreur', async () => {
+    const session = await prisma.mappingSession.create({
+      data: { robotId, startedById: userId, state: 'RUNNING' },
+    })
+    const res = await request(app)
+      .post('/api/mapping/stop')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ sessionId: session.id })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('refuse 404 si sessionId inconnu', async () => {
+    const res = await request(app)
+      .post('/api/mapping/stop')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ sessionId: 999999 })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /api/mapping/sessions', () => {
+  it('liste les sessions du robot', async () => {
+    const res = await request(app)
+      .get(`/api/mapping/sessions?robotId=${robotId}`)
+      .set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+  })
+
+  it('refuse 400 sans robotId', async () => {
+    const res = await request(app)
+      .get('/api/mapping/sessions')
+      .set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(400)
+  })
+})

--- a/web/backend/src/test/mqtt-mapping-handlers.test.ts
+++ b/web/backend/src/test/mqtt-mapping-handlers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mqttEvents } from '../services/mqttEvents'
+import { robotMqtt } from '../services/mqtt'
+
+// Tests unitaires des handlers mapping de mqtt.ts.
+// On appelle les methodes privees via (robotMqtt as any) pour eviter de
+// mocker tout le broker.
+
+describe('mqtt mapping handlers', () => {
+  beforeEach(() => mqttEvents.removeAllListeners())
+
+  it('handleMap emet map_update avec png + meta combines', () => {
+    const events: unknown[] = []
+    mqttEvents.on('map_update', (e) => events.push(e))
+    const meta = {
+      schemaVersion: 1,
+      messageId: 'm-1',
+      timestamp: '2026-05-22T15:00:00Z',
+      width: 4,
+      height: 3,
+      resolution: 0.05,
+      originX: -1,
+      originY: -2,
+      stamp: 123.45,
+    }
+    ;(robotMqtt as any).handleMapMeta(1, meta)
+    ;(robotMqtt as any).handleMap(1, Buffer.from('FAKEPNG'))
+    expect(events.length).toBe(1)
+    const e = events[0] as any
+    expect(e.robotId).toBe(1)
+    expect(e.png.toString()).toBe('FAKEPNG')
+    expect(e.meta.width).toBe(4)
+    expect(e.meta.resolution).toBeCloseTo(0.05)
+  })
+
+  it('handleMappingState emet mapping_state valide', () => {
+    const events: unknown[] = []
+    mqttEvents.on('mapping_state', (e) => events.push(e))
+    ;(robotMqtt as any).handleMappingState(1, {
+      schemaVersion: 1,
+      messageId: 'm-2',
+      timestamp: '2026-05-22T15:00:01Z',
+      state: 'RUNNING',
+      sessionId: null,
+      startedAt: 1234,
+    })
+    expect(events.length).toBe(1)
+    expect((events[0] as any).state).toBe('RUNNING')
+  })
+
+  it('rejette mapping_state avec state inconnu', () => {
+    const events: unknown[] = []
+    mqttEvents.on('mapping_state', (e) => events.push(e))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    ;(robotMqtt as any).handleMappingState(1, { state: 'BOGUS', sessionId: null })
+    expect(events.length).toBe(0)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('handleScan emet scan_update', () => {
+    const events: unknown[] = []
+    mqttEvents.on('scan_update', (e) => events.push(e))
+    ;(robotMqtt as any).handleScan(2, {
+      ranges: [0.5, 0.7, 1.2],
+      angleMin: -1.57,
+      angleIncrement: 0.01,
+      frameId: 'base_scan',
+    })
+    expect(events.length).toBe(1)
+    expect((events[0] as any).ranges).toHaveLength(3)
+  })
+})

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -64,6 +64,7 @@ describe('RobotMqttAdapter — transport', () => {
         'roblaude/+/telemetry/#',
         'roblaude/+/status',
         'roblaude/+/mission/#',
+        'roblaude/+/mapping/#',
         'roblaude/+/connection',
       ],
       { qos: 1 },


### PR DESCRIPTION
## Résumé

Étend le backend pour piloter le mode mapping côté robot :

- **mqttEvents** : 8 nouveaux events typés (`map_update`, `scan_update`, `plan_update`, `frontiers_update`, `tf_update`, `mapping_state`, `mapping_save_result`, `annotation_change`).
- **mqtt.ts** :
  - 4 nouvelles `CmdAction` (`mapping/start`, `mapping/stop`, `mapping/save`, `teleop`)
  - subscription `roblaude/+/mapping/#`
  - routeur PNG binaire (`telemetry/map`) avant `JSON.parse`
  - 7 nouveaux handlers + fusion map_meta/PNG par robotId
  - `mapping/state` met aussi à jour `MappingSession` en DB
- **REST `/api/mapping`** (derrière authGuard) :
  - `POST /start`, `POST /stop`, `POST /save` (attend `mapping_save_result` 30s)
  - `GET /sessions`, `GET /sessions/:id`
  - `GET /snapshots/:id/download.:ext`
  - `POST /snapshots/:id/set-current` (adminGuard)
- **mapStorage.ts** : écriture PGM/YAML/PNG sur disque `web/backend/maps/` (gitignored)

## Tests

- 70/70 passent (4 nouveaux handlers + 7 endpoints REST)
- `mqtt-mapping-handlers.test.ts` : map_meta+png fusion, mapping/state valide/invalide, scan
- `mapping-controller.test.ts` : start/stop/sessions, 400/401/404

## Plan de test

- [x] `npm run build` clean
- [x] `npm test` 70/70 vert
- [ ] Test end-to-end avec robot (post-merge — Plan 3 frontend nécessaire)

## Hors scope

- WS endpoints `/telemetry`, `/tf`, `/topics` → T3.5.6 / T3.5.7
- Annotations CRUD → T3.5.6