### PR TITLE
feat(T3.5.6): wsTelemetry — WS rooms par robot pour carte/scan/plan/teleop

### DIFF
--- a/web/backend/src/index.ts
+++ b/web/backend/src/index.ts
@@ -4,6 +4,7 @@ import { app } from './app'
 import { robotMqtt } from './services/mqtt'
 import { wsRouter } from './services/wsRouter'
 import { wsRelay } from './services/websocket'
+import { wsTelemetry } from './services/wsTelemetry'
 
 const PORT = process.env.PORT || 3001
 
@@ -14,6 +15,7 @@ const server = http.createServer(app)
 // wsRelay s'enregistre comme handler du path /ws via wsRouter.
 wsRouter.attach(server)
 wsRelay.register()
+wsTelemetry.register()
 
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)
@@ -25,6 +27,7 @@ function shutdown(signal: string) {
   console.log(`[server] ${signal} recu, arret propre…`)
   robotMqtt.disconnect()
   wsRelay.close()
+  wsTelemetry.close()
   server.close(() => process.exit(0))
 }
 

--- a/web/backend/src/services/wsTelemetry.ts
+++ b/web/backend/src/services/wsTelemetry.ts
@@ -1,0 +1,122 @@
+import { WebSocketServer, WebSocket, type RawData } from 'ws'
+import { wsRouter } from './wsRouter'
+import { mqttEvents } from './mqttEvents'
+import { robotMqtt } from './mqtt'
+
+// WS endpoint /ws/robots/:id/telemetry (T3.5.6).
+// Groupe les clients par robotId (room). Chaque event mqtt mapping est
+// broadcaste a la room concernee. Un message teleop d'un client est
+// forwarde sur MQTT cmd/teleop.
+//
+// PNG map : frame BINARY prefixee d'un byte de type (0x01) + meta JSON
+// envoye en frame texte separee (le frontend doit recoller les deux).
+
+type Room = Set<WebSocket>
+
+const TYPE_MAP_PNG = 0x01
+
+class WsTelemetry {
+  private wss: WebSocketServer | null = null
+  private rooms = new Map<number, Room>()
+
+  register(): void {
+    if (this.wss) return
+    this.wss = new WebSocketServer({ noServer: true })
+
+    wsRouter.register('/ws/robots/:id/telemetry', ({ req, socket, head, params }) => {
+      const robotId = Number(params.id)
+      if (!Number.isInteger(robotId) || robotId <= 0) {
+        socket.destroy()
+        return
+      }
+      this.wss!.handleUpgrade(req, socket, head, (ws) => {
+        this.attachClient(robotId, ws)
+      })
+    })
+
+    mqttEvents.on('map_update', (e) => this.broadcastMap(e.robotId, e.png, e.meta))
+    mqttEvents.on('scan_update', (e) => this.broadcastJson(e.robotId, { type: 'scan', ...e }))
+    mqttEvents.on('plan_update', (e) => this.broadcastJson(e.robotId, { type: 'plan', poses: e.poses }))
+    mqttEvents.on('frontiers_update', (e) => this.broadcastJson(e.robotId, { type: 'frontiers', cells: e.cells }))
+    mqttEvents.on('mapping_state', (e) => this.broadcastJson(e.robotId, { type: 'mapping_state', ...e }))
+    mqttEvents.on('annotation_change', (e) => this.broadcastJson(e.robotId, {
+      type: e.action === 'deleted' ? 'annotation_deleted' : `annotation_${e.action}`,
+      annotation: e.annotation,
+      id: e.id,
+    }))
+
+    console.log('[ws] wsTelemetry registered on /ws/robots/:id/telemetry')
+  }
+
+  private attachClient(robotId: number, ws: WebSocket): void {
+    let room = this.rooms.get(robotId)
+    if (!room) {
+      room = new Set()
+      this.rooms.set(robotId, room)
+    }
+    room.add(ws)
+    ws.on('message', (data) => this.onClientMessage(robotId, ws, data))
+    ws.on('close', () => {
+      room!.delete(ws)
+      if (room!.size === 0) this.rooms.delete(robotId)
+    })
+    ws.on('error', () => ws.close())
+  }
+
+  private onClientMessage(robotId: number, _ws: WebSocket, data: RawData): void {
+    let msg: { type?: string; lin?: unknown; ang?: unknown }
+    try {
+      msg = JSON.parse(data.toString())
+    } catch {
+      return
+    }
+    if (msg.type === 'teleop') {
+      const lin = Number(msg.lin ?? 0)
+      const ang = Number(msg.ang ?? 0)
+      if (!Number.isFinite(lin) || !Number.isFinite(ang)) return
+      // clamp securite — vitesses brutes refusees (cf. spec §5.5 dead-man)
+      const cLin = Math.max(-0.5, Math.min(0.5, lin))
+      const cAng = Math.max(-1.0, Math.min(1.0, ang))
+      robotMqtt.publishCommand(robotId, 'teleop', { lin: cLin, ang: cAng })
+    }
+    // type === 'subscribe' / autre : no-op MVP (tous canaux actifs par defaut)
+  }
+
+  private broadcastJson(robotId: number, payload: object): void {
+    const room = this.rooms.get(robotId)
+    if (!room) return
+    const data = JSON.stringify(payload)
+    for (const ws of room) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data)
+    }
+  }
+
+  private broadcastMap(
+    robotId: number,
+    png: Buffer,
+    meta: { width: number; height: number; resolution: number; originX: number; originY: number; stamp: number },
+  ): void {
+    const room = this.rooms.get(robotId)
+    if (!room) return
+    const header = Buffer.from([TYPE_MAP_PNG])
+    const binary = Buffer.concat([header, png])
+    const metaMsg = JSON.stringify({ type: 'map_meta', meta })
+    for (const ws of room) {
+      if (ws.readyState !== WebSocket.OPEN) continue
+      ws.send(binary, { binary: true })
+      ws.send(metaMsg)
+    }
+  }
+
+  /** Ferme tous les sockets — utilise au shutdown. */
+  close(): void {
+    for (const room of this.rooms.values()) {
+      for (const ws of room) ws.close()
+    }
+    this.rooms.clear()
+    this.wss?.close()
+    this.wss = null
+  }
+}
+
+export const wsTelemetry = new WsTelemetry()

