### PR TITLE
chore(mapping): polish démo — authz teleop + multi-robot URL + E2E smoke

### DIFF
--- a/web/backend/src/services/wsTelemetry.ts
+++ b/web/backend/src/services/wsTelemetry.ts
@@ -2,6 +2,7 @@ import { WebSocketServer, WebSocket, type RawData } from 'ws'
 import { wsRouter } from './wsRouter'
 import { mqttEvents } from './mqttEvents'
 import { robotMqtt } from './mqtt'
+import prisma from '../lib/prisma'
 
 // WS endpoint /ws/robots/:id/telemetry (T3.5.6).
 // Groupe les clients par robotId (room). Chaque event mqtt mapping est
@@ -23,15 +24,36 @@ class WsTelemetry {
     if (this.wss) return
     this.wss = new WebSocketServer({ noServer: true })
 
-    wsRouter.register('/ws/robots/:id/telemetry', ({ req, socket, head, params }) => {
+    wsRouter.register('/ws/robots/:id/telemetry', ({ req, socket, head, params, decodedToken }) => {
       const robotId = Number(params.id)
       if (!Number.isInteger(robotId) || robotId <= 0) {
         socket.destroy()
         return
       }
-      this.wss!.handleUpgrade(req, socket, head, (ws) => {
-        this.attachClient(robotId, ws)
-      })
+      // verifier l'existence du robot — refuse upgrade pour les ids inconnus.
+      // Le user est deja authentifie par wsRouter (JWT valide). Pour l'instant
+      // tout user authentifie peut s'abonner a n'importe quel robot existant.
+      // Modele permissions par robot = a faire dans une vraie multi-tenant.
+      const userId = typeof decodedToken === 'object' && decodedToken !== null
+        ? (decodedToken as { userId?: number }).userId
+        : undefined
+      void prisma.robot
+        .findUnique({ where: { id: robotId }, select: { id: true } })
+        .then((robot) => {
+          if (!robot) {
+            socket.write('HTTP/1.1 404 Not Found\r\n\r\n')
+            socket.destroy()
+            return
+          }
+          this.wss!.handleUpgrade(req, socket, head, (ws) => {
+            this.attachClient(robotId, ws, userId)
+          })
+        })
+        .catch((err) => {
+          console.error('[ws] robot lookup echec :', err instanceof Error ? err.message : err)
+          socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n')
+          socket.destroy()
+        })
     })
 
     mqttEvents.on('map_update', (e) => this.broadcastMap(e.robotId, e.png, e.meta))
@@ -48,14 +70,14 @@ class WsTelemetry {
     console.log('[ws] wsTelemetry registered on /ws/robots/:id/telemetry')
   }
 
-  private attachClient(robotId: number, ws: WebSocket): void {
+  private attachClient(robotId: number, ws: WebSocket, userId?: number): void {
     let room = this.rooms.get(robotId)
     if (!room) {
       room = new Set()
       this.rooms.set(robotId, room)
     }
     room.add(ws)
-    ws.on('message', (data) => this.onClientMessage(robotId, ws, data))
+    ws.on('message', (data) => this.onClientMessage(robotId, ws, data, userId))
     ws.on('close', () => {
       room!.delete(ws)
       if (room!.size === 0) this.rooms.delete(robotId)
@@ -63,7 +85,7 @@ class WsTelemetry {
     ws.on('error', () => ws.close())
   }
 
-  private onClientMessage(robotId: number, _ws: WebSocket, data: RawData): void {
+  private onClientMessage(robotId: number, _ws: WebSocket, data: RawData, userId?: number): void {
     let msg: { type?: string; lin?: unknown; ang?: unknown }
     try {
       msg = JSON.parse(data.toString())
@@ -77,6 +99,11 @@ class WsTelemetry {
       // clamp securite — vitesses brutes refusees (cf. spec §5.5 dead-man)
       const cLin = Math.max(-0.5, Math.min(0.5, lin))
       const cAng = Math.max(-1.0, Math.min(1.0, ang))
+      // userId logge pour audit minimal (qui pilote quoi). Pas de table dediee
+      // pour l'instant — la trace finit en console.log a defaut.
+      if (cLin !== 0 || cAng !== 0) {
+        console.log(`[teleop] user=${userId ?? '?'} robot=${robotId} lin=${cLin} ang=${cAng}`)
+      }
       robotMqtt.publishCommand(robotId, 'teleop', { lin: cLin, ang: cAng })
     }
     // type === 'subscribe' / autre : no-op MVP (tous canaux actifs par defaut)

--- a/web/backend/src/test/wsTelemetry.test.ts
+++ b/web/backend/src/test/wsTelemetry.test.ts
@@ -2,18 +2,30 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import http from 'node:http'
 import WebSocket from 'ws'
 import jwt from 'jsonwebtoken'
+import { PrismaClient } from '@prisma/client'
 import { wsRouter } from '../services/wsRouter'
 import { wsTelemetry } from '../services/wsTelemetry'
 import { mqttEvents } from '../services/mqttEvents'
 import { robotMqtt } from '../services/mqtt'
 import { getJwtSecret } from '../middleware/auth'
 
+const prisma = new PrismaClient()
+
 let server: http.Server
 let port: number
 let token: string
+let robotIdA: number
+let robotIdB: number
 const openSockets: WebSocket[] = []
 
 beforeAll(async () => {
+  // wsTelemetry verifie l'existence du Robot en DB a l'upgrade — on cree
+  // 2 robots de test (un par room) et on retient leurs ids pour les tests.
+  const a = await prisma.robot.create({ data: { name: `wt-a-${Date.now()}` } })
+  const b = await prisma.robot.create({ data: { name: `wt-b-${Date.now()}` } })
+  robotIdA = a.id
+  robotIdB = b.id
+
   server = http.createServer((_req, res) => res.end('ok'))
   wsRouter.attach(server)
   wsTelemetry.register()
@@ -22,9 +34,12 @@ beforeAll(async () => {
   token = jwt.sign({ userId: 1, email: 'x@x', role: 'USER' }, getJwtSecret(), { expiresIn: '5m' })
 })
 
-afterAll(() => {
+afterAll(async () => {
   wsTelemetry.close()
   server.close()
+  await prisma.robot.delete({ where: { id: robotIdA } }).catch(() => {})
+  await prisma.robot.delete({ where: { id: robotIdB } }).catch(() => {})
+  await prisma.$disconnect()
 })
 
 beforeEach(() => {
@@ -54,24 +69,24 @@ function open(robotId: number): Promise<WebSocket> {
 
 describe('wsTelemetry', () => {
   it('isole les events par robotId (un client recoit son robot uniquement)', async () => {
-    const ws1 = await open(1)
-    const ws2 = await open(2)
+    const ws1 = await open(robotIdA)
+    const ws2 = await open(robotIdB)
     const r1: unknown[] = []
     const r2: unknown[] = []
     ws1.on('message', (d) => r1.push(JSON.parse(d.toString())))
     ws2.on('message', (d) => r2.push(JSON.parse(d.toString())))
-    mqttEvents.emit('mapping_state', { robotId: 1, state: 'RUNNING', sessionId: 99 })
+    mqttEvents.emit('mapping_state', { robotId: robotIdA, state: 'RUNNING', sessionId: 99 })
     await new Promise((r) => setTimeout(r, 50))
     expect(r1.some((m) => (m as { type: string; state: string }).type === 'mapping_state' && (m as { state: string }).state === 'RUNNING')).toBe(true)
     expect(r2.length).toBe(0)
   })
 
   it('recoit le PNG map en frame binary + meta JSON compagnon', async () => {
-    const ws = await open(1)
+    const ws = await open(robotIdA)
     const received: { data: Buffer | string; isBinary: boolean }[] = []
     ws.on('message', (d, isBinary) => received.push({ data: d as Buffer, isBinary }))
     mqttEvents.emit('map_update', {
-      robotId: 1,
+      robotId: robotIdA,
       png: Buffer.from('FAKEPNG'),
       meta: { width: 4, height: 3, resolution: 0.05, originX: 0, originY: 0, stamp: 0 },
     })
@@ -84,7 +99,7 @@ describe('wsTelemetry', () => {
   })
 
   it('teleop client est forwarde sur MQTT avec clamp', async () => {
-    const ws = await open(1)
+    const ws = await open(robotIdA)
     const calls: { id: number; action: string; body: unknown }[] = []
     const orig = robotMqtt.publishCommand.bind(robotMqtt)
     robotMqtt.publishCommand = ((id: number, action: string, body: object) => {
@@ -96,7 +111,7 @@ describe('wsTelemetry', () => {
       ws.send(JSON.stringify({ type: 'teleop', lin: 2.0, ang: -3.0 }))
       await new Promise((r) => setTimeout(r, 50))
       expect(calls).toHaveLength(1)
-      expect(calls[0].id).toBe(1)
+      expect(calls[0].id).toBe(robotIdA)
       expect(calls[0].action).toBe('teleop')
       expect(calls[0].body).toEqual({ lin: 0.5, ang: -1.0 })
     } finally {
@@ -105,8 +120,14 @@ describe('wsTelemetry', () => {
   })
 
   it('refuse upgrade si token absent (401)', async () => {
-    const ws = new WebSocket(`ws://localhost:${port}/ws/robots/1/telemetry`)
+    const ws = new WebSocket(`ws://localhost:${port}/ws/robots/${robotIdA}/telemetry`)
     const err = await new Promise<Error>((res) => ws.on('error', res))
     expect(err.message).toMatch(/401|Unexpected/)
+  })
+
+  it('refuse upgrade si robotId inexistant (404)', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws/robots/999999/telemetry?token=${token}`)
+    const err = await new Promise<Error>((res) => ws.on('error', res))
+    expect(err.message).toMatch(/404|Unexpected/)
   })
 })

--- a/web/frontend/.gitignore
+++ b/web/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+playwright-report/

--- a/web/frontend/e2e/mapping.spec.ts
+++ b/web/frontend/e2e/mapping.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+// Smoke E2E /mapping. Le backend n'est pas lance par playwright (webServer
+// ne fait que `npm run dev` frontend), donc on teste uniquement les
+// comportements client-side : redirection auth + chargement post-stub.
+
+test.describe('Page Mapping', () => {
+  test('redirige vers /login sans token', async ({ page }) => {
+    await page.goto('/mapping')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('charge la page apres injection token (smoke shell)', async ({ page }) => {
+    // injecte un token bidon dans zustand pour passer RequireAuth.
+    // Le WS et les calls API echoueront mais le shell doit s'afficher.
+    await page.addInitScript(() => {
+      // authStore est persiste via zustand/persist en cle 'roblaude-auth'
+      window.localStorage.setItem(
+        'roblaude-auth',
+        JSON.stringify({
+          state: { token: 'smoke-fake-token', user: { id: 1, email: 'smoke@x.com', name: 'Smoke', role: 'USER' } },
+          version: 0,
+        }),
+      )
+    })
+
+    // stub les appels backend pour ne pas attendre des 401 reels
+    await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+    // stub les WS aussi (le hook va tenter un connect — laissons echouer mais
+    // le shell s'affiche quand meme)
+    await page.goto('/mapping')
+
+    // titre + boutons cles
+    await expect(page.getByRole('heading', { name: 'Mode mapping' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Demarrer/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Arreter/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Sauvegarder/ })).toBeVisible()
+  })
+})

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
             />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/mapping" element={<MappingPage />} />
+            <Route path="/mapping/:robotId" element={<MappingPage />} />
           </Route>
         </Route>
 

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { ArrowLeft, Play, Square, Save, Wifi, WifiOff, MapPin } from 'lucide-react'
 import { useRobotStore } from '../stores/robotStore'
@@ -20,7 +20,12 @@ const STATE_LABEL: Record<string, { label: string; color: string }> = {
 }
 
 export function MappingPage() {
-  const robotId = useRobotStore((s) => s.id)
+  const params = useParams<{ robotId?: string }>()
+  const storeRobotId = useRobotStore((s) => s.id)
+  // /mapping/:robotId override le robot courant du store, sinon fallback
+  // au robot par defaut (single-robot MVP).
+  const parsed = params.robotId ? Number(params.robotId) : NaN
+  const robotId = Number.isInteger(parsed) && parsed > 0 ? parsed : storeRobotId
   const robotConnected = useRobotStore((s) => s.connected)
   const { state, sessionId, mapPngUrl, mapMeta, wsConnected, failureReason, setMapping } = useMappingStore()
 


### PR DESCRIPTION
## Résumé

Stacked sur #243. Couvre les 🟢 \"dette tech\" identifiés post-T3.5.8.

### Authz teleop (backend)
- `wsTelemetry` vérifie l'existence du Robot en DB à l'upgrade (404 sinon). Évite les rooms zombies pour des ids fantaisistes.
- `userId` extrait du JWT est tracé dans `console.log(\"[teleop] user=X robot=Y lin=Z ang=W\")` — audit minimal sans table dédiée.
- Modèle de permissions par robot = à faire si on passe multi-tenant.

### Route /mapping/:robotId (frontend)
- Nouvelle route React Router en plus de `/mapping`. Permet de passer en multi-robot sans recompiler.
- Fallback vers `useRobotStore.id` si le param est absent ou invalide.

### E2E Playwright
- Nouveau `e2e/mapping.spec.ts` :
  - test 1 : `/mapping` sans token → redirige vers `/login`
  - test 2 : token injecté + API stubée → shell de la page se charge (titre + boutons)
- `playwright-report/` ajouté au gitignore.
- Pas dans la CI (workflow existant n'a pas Playwright), lançable via `npm run test:e2e`.

### Vérifs

- `npm run build` clean (backend + frontend)
- `npm test` 75/75 backend OK (nouveau test 404 wsTelemetry)
- `npx playwright test --list` → 4 tests détectés

### Stack

Cette PR dépend de #243 — merger #243 d'abord (ou GitHub rebasera automatiquement).