### PR TITLE
feat(T3.5.8): page Mapping — start/stop/save + carte SLAM live

### DIFF
--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { MissionDetailPage } from './pages/MissionDetailPage'
 import { NewMissionPage } from './pages/NewMissionPage'
 import { AdminPage } from './pages/AdminPage'
 import { ProfilePage } from './pages/ProfilePage'
+import { MappingPage } from './pages/MappingPage'
 import { LoginPage } from './pages/LoginPage'
 import { RequireAuth } from './components/RequireAuth'
 import { useAuthStore } from './stores/authStore'
@@ -34,6 +35,7 @@ export default function App() {
               element={role === 'ADMIN' ? <AdminPage /> : <Navigate to="/" replace />}
             />
             <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/mapping" element={<MappingPage />} />
           </Route>
         </Route>
 

--- a/web/frontend/src/hooks/useMappingTelemetry.ts
+++ b/web/frontend/src/hooks/useMappingTelemetry.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import { useAuthStore } from '@/stores/authStore'
+import { useMappingStore, type MapMeta, type MappingState } from '@/stores/mappingStore'
+
+// Ouvre /ws/robots/:id/telemetry et alimente mappingStore.
+// PNG arrive en frame BINARY prefixee d'un byte de type (0x01 = map png),
+// + meta JSON envoye en frame texte separee. On recolle dans le store.
+
+const TYPE_MAP_PNG = 0x01
+
+export function useMappingTelemetry(robotId: number, enabled: boolean): void {
+  const token = useAuthStore((s) => s.token)
+  const setMapPng = useMappingStore((s) => s.setMapPng)
+  const setMapMeta = useMappingStore((s) => s.setMapMeta)
+  const setMapping = useMappingStore((s) => s.setMapping)
+  const setCoverage = useMappingStore((s) => s.setCoverage)
+  const setFailure = useMappingStore((s) => s.setFailure)
+  const setWsConnected = useMappingStore((s) => s.setWsConnected)
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !token) return
+
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${proto}//${window.location.host}/ws/robots/${robotId}/telemetry?token=${encodeURIComponent(token)}`
+    const ws = new WebSocket(url)
+    ws.binaryType = 'arraybuffer'
+    wsRef.current = ws
+
+    ws.onopen = () => setWsConnected(true)
+    ws.onclose = () => setWsConnected(false)
+    ws.onerror = () => setWsConnected(false)
+
+    ws.onmessage = (e) => {
+      if (e.data instanceof ArrayBuffer) {
+        const view = new Uint8Array(e.data)
+        if (view.length < 2 || view[0] !== TYPE_MAP_PNG) return
+        // strip le byte de type
+        const png = view.slice(1)
+        const blob = new Blob([png], { type: 'image/png' })
+        setMapPng(URL.createObjectURL(blob))
+        return
+      }
+      // frame texte = JSON
+      let msg: Record<string, unknown>
+      try {
+        msg = JSON.parse(e.data)
+      } catch {
+        return
+      }
+      switch (msg.type) {
+        case 'map_meta':
+          setMapMeta(msg.meta as MapMeta)
+          break
+        case 'mapping_state':
+          setMapping(msg.state as MappingState, (msg.sessionId as number | null) ?? null)
+          if (typeof msg.coveragePercent === 'number') setCoverage(msg.coveragePercent)
+          if (typeof msg.failureReason === 'string') setFailure(msg.failureReason)
+          else if (msg.state !== 'FAILED') setFailure(null)
+          break
+        // scan / plan / frontiers : ignores pour MVP demo
+      }
+    }
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+      setWsConnected(false)
+    }
+  }, [robotId, enabled, token, setMapPng, setMapMeta, setMapping, setCoverage, setFailure, setWsConnected])
+}