--- a/web/backend/src/test/wsTelemetry.test.ts
+++ b/web/backend/src/test/wsTelemetry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'node:http'
+import WebSocket from 'ws'
+import jwt from 'jsonwebtoken'
+import { wsRouter } from '../services/wsRouter'
+import { wsTelemetry } from '../services/wsTelemetry'
+import { mqttEvents } from '../services/mqttEvents'
+import { robotMqtt } from '../services/mqtt'
+import { getJwtSecret } from '../middleware/auth'
+
+let server: http.Server
+let port: number
+let token: string
+const openSockets: WebSocket[] = []
+
+beforeAll(async () => {
+  server = http.createServer((_req, res) => res.end('ok'))
+  wsRouter.attach(server)
+  wsTelemetry.register()
+  await new Promise<void>((r) => server.listen(0, () => r()))
+  port = (server.address() as { port: number }).port
+  token = jwt.sign({ userId: 1, email: 'x@x', role: 'USER' }, getJwtSecret(), { expiresIn: '5m' })
+})
+
+afterAll(() => {
+  wsTelemetry.close()
+  server.close()
+})
+
+beforeEach(() => {
+  // mqttEvents est un singleton — nettoyer apres chaque test pour eviter
+  // les listeners qui s'accumulent (mais on doit re-register les listeners
+  // de wsTelemetry, sinon il devient muet). Le plus simple : ne PAS
+  // removeAllListeners ici (wsTelemetry s'est abonne au beforeAll).
+})
+
+afterEach(async () => {
+  while (openSockets.length) {
+    const ws = openSockets.pop()!
+    if (ws.readyState === WebSocket.OPEN) ws.close()
+  }
+  // laisse le temps aux rooms de se vider
+  await new Promise((r) => setTimeout(r, 30))
+})
+
+function open(robotId: number): Promise<WebSocket> {
+  return new Promise((res, rej) => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws/robots/${robotId}/telemetry?token=${token}`)
+    openSockets.push(ws)
+    ws.on('open', () => res(ws))
+    ws.on('error', rej)
+  })
+}
+
+describe('wsTelemetry', () => {
+  it('isole les events par robotId (un client recoit son robot uniquement)', async () => {
+    const ws1 = await open(1)
+    const ws2 = await open(2)
+    const r1: unknown[] = []
+    const r2: unknown[] = []
+    ws1.on('message', (d) => r1.push(JSON.parse(d.toString())))
+    ws2.on('message', (d) => r2.push(JSON.parse(d.toString())))
+    mqttEvents.emit('mapping_state', { robotId: 1, state: 'RUNNING', sessionId: 99 })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(r1.some((m) => (m as { type: string; state: string }).type === 'mapping_state' && (m as { state: string }).state === 'RUNNING')).toBe(true)
+    expect(r2.length).toBe(0)
+  })
+
+  it('recoit le PNG map en frame binary + meta JSON compagnon', async () => {
+    const ws = await open(1)
+    const received: { data: Buffer | string; isBinary: boolean }[] = []
+    ws.on('message', (d, isBinary) => received.push({ data: d as Buffer, isBinary }))
+    mqttEvents.emit('map_update', {
+      robotId: 1,
+      png: Buffer.from('FAKEPNG'),
+      meta: { width: 4, height: 3, resolution: 0.05, originX: 0, originY: 0, stamp: 0 },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    const bin = received.find((r) => r.isBinary)
+    const metaFrame = received.find((r) => !r.isBinary && JSON.parse((r.data as Buffer).toString()).type === 'map_meta')
+    expect(bin).toBeDefined()
+    expect((bin!.data as Buffer)[0]).toBe(0x01)
+    expect(metaFrame).toBeDefined()
+  })
+
+  it('teleop client est forwarde sur MQTT avec clamp', async () => {
+    const ws = await open(1)
+    const calls: { id: number; action: string; body: unknown }[] = []
+    const orig = robotMqtt.publishCommand.bind(robotMqtt)
+    robotMqtt.publishCommand = ((id: number, action: string, body: object) => {
+      calls.push({ id, action, body })
+      return true
+    }) as typeof robotMqtt.publishCommand
+    try {
+      // 2.0 > clamp 0.5 — on verifie que le clamp s'applique
+      ws.send(JSON.stringify({ type: 'teleop', lin: 2.0, ang: -3.0 }))
+      await new Promise((r) => setTimeout(r, 50))
+      expect(calls).toHaveLength(1)
+      expect(calls[0].id).toBe(1)
+      expect(calls[0].action).toBe('teleop')
+      expect(calls[0].body).toEqual({ lin: 0.5, ang: -1.0 })
+    } finally {
+      robotMqtt.publishCommand = orig
+    }
+  })
+
+  it('refuse upgrade si token absent (401)', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws/robots/1/telemetry`)
+    const err = await new Promise<Error>((res) => ws.on('error', res))
+    expect(err.message).toMatch(/401|Unexpected/)
+  })
+})


### PR DESCRIPTION
## Résumé

Endpoint WS `/ws/robots/:id/telemetry?token=...` qui relaie les events MQTT mapping vers le frontend, et forward le téléop dans l'autre sens.

- Rooms par `robotId` : un client ne reçoit que les events de SON robot.
- PNG map en frame **binary** préfixée d'un byte de type (0x01) + meta JSON compagnon en frame texte (le frontend recolle).
- Events JSON broadcastés : `mapping_state`, `scan`, `plan`, `frontiers`, `annotation_*`.
- Téléop client → MQTT `cmd/teleop` avec clamp sécurité (lin ±0.5, ang ±1.0).
- Auth JWT via `?token=` (wsRouter centralisé).
- `close()` propre au shutdown SIGINT/SIGTERM.

## Tests

- 4/4 nouveaux (isolation rooms, frame binary PNG, teleop clamp, refus 401)
- 74/74 backend OK

## Hors scope

- Annotations REST CRUD → reporté (pas bloquant pour démo)
- wsTf / wsTopics → T3.5.7