### PR TITLE
fix(mapping): durcissement démo — sharp PNG + reconnect + historique + heartbeat + téléop

### DIFF
--- a/web/backend/src/lib/mapStorage.ts
+++ b/web/backend/src/lib/mapStorage.ts
@@ -1,10 +1,11 @@
 // Ecriture/lecture des cartes SLAM (PGM + YAML + PNG) sur disque.
 // Stockage : web/backend/maps/<snapshotId>.{pgm,yaml,png}
-// Le PNG MVP = copie du PGM (le frontend recoit le live PNG via /telemetry/map).
+// PNG genere via sharp (libvips lit le PGM raw natif).
 
 import { writeFile, mkdir, readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
+import sharp from 'sharp'
 
 const MAPS_DIR = path.resolve(process.cwd(), 'maps')
 
@@ -24,8 +25,17 @@ export async function saveSnapshotFiles(
   const pngPath = path.join(MAPS_DIR, `${snapshotId}.png`)
   await writeFile(pgmPath, pgmBuf)
   await writeFile(yamlPath, yamlContent)
-  // todo: convertir PGM -> PNG via sharp (cf. mapController). MVP : copie brute.
-  await writeFile(pngPath, pgmBuf)
+  // sharp lit le PGM raw via libvips, sortie PNG vraie -> le snapshot est
+  // ouvrable directement dans n'importe quel viewer (vs PGM = niche).
+  try {
+    const pngBuf = await sharp(pgmBuf).png().toBuffer()
+    await writeFile(pngPath, pngBuf)
+  } catch (err) {
+    // fallback PGM brut si sharp echoue (PGM mal forme ?) — on prefere
+    // garder un fichier que rien du tout, le snapshot reste recuperable.
+    console.error('[mapStorage] sharp PGM->PNG echec :', err instanceof Error ? err.message : err)
+    await writeFile(pngPath, pgmBuf)
+  }
   return { pgmPath, yamlPath, pngPath, sizeBytes: pgmBuf.length }
 }
 

--- a/web/frontend/src/components/MappingSessionsList.tsx
+++ b/web/frontend/src/components/MappingSessionsList.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { History, RefreshCw } from 'lucide-react'
+import { listSessions, type MappingSessionLite } from '@/lib/mappingApi'
+
+interface Props {
+  robotId: number
+  // refreshKey change quand on veut force-refresh (apres start/stop/save)
+  refreshKey?: number
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleString('fr-FR', {
+    day: '2-digit', month: '2-digit', year: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function fmtDuration(startedAt: string, endedAt: string | null): string {
+  const start = new Date(startedAt).getTime()
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now()
+  const sec = Math.floor((end - start) / 1000)
+  if (sec < 60) return `${sec}s`
+  const m = Math.floor(sec / 60)
+  return `${m}m${sec % 60 < 10 ? '0' : ''}${sec % 60}`
+}
+
+const STATE_COLOR: Record<string, string> = {
+  STARTING: 'text-yellow-400',
+  RUNNING: 'text-green-400',
+  STOPPING: 'text-yellow-400',
+  STOPPED: 'text-gray-400',
+  FAILED: 'text-red-400',
+}
+
+export function MappingSessionsList({ robotId, refreshKey }: Props) {
+  const [sessions, setSessions] = useState<MappingSessionLite[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listSessions(robotId)
+      setSessions(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'erreur chargement')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [robotId, refreshKey])
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <History className="w-4 h-4 text-gray-400" />
+          <h2 className="text-sm font-medium text-gray-300">Historique sessions</h2>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="text-gray-500 hover:text-white disabled:opacity-50"
+          aria-label="Rafraichir"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {error && <div className="text-xs text-red-400 mb-2">{error}</div>}
+
+      {sessions.length === 0 && !loading && (
+        <div className="text-xs text-gray-500 py-4">Aucune session pour ce robot.</div>
+      )}
+
+      <ul className="space-y-2">
+        {sessions.slice(0, 10).map((s) => (
+          <li key={s.id} className="flex items-center justify-between text-sm border-b border-gray-800 pb-2 last:border-0">
+            <div>
+              <div className="text-gray-200">
+                #{s.id} <span className={STATE_COLOR[s.state] ?? 'text-gray-400'}>{s.state}</span>
+              </div>
+              <div className="text-xs text-gray-500">
+                {fmtDate(s.startedAt)} · {fmtDuration(s.startedAt, s.endedAt)}
+                {s._count && ` · ${s._count.snapshots} carte${s._count.snapshots > 1 ? 's' : ''}`}
+              </div>
+              {s.failureReason && <div className="text-xs text-red-400 mt-0.5">{s.failureReason}</div>}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/web/frontend/src/components/TeleopPanel.tsx
+++ b/web/frontend/src/components/TeleopPanel.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState, useRef } from 'react'
+import { Gamepad2, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Square } from 'lucide-react'
+import { sendTeleop } from '@/hooks/useMappingTelemetry'
+
+// Joystick clavier + boutons. Dead-man : on republie {lin,ang} a 10Hz tant
+// qu'une touche est tenue. Au keyup -> envoie {0,0} pour stopper.
+// Le backend clamp deja (±0.5 / ±1.0) mais on reste prudents cote front.
+
+const SPEED_LIN = 0.2
+const SPEED_ANG = 0.5
+const TICK_MS = 100
+
+type Key = 'forward' | 'backward' | 'left' | 'right'
+
+const KEY_MAP: Record<string, Key> = {
+  ArrowUp: 'forward', w: 'forward', z: 'forward',
+  ArrowDown: 'backward', s: 'backward',
+  ArrowLeft: 'left', a: 'left', q: 'left',
+  ArrowRight: 'right', d: 'right',
+}
+
+interface Props {
+  enabled: boolean
+}
+
+export function TeleopPanel({ enabled }: Props) {
+  const [pressed, setPressed] = useState<Set<Key>>(new Set())
+  const pressedRef = useRef<Set<Key>>(new Set())
+
+  // sync ref + state pour acces synchrone dans le tick
+  const setKeyState = (k: Key, on: boolean): void => {
+    pressedRef.current = new Set(pressedRef.current)
+    if (on) pressedRef.current.add(k)
+    else pressedRef.current.delete(k)
+    setPressed(new Set(pressedRef.current))
+  }
+
+  useEffect(() => {
+    if (!enabled) return
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const k = KEY_MAP[e.key]
+      if (!k) return
+      // ne pas bloquer les inputs (textarea/input)
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      e.preventDefault()
+      setKeyState(k, true)
+    }
+    const onKeyUp = (e: KeyboardEvent): void => {
+      const k = KEY_MAP[e.key]
+      if (!k) return
+      setKeyState(k, false)
+    }
+    const onBlur = (): void => {
+      // perte de focus = on relache tout (sinon le robot continue)
+      pressedRef.current = new Set()
+      setPressed(new Set())
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+    let lastWasZero = true
+    const tick = (): void => {
+      const p = pressedRef.current
+      let lin = 0
+      let ang = 0
+      if (p.has('forward')) lin += SPEED_LIN
+      if (p.has('backward')) lin -= SPEED_LIN
+      // attention : 'left' = tourner a gauche => ang positif en ROS REP-103
+      if (p.has('left')) ang += SPEED_ANG
+      if (p.has('right')) ang -= SPEED_ANG
+
+      const isZero = lin === 0 && ang === 0
+      // si on est en stop continu, inutile de spammer le broker
+      if (isZero && lastWasZero) return
+      sendTeleop(lin, ang)
+      lastWasZero = isZero
+    }
+    const id = setInterval(tick, TICK_MS)
+    return () => {
+      clearInterval(id)
+      // safety : envoie un stop au demontage
+      sendTeleop(0, 0)
+    }
+  }, [enabled])
+
+  const stop = (): void => {
+    pressedRef.current = new Set()
+    setPressed(new Set())
+    sendTeleop(0, 0)
+  }
+
+  const btnStyle = (active: boolean): string =>
+    `w-12 h-12 flex items-center justify-center rounded border ${
+      active
+        ? 'bg-blue-600 border-blue-400 text-white'
+        : 'bg-gray-800 border-gray-700 text-gray-400'
+    } disabled:opacity-40`
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Gamepad2 className="w-4 h-4 text-gray-400" />
+          <h2 className="text-sm font-medium text-gray-300">Téléop</h2>
+        </div>
+        <button
+          onClick={stop}
+          disabled={!enabled}
+          className="text-xs flex items-center gap-1 px-2 py-1 bg-red-600 hover:bg-red-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded"
+        >
+          <Square className="w-3 h-3" /> STOP
+        </button>
+      </div>
+
+      <div className="text-xs text-gray-500 mb-3">
+        Touches : ↑ ↓ ← → ou ZQSD / WASD. Active uniquement pendant RUNNING.
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 max-w-[180px] mx-auto">
+        <div />
+        <button
+          disabled={!enabled}
+          className={btnStyle(pressed.has('forward'))}
+          onMouseDown={() => setKeyState('forward', true)}
+          onMouseUp={() => setKeyState('forward', false)}
+          onMouseLeave={() => setKeyState('forward', false)}
+        >
+          <ArrowUp className="w-5 h-5" />
+        </button>
+        <div />
+
+        <button
+          disabled={!enabled}
+          className={btnStyle(pressed.has('left'))}
+          onMouseDown={() => setKeyState('left', true)}
+          onMouseUp={() => setKeyState('left', false)}
+          onMouseLeave={() => setKeyState('left', false)}
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <button
+          disabled={!enabled}
+          className={btnStyle(pressed.has('backward'))}
+          onMouseDown={() => setKeyState('backward', true)}
+          onMouseUp={() => setKeyState('backward', false)}
+          onMouseLeave={() => setKeyState('backward', false)}
+        >
+          <ArrowDown className="w-5 h-5" />
+        </button>
+        <button
+          disabled={!enabled}
+          className={btnStyle(pressed.has('right'))}
+          onMouseDown={() => setKeyState('right', true)}
+          onMouseUp={() => setKeyState('right', false)}
+          onMouseLeave={() => setKeyState('right', false)}
+        >
+          <ArrowRight className="w-5 h-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/hooks/useMappingTelemetry.ts
+++ b/web/frontend/src/hooks/useMappingTelemetry.ts
@@ -5,8 +5,10 @@ import { useMappingStore, type MapMeta, type MappingState } from '@/stores/mappi
 // Ouvre /ws/robots/:id/telemetry et alimente mappingStore.
 // PNG arrive en frame BINARY prefixee d'un byte de type (0x01 = map png),
 // + meta JSON envoye en frame texte separee. On recolle dans le store.
+// Reconnect auto avec backoff 1/2/4/8s (cap 30s) — comme wsClient legacy.
 
 const TYPE_MAP_PNG = 0x01
+const MAX_BACKOFF_MS = 30_000
 
 export function useMappingTelemetry(robotId: number, enabled: boolean): void {
   const token = useAuthStore((s) => s.token)
@@ -16,56 +18,95 @@ export function useMappingTelemetry(robotId: number, enabled: boolean): void {
   const setCoverage = useMappingStore((s) => s.setCoverage)
   const setFailure = useMappingStore((s) => s.setFailure)
   const setWsConnected = useMappingStore((s) => s.setWsConnected)
+  const setLastTelemetry = useMappingStore((s) => s.setLastTelemetry)
   const wsRef = useRef<WebSocket | null>(null)
+  const cancelledRef = useRef(false)
+  const retryCountRef = useRef(0)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!enabled || !token) return
+    cancelledRef.current = false
+    retryCountRef.current = 0
 
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const url = `${proto}//${window.location.host}/ws/robots/${robotId}/telemetry?token=${encodeURIComponent(token)}`
-    const ws = new WebSocket(url)
-    ws.binaryType = 'arraybuffer'
-    wsRef.current = ws
 
-    ws.onopen = () => setWsConnected(true)
-    ws.onclose = () => setWsConnected(false)
-    ws.onerror = () => setWsConnected(false)
+    function connect(): void {
+      if (cancelledRef.current) return
+      const ws = new WebSocket(url)
+      ws.binaryType = 'arraybuffer'
+      wsRef.current = ws
+      currentWs = ws
 
-    ws.onmessage = (e) => {
-      if (e.data instanceof ArrayBuffer) {
-        const view = new Uint8Array(e.data)
-        if (view.length < 2 || view[0] !== TYPE_MAP_PNG) return
-        // strip le byte de type
-        const png = view.slice(1)
-        const blob = new Blob([png], { type: 'image/png' })
-        setMapPng(URL.createObjectURL(blob))
-        return
+      ws.onopen = () => {
+        retryCountRef.current = 0
+        setWsConnected(true)
       }
-      // frame texte = JSON
-      let msg: Record<string, unknown>
-      try {
-        msg = JSON.parse(e.data)
-      } catch {
-        return
+
+      ws.onclose = () => {
+        setWsConnected(false)
+        if (currentWs === ws) currentWs = null
+        if (cancelledRef.current) return
+        const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** retryCountRef.current)
+        retryCountRef.current += 1
+        retryTimerRef.current = setTimeout(connect, delay)
       }
-      switch (msg.type) {
-        case 'map_meta':
-          setMapMeta(msg.meta as MapMeta)
-          break
-        case 'mapping_state':
-          setMapping(msg.state as MappingState, (msg.sessionId as number | null) ?? null)
-          if (typeof msg.coveragePercent === 'number') setCoverage(msg.coveragePercent)
-          if (typeof msg.failureReason === 'string') setFailure(msg.failureReason)
-          else if (msg.state !== 'FAILED') setFailure(null)
-          break
-        // scan / plan / frontiers : ignores pour MVP demo
+
+      ws.onerror = () => {
+        // close suivra et declenchera le retry
+      }
+
+      ws.onmessage = (e) => {
+        setLastTelemetry(Date.now())
+        if (e.data instanceof ArrayBuffer) {
+          const view = new Uint8Array(e.data)
+          if (view.length < 2 || view[0] !== TYPE_MAP_PNG) return
+          const png = view.slice(1)
+          const blob = new Blob([png], { type: 'image/png' })
+          setMapPng(URL.createObjectURL(blob))
+          return
+        }
+        let msg: Record<string, unknown>
+        try {
+          msg = JSON.parse(e.data)
+        } catch {
+          return
+        }
+        switch (msg.type) {
+          case 'map_meta':
+            setMapMeta(msg.meta as MapMeta)
+            break
+          case 'mapping_state':
+            setMapping(msg.state as MappingState, (msg.sessionId as number | null) ?? null)
+            if (typeof msg.coveragePercent === 'number') setCoverage(msg.coveragePercent)
+            if (typeof msg.failureReason === 'string') setFailure(msg.failureReason)
+            else if (msg.state !== 'FAILED') setFailure(null)
+            break
+          // scan / plan / frontiers : ignores pour MVP demo
+        }
       }
     }
+
+    connect()
 
     return () => {
-      ws.close()
+      cancelledRef.current = true
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
+      wsRef.current?.close()
       wsRef.current = null
+      currentWs = null
       setWsConnected(false)
     }
-  }, [robotId, enabled, token, setMapPng, setMapMeta, setMapping, setCoverage, setFailure, setWsConnected])
+  }, [robotId, enabled, token, setMapPng, setMapMeta, setMapping, setCoverage, setFailure, setWsConnected, setLastTelemetry])
+}
+
+// module-level ref vers le WS courant — utilise par sendTeleop (item teleop UI).
+let currentWs: WebSocket | null = null
+
+/** Envoie un message teleop sur le WS courant. Renvoie false si pas connecte. */
+export function sendTeleop(lin: number, ang: number): boolean {
+  if (!currentWs || currentWs.readyState !== WebSocket.OPEN) return false
+  currentWs.send(JSON.stringify({ type: 'teleop', lin, ang }))
+  return true
 }

--- a/web/frontend/src/hooks/useStaleness.ts
+++ b/web/frontend/src/hooks/useStaleness.ts
@@ -2,8 +2,12 @@ import { useEffect, useState } from 'react'
 import { useMappingStore } from '@/stores/mappingStore'
 
 // Renvoie true si on est en RUNNING/STARTING/STOPPING et qu'aucun message
-// telemetry n'a ete recu depuis `thresholdMs`. Re-evalue toutes les secondes.
-// Permet d'afficher un badge "perte signal robot" pendant la demo si MQTT lag.
+// telemetry n'a ete recu depuis `thresholdMs`. Re-evalue toutes les secondes
+// dans un setInterval (l'update setState async satisfait react-hooks/purity
+// et react-hooks/set-state-in-effect — Date.now est dans le tick, pas dans
+// le render).
+
+const ACTIVE_STATES = new Set(['STARTING', 'RUNNING', 'STOPPING'])
 
 export function useMappingStaleness(thresholdMs = 10_000): boolean {
   const state = useMappingStore((s) => s.state)
@@ -11,20 +15,14 @@ export function useMappingStaleness(thresholdMs = 10_000): boolean {
   const [stale, setStale] = useState(false)
 
   useEffect(() => {
-    const activeStates = ['STARTING', 'RUNNING', 'STOPPING']
-    if (!activeStates.includes(state)) {
-      setStale(false)
-      return
+    const compute = (): boolean => {
+      if (!ACTIVE_STATES.has(state)) return false
+      if (!lastTelemetryAt) return true
+      return Date.now() - lastTelemetryAt > thresholdMs
     }
-    const tick = (): void => {
-      if (!lastTelemetryAt) {
-        setStale(true)
-        return
-      }
-      setStale(Date.now() - lastTelemetryAt > thresholdMs)
-    }
-    tick()
-    const id = setInterval(tick, 1000)
+    // Pas de tick initial synchrone (sinon eslint set-state-in-effect).
+    // Le premier tick arrive au bout de 1s — acceptable.
+    const id = setInterval(() => setStale(compute()), 1000)
     return () => clearInterval(id)
   }, [state, lastTelemetryAt, thresholdMs])
 

--- a/web/frontend/src/hooks/useStaleness.ts
+++ b/web/frontend/src/hooks/useStaleness.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { useMappingStore } from '@/stores/mappingStore'
+
+// Renvoie true si on est en RUNNING/STARTING/STOPPING et qu'aucun message
+// telemetry n'a ete recu depuis `thresholdMs`. Re-evalue toutes les secondes.
+// Permet d'afficher un badge "perte signal robot" pendant la demo si MQTT lag.
+
+export function useMappingStaleness(thresholdMs = 10_000): boolean {
+  const state = useMappingStore((s) => s.state)
+  const lastTelemetryAt = useMappingStore((s) => s.lastTelemetryAt)
+  const [stale, setStale] = useState(false)
+
+  useEffect(() => {
+    const activeStates = ['STARTING', 'RUNNING', 'STOPPING']
+    if (!activeStates.includes(state)) {
+      setStale(false)
+      return
+    }
+    const tick = (): void => {
+      if (!lastTelemetryAt) {
+        setStale(true)
+        return
+      }
+      setStale(Date.now() - lastTelemetryAt > thresholdMs)
+    }
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [state, lastTelemetryAt, thresholdMs])
+
+  return stale
+}

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -5,7 +5,10 @@ import { ArrowLeft, Play, Square, Save, Wifi, WifiOff, MapPin } from 'lucide-rea
 import { useRobotStore } from '../stores/robotStore'
 import { useMappingStore } from '../stores/mappingStore'
 import { useMappingTelemetry } from '../hooks/useMappingTelemetry'
+import { useMappingStaleness } from '../hooks/useStaleness'
 import { startMapping, stopMapping, saveMapping } from '../lib/mappingApi'
+import { MappingSessionsList } from '../components/MappingSessionsList'
+import { TeleopPanel } from '../components/TeleopPanel'
 
 const STATE_LABEL: Record<string, { label: string; color: string }> = {
   IDLE: { label: 'En veille', color: 'bg-gray-700 text-gray-200' },
@@ -23,8 +26,10 @@ export function MappingPage() {
 
   // ouvre le WS telemetry (carte live)
   useMappingTelemetry(robotId, true)
+  const stale = useMappingStaleness()
 
   const [busy, setBusy] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   const onStart = async (): Promise<void> => {
     setBusy(true)
@@ -32,6 +37,7 @@ export function MappingPage() {
       const r = await startMapping(robotId)
       setMapping('STARTING', r.sessionId)
       toast.success(`Session ${r.sessionId} demarree`)
+      setRefreshKey((k) => k + 1)
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'erreur start')
     } finally {
@@ -46,6 +52,7 @@ export function MappingPage() {
       await stopMapping(sessionId)
       setMapping('STOPPING', sessionId)
       toast.success('Arret demande')
+      setRefreshKey((k) => k + 1)
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'erreur stop')
     } finally {
@@ -59,6 +66,7 @@ export function MappingPage() {
     try {
       const r = await saveMapping(sessionId)
       toast.success(`Carte sauvegardee (snapshot #${r.snapshotId})`)
+      setRefreshKey((k) => k + 1)
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'erreur save')
     } finally {
@@ -85,7 +93,12 @@ export function MappingPage() {
             <p className="text-sm text-gray-500 mt-0.5">Cartographie SLAM live</p>
           </div>
         </div>
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex items-center gap-3 text-sm">
+          {stale && (
+            <span className="px-2 py-0.5 rounded bg-yellow-600 text-white text-xs font-medium">
+              Perte signal robot
+            </span>
+          )}
           {wsConnected ? (
             <span className="flex items-center gap-1.5 text-green-400">
               <Wifi className="w-4 h-4" /> WS connecte
@@ -159,8 +172,9 @@ export function MappingPage() {
         </button>
       </div>
 
-      {/* Carte live */}
-      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+      {/* Carte live + historique sessions cote a cote */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-lg p-4">
         <div className="flex items-center gap-2 mb-3">
           <MapPin className="w-4 h-4 text-gray-400" />
           <h2 className="text-sm font-medium text-gray-300">Carte SLAM live</h2>
@@ -179,6 +193,12 @@ export function MappingPage() {
             </div>
           )}
         </div>
+      </div>
+
+      <div className="space-y-4">
+        <TeleopPanel enabled={state === 'RUNNING' && wsConnected} />
+        <MappingSessionsList robotId={robotId} refreshKey={refreshKey} />
+      </div>
       </div>
     </div>
   )

--- a/web/frontend/src/stores/mappingStore.ts
+++ b/web/frontend/src/stores/mappingStore.ts
@@ -19,6 +19,7 @@ interface MappingStore {
   coveragePercent: number | null
   failureReason: string | null
   wsConnected: boolean
+  lastTelemetryAt: number | null
 
   setState: (state: MappingState) => void
   setSession: (sessionId: number | null) => void
@@ -28,6 +29,7 @@ interface MappingStore {
   setCoverage: (percent: number | null) => void
   setFailure: (reason: string | null) => void
   setWsConnected: (b: boolean) => void
+  setLastTelemetry: (ts: number) => void
   reset: () => void
 }
 
@@ -39,6 +41,7 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   coveragePercent: null,
   failureReason: null,
   wsConnected: false,
+  lastTelemetryAt: null,
 
   setState: (state) => set({ state }),
   setSession: (sessionId) => set({ sessionId }),
@@ -54,6 +57,7 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   setCoverage: (percent) => set({ coveragePercent: percent }),
   setFailure: (reason) => set({ failureReason: reason }),
   setWsConnected: (b) => set({ wsConnected: b }),
+  setLastTelemetry: (ts) => set({ lastTelemetryAt: ts }),
 
   reset: () => {
     const prev = get().mapPngUrl


### PR DESCRIPTION
## Résumé

Hardening du mode mapping en vue de la démo. Tous les bloquants 🔴 et les améliorations ops 🟡 identifiés post-T3.5.8.

### 🔴 Bloquants
- **PGM → PNG** : `saveSnapshotFiles` convertit désormais via `sharp` (libvips). Avant, on copiait le PGM brut dans le `.png` → fichier non ouvrable.
- **Vérifs bridge robot** : la chaîne `telemetry/map`+`telemetry/map_meta` et `mapping/save-result` est bien câblée côté `mqtt_bridge.py` + `mapping_supervisor.py`. Pas de fix robot à faire.
- **Smoke local** : `/health` 200, `/api/mapping/sessions` 401 sans token, mosquitto + mysql up.

### 🟡 Améliorations ops
- **Reconnect WS auto** dans `useMappingTelemetry` avec backoff 1/2/4/8s (cap 30s) — la démo survit aux coupures réseau.
- **Historique sessions** : composant `MappingSessionsList` qui consomme `GET /api/mapping/sessions`, refresh auto après start/stop/save.
- **Heartbeat staleness** : hook `useMappingStaleness` affiche un badge \"Perte signal robot\" si pas de telemetry depuis 10s pendant un état actif. Toujours utile si le robot crash en démo.
- **Téléop UI** : `TeleopPanel` avec touches ↑↓←→ / WASD / ZQSD + boutons souris. Republication à 10Hz tant qu'enfoncé, stop au keyup et au blur (perte focus). Activé uniquement en RUNNING.

### Vérifs

- `npm run build` clean (backend + frontend)
- `npm test` 74/74 backend OK
- ESLint clean

### Reste après ça (🟢 → autre PR)

- Authz teleop par robot (tous les users authentifiés peuvent encore teleop n'importe quel robot)
- robot.id dynamique multi-robot
- E2E Playwright

## Démo après merge

1. Restart backend pour charger fix sharp
2. Login → Mode mapping
3. Démarrer → carte live + sessions list
4. Tester ↑ pour avancer pendant RUNNING
5. Couper le WiFi 5s → badge \"Perte signal\" → reconnect auto
6. Sauvegarder → vérifier `.png` ouvrable