--- a/web/frontend/src/lib/mappingApi.ts
+++ b/web/frontend/src/lib/mappingApi.ts
@@ -1,0 +1,50 @@
+import { apiFetch } from './api'
+
+// Wrappers REST /api/mapping. Le JWT est ajoute automatiquement par apiFetch.
+
+export interface MappingSessionLite {
+  id: number
+  robotId: number
+  state: 'STARTING' | 'RUNNING' | 'STOPPING' | 'STOPPED' | 'FAILED'
+  startedAt: string
+  endedAt: string | null
+  coverageM2: number | null
+  failureReason: string | null
+  _count?: { snapshots: number; annotations: number }
+}
+
+export async function startMapping(robotId: number): Promise<{ sessionId: number; state: string }> {
+  const res = await apiFetch('/mapping/start', {
+    method: 'POST',
+    body: JSON.stringify({ robotId }),
+  })
+  if (!res.ok) throw new Error(`startMapping ${res.status}`)
+  return res.json()
+}
+
+export async function stopMapping(sessionId: number): Promise<{ ok: boolean }> {
+  const res = await apiFetch('/mapping/stop', {
+    method: 'POST',
+    body: JSON.stringify({ sessionId }),
+  })
+  if (!res.ok) throw new Error(`stopMapping ${res.status}`)
+  return res.json()
+}
+
+export async function saveMapping(sessionId: number, name?: string): Promise<{ snapshotId: number }> {
+  const res = await apiFetch('/mapping/save', {
+    method: 'POST',
+    body: JSON.stringify({ sessionId, ...(name ? { name } : {}) }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.reason ?? `saveMapping ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function listSessions(robotId: number): Promise<MappingSessionLite[]> {
+  const res = await apiFetch(`/mapping/sessions?robotId=${robotId}`)
+  if (!res.ok) throw new Error(`listSessions ${res.status}`)
+  return res.json()
+}

--- a/web/frontend/src/pages/DashboardPage.tsx
+++ b/web/frontend/src/pages/DashboardPage.tsx
@@ -256,6 +256,28 @@ export function DashboardPage() {
               <ArrowRight className="size-4 group-hover:translate-x-0.5 transition-transform" />
             </div>
           </Link>
+
+          <Link
+            to="/mapping"
+            className="group relative rounded-sm border border-border bg-card/40 hover:bg-card/70
+                       p-5 transition-colors flex flex-col justify-between min-h-[120px] overflow-hidden"
+          >
+            <CornerBrackets />
+            <div className="relative">
+              <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-muted-foreground mb-1">
+                · Mode mapping
+              </p>
+              <p className="font-mono text-2xl font-light text-foreground">
+                Cartographier
+              </p>
+            </div>
+            <div className="relative flex items-center justify-between text-foreground/70">
+              <span className="font-mono text-[10px] uppercase tracking-widest">
+                SLAM live
+              </span>
+              <ArrowRight className="size-4 group-hover:translate-x-0.5 transition-transform" />
+            </div>
+          </Link>
         </section>
       </div>
 

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { toast } from 'sonner'
+import { ArrowLeft, Play, Square, Save, Wifi, WifiOff, MapPin } from 'lucide-react'
+import { useRobotStore } from '../stores/robotStore'
+import { useMappingStore } from '../stores/mappingStore'
+import { useMappingTelemetry } from '../hooks/useMappingTelemetry'
+import { startMapping, stopMapping, saveMapping } from '../lib/mappingApi'
+
+const STATE_LABEL: Record<string, { label: string; color: string }> = {
+  IDLE: { label: 'En veille', color: 'bg-gray-700 text-gray-200' },
+  STARTING: { label: 'Demarrage…', color: 'bg-yellow-600 text-white' },
+  RUNNING: { label: 'Cartographie en cours', color: 'bg-green-600 text-white' },
+  STOPPING: { label: 'Arret…', color: 'bg-yellow-600 text-white' },
+  STOPPED: { label: 'Arrete', color: 'bg-gray-700 text-gray-200' },
+  FAILED: { label: 'Echec', color: 'bg-red-600 text-white' },
+}
+
+export function MappingPage() {
+  const robotId = useRobotStore((s) => s.id)
+  const robotConnected = useRobotStore((s) => s.connected)
+  const { state, sessionId, mapPngUrl, mapMeta, wsConnected, failureReason, setMapping } = useMappingStore()
+
+  // ouvre le WS telemetry (carte live)
+  useMappingTelemetry(robotId, true)
+
+  const [busy, setBusy] = useState(false)
+
+  const onStart = async (): Promise<void> => {
+    setBusy(true)
+    try {
+      const r = await startMapping(robotId)
+      setMapping('STARTING', r.sessionId)
+      toast.success(`Session ${r.sessionId} demarree`)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'erreur start')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onStop = async (): Promise<void> => {
+    if (!sessionId) return
+    setBusy(true)
+    try {
+      await stopMapping(sessionId)
+      setMapping('STOPPING', sessionId)
+      toast.success('Arret demande')
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'erreur stop')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onSave = async (): Promise<void> => {
+    if (!sessionId) return
+    setBusy(true)
+    try {
+      const r = await saveMapping(sessionId)
+      toast.success(`Carte sauvegardee (snapshot #${r.snapshotId})`)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'erreur save')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const canStart = state === 'IDLE' || state === 'STOPPED' || state === 'FAILED'
+  const canStop = state === 'STARTING' || state === 'RUNNING'
+  const canSave = state === 'RUNNING' || state === 'STOPPED'
+
+  const badge = STATE_LABEL[state] ?? STATE_LABEL.IDLE
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link to="/" className="text-gray-400 hover:text-white">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Mode mapping</h1>
+            <p className="text-sm text-gray-500 mt-0.5">Cartographie SLAM live</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          {wsConnected ? (
+            <span className="flex items-center gap-1.5 text-green-400">
+              <Wifi className="w-4 h-4" /> WS connecte
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 text-gray-500">
+              <WifiOff className="w-4 h-4" /> WS deconnecte
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Etat + boutons */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="text-xs text-gray-500 uppercase mb-1">Etat</div>
+          <span className={`inline-block px-3 py-1 rounded text-sm font-medium ${badge.color}`}>
+            {badge.label}
+          </span>
+          {sessionId && <div className="text-xs text-gray-500 mt-2">Session #{sessionId}</div>}
+          {failureReason && <div className="text-xs text-red-400 mt-2">{failureReason}</div>}
+        </div>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="text-xs text-gray-500 uppercase mb-1">Robot</div>
+          <div className="text-white font-medium">{useRobotStore.getState().name}</div>
+          <div className={`text-xs mt-1 ${robotConnected ? 'text-green-400' : 'text-gray-500'}`}>
+            {robotConnected ? 'En ligne' : 'Hors ligne'}
+          </div>
+        </div>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="text-xs text-gray-500 uppercase mb-1">Carte</div>
+          {mapMeta ? (
+            <>
+              <div className="text-white text-sm">
+                {mapMeta.width} × {mapMeta.height} px
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                resolution {mapMeta.resolution.toFixed(3)} m/px
+              </div>
+            </>
+          ) : (
+            <div className="text-gray-500 text-sm">en attente…</div>
+          )}
+        </div>
+      </div>
+
+      {/* Boutons */}
+      <div className="flex gap-3 mb-6">
+        <button
+          onClick={onStart}
+          disabled={!canStart || busy || !robotConnected}
+          className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
+        >
+          <Play className="w-4 h-4" /> Demarrer
+        </button>
+        <button
+          onClick={onStop}
+          disabled={!canStop || busy}
+          className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
+        >
+          <Square className="w-4 h-4" /> Arreter
+        </button>
+        <button
+          onClick={onSave}
+          disabled={!canSave || busy}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
+        >
+          <Save className="w-4 h-4" /> Sauvegarder
+        </button>
+      </div>
+
+      {/* Carte live */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <MapPin className="w-4 h-4 text-gray-400" />
+          <h2 className="text-sm font-medium text-gray-300">Carte SLAM live</h2>
+        </div>
+        <div className="bg-black border border-gray-900 rounded min-h-96 flex items-center justify-center overflow-hidden">
+          {mapPngUrl ? (
+            <img
+              src={mapPngUrl}
+              alt="Carte SLAM"
+              className="max-w-full max-h-[600px] object-contain"
+              style={{ imageRendering: 'pixelated' }}
+            />
+          ) : (
+            <div className="text-gray-600 text-sm py-24">
+              {state === 'RUNNING' ? 'En attente du premier frame…' : 'Demarre une session pour voir la carte'}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/stores/mappingStore.ts
+++ b/web/frontend/src/stores/mappingStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand'
+
+export type MappingState = 'IDLE' | 'STARTING' | 'RUNNING' | 'STOPPING' | 'STOPPED' | 'FAILED'
+
+export interface MapMeta {
+  width: number
+  height: number
+  resolution: number
+  originX: number
+  originY: number
+  stamp: number
+}
+
+interface MappingStore {
+  state: MappingState
+  sessionId: number | null
+  mapPngUrl: string | null
+  mapMeta: MapMeta | null
+  coveragePercent: number | null
+  failureReason: string | null
+  wsConnected: boolean
+
+  setState: (state: MappingState) => void
+  setSession: (sessionId: number | null) => void
+  setMapping: (s: MappingState, sessionId: number | null) => void
+  setMapPng: (url: string | null) => void
+  setMapMeta: (meta: MapMeta) => void
+  setCoverage: (percent: number | null) => void
+  setFailure: (reason: string | null) => void
+  setWsConnected: (b: boolean) => void
+  reset: () => void
+}
+
+export const useMappingStore = create<MappingStore>((set, get) => ({
+  state: 'IDLE',
+  sessionId: null,
+  mapPngUrl: null,
+  mapMeta: null,
+  coveragePercent: null,
+  failureReason: null,
+  wsConnected: false,
+
+  setState: (state) => set({ state }),
+  setSession: (sessionId) => set({ sessionId }),
+  setMapping: (state, sessionId) => set({ state, sessionId }),
+
+  setMapPng: (url) => {
+    // revoke l'ancien blob URL pour eviter la fuite memoire
+    const prev = get().mapPngUrl
+    if (prev) URL.revokeObjectURL(prev)
+    set({ mapPngUrl: url })
+  },
+  setMapMeta: (meta) => set({ mapMeta: meta }),
+  setCoverage: (percent) => set({ coveragePercent: percent }),
+  setFailure: (reason) => set({ failureReason: reason }),
+  setWsConnected: (b) => set({ wsConnected: b }),
+
+  reset: () => {
+    const prev = get().mapPngUrl
+    if (prev) URL.revokeObjectURL(prev)
+    set({
+      state: 'IDLE',
+      sessionId: null,
+      mapPngUrl: null,
+      mapMeta: null,
+      coveragePercent: null,
+      failureReason: null,
+    })
+  },
+}))


### PR DESCRIPTION
## Résumé

Page \`/mapping\` accessible depuis le Dashboard, qui pilote le mode cartographie SLAM du robot.

### Ajouts
- **lib/mappingApi.ts** : wrappers REST start / stop / save / listSessions
- **stores/mappingStore.ts** : état (IDLE → STARTING → RUNNING → STOPPING → STOPPED/FAILED), sessionId, blob URL carte, meta
- **hooks/useMappingTelemetry.ts** : ouvre \`/ws/robots/:id/telemetry\`, recolle PNG binary (byte 0x01) + meta JSON, alimente le store, revoke proprement les blob URLs
- **pages/MappingPage.tsx** : header + badge état + carte robot + carte info + boutons Démarrer / Arrêter / Sauvegarder + img live
- **DashboardPage** : nouvelle tuile \"Mode mapping → Cartographier\"
- **App.tsx** : route \`/mapping\` derrière RequireAuth

### Vérifs

- \`npm run build\` clean
- \`npm test\` 4/4 OK
- ESLint clean sur nouveaux fichiers

### Hors scope

- Téléop joystick UI → Plan 4
- Annotations sur carte → Plan 4
- Liste historique sessions → bonus / Plan 5

## Démo

1. Login → Dashboard → click \"Mode mapping\"
2. Bouton \"Démarrer\" → robot lance \`explore.launch.py\`
3. Carte SLAM apparaît live (PNG via WS)
4. \"Sauvegarder\" → snapshot DB + fichier disque
5. \"Arrêter\" → robot stoppe le mapping