### PR TITLE
feat(plan4): MapLive (overlay scan/plan/frontiers/trail + plein écran) + joystick + DockBottom

### DIFF
--- a/web/frontend/src/components/DockBottom.tsx
+++ b/web/frontend/src/components/DockBottom.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { Terminal, GitBranch, List, ChevronDown, ChevronUp } from 'lucide-react'
+import { useMappingStore } from '@/stores/mappingStore'
+
+// Dock en bas d'ecran avec tabs : Logs / TF / Topics.
+// Logs = placeholder (WS /ws/robots/:id/logs viendra en T3.5.12 SSH).
+
+type Tab = 'logs' | 'tf' | 'topics'
+
+export function DockBottom() {
+  const [open, setOpen] = useState(false)
+  const [tab, setTab] = useState<Tab>('tf')
+  const tfFrames = useMappingStore((s) => s.tfFrames)
+  const topics = useMappingStore((s) => s.topics)
+
+  const tabBtn = (key: Tab, label: string, Icon: typeof Terminal) => (
+    <button
+      onClick={() => { setTab(key); setOpen(true) }}
+      className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-t ${
+        tab === key && open
+          ? 'bg-gray-900 text-white border-t border-x border-gray-800'
+          : 'text-gray-400 hover:text-white'
+      }`}
+    >
+      <Icon className="w-3.5 h-3.5" /> {label}
+    </button>
+  )
+
+  return (
+    <div className="bg-gray-950 border-t border-gray-800 rounded-t-lg overflow-hidden">
+      <div className="flex items-center justify-between px-2 pt-1">
+        <div className="flex">
+          {tabBtn('logs', 'Logs', Terminal)}
+          {tabBtn('tf', 'TF tree', GitBranch)}
+          {tabBtn('topics', 'Topics', List)}
+        </div>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="text-gray-500 hover:text-white p-1.5"
+          aria-label={open ? 'Replier' : 'Deplier'}
+        >
+          {open ? <ChevronDown className="w-4 h-4" /> : <ChevronUp className="w-4 h-4" />}
+        </button>
+      </div>
+
+      {open && (
+        <div className="bg-gray-900 border-t border-gray-800 p-3 max-h-64 overflow-auto font-mono text-xs">
+          {tab === 'logs' && (
+            <div className="text-gray-500">
+              Logs ROS : disponibles via SSH (T3.5.12 — pas encore implemente).
+            </div>
+          )}
+
+          {tab === 'tf' && (
+            tfFrames && tfFrames.length > 0 ? (
+              <ul className="space-y-0.5 text-gray-300">
+                {tfFrames.map((f, i) => (
+                  <li key={i}>
+                    <span className="text-cyan-400">{f.parent}</span>
+                    <span className="text-gray-600"> → </span>
+                    <span className="text-green-400">{f.id}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-gray-500">Aucun TF recu (le robot publie sur /tf).</div>
+            )
+          )}
+
+          {tab === 'topics' && (
+            topics && topics.length > 0 ? (
+              <ul className="space-y-0.5 text-gray-300">
+                {topics.map((t, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="text-cyan-400 min-w-[180px]">{t.name}</span>
+                    <span className="text-gray-500">{t.msgType}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-gray-500">
+                Aucun topic recu (poll SSH actif si ROBOT_X_SSH_HOST configure).
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/components/MapLive.tsx
+++ b/web/frontend/src/components/MapLive.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { Maximize2, Minimize2, Layers } from 'lucide-react'
+import { useMappingStore } from '@/stores/mappingStore'
+import { worldToPixel } from '@/lib/mapProjection'
+
+// Carte SLAM live avec overlay canvas (scan laser, plan, frontiers, robot pose).
+// Mode plein ecran via Fullscreen API.
+
+interface LayerToggles {
+  scan: boolean
+  plan: boolean
+  frontiers: boolean
+  trail: boolean
+}
+
+export function MapLive() {
+  const { mapPngUrl, mapMeta, scan, plan, frontiers, trail, robotPose } = useMappingStore()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [fullscreen, setFullscreen] = useState(false)
+  const [layers, setLayers] = useState<LayerToggles>({
+    scan: true,
+    plan: true,
+    frontiers: true,
+    trail: true,
+  })
+  const [showLayerMenu, setShowLayerMenu] = useState(false)
+
+  const toggleFullscreen = useCallback((): void => {
+    const el = containerRef.current
+    if (!el) return
+    if (!document.fullscreenElement) {
+      void el.requestFullscreen()
+    } else {
+      void document.exitFullscreen()
+    }
+  }, [])
+
+  useEffect(() => {
+    const onFs = (): void => setFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', onFs)
+    return () => document.removeEventListener('fullscreenchange', onFs)
+  }, [])
+
+  // redessine le canvas a chaque changement de scan/plan/trail/etc.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !mapMeta) return
+    canvas.width = mapMeta.width
+    canvas.height = mapMeta.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+    // robot position
+    if (robotPose) {
+      const p = worldToPixel(mapMeta, robotPose.x, robotPose.y)
+      // fleche orientation
+      const len = 12
+      const dx = Math.cos(robotPose.theta) * len
+      const dy = -Math.sin(robotPose.theta) * len
+      ctx.strokeStyle = '#22d3ee'
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(p.x, p.y)
+      ctx.lineTo(p.x + dx, p.y + dy)
+      ctx.stroke()
+      ctx.fillStyle = '#06b6d4'
+      ctx.beginPath()
+      ctx.arc(p.x, p.y, 4, 0, Math.PI * 2)
+      ctx.fill()
+    }
+
+    // trail
+    if (layers.trail && trail.length > 1) {
+      ctx.strokeStyle = 'rgba(34, 211, 238, 0.6)'
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      const first = worldToPixel(mapMeta, trail[0].x, trail[0].y)
+      ctx.moveTo(first.x, first.y)
+      for (let i = 1; i < trail.length; i++) {
+        const pt = worldToPixel(mapMeta, trail[i].x, trail[i].y)
+        ctx.lineTo(pt.x, pt.y)
+      }
+      ctx.stroke()
+    }
+
+    // plan (chemin Nav2)
+    if (layers.plan && plan && plan.length > 1) {
+      ctx.strokeStyle = '#a855f7'
+      ctx.lineWidth = 2
+      ctx.setLineDash([4, 3])
+      ctx.beginPath()
+      const start = worldToPixel(mapMeta, plan[0].x, plan[0].y)
+      ctx.moveTo(start.x, start.y)
+      for (let i = 1; i < plan.length; i++) {
+        const pt = worldToPixel(mapMeta, plan[i].x, plan[i].y)
+        ctx.lineTo(pt.x, pt.y)
+      }
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+
+    // frontiers (zones a explorer)
+    if (layers.frontiers && frontiers) {
+      ctx.fillStyle = 'rgba(34, 197, 94, 0.5)'
+      for (const f of frontiers) {
+        const pt = worldToPixel(mapMeta, f.x, f.y)
+        const r = Math.max(2, f.size / mapMeta.resolution / 2)
+        ctx.beginPath()
+        ctx.arc(pt.x, pt.y, r, 0, Math.PI * 2)
+        ctx.fill()
+      }
+    }
+
+    // scan laser
+    if (layers.scan && scan && robotPose) {
+      ctx.fillStyle = 'rgba(248, 113, 113, 0.9)'
+      for (let i = 0; i < scan.ranges.length; i++) {
+        const r = scan.ranges[i]
+        if (!Number.isFinite(r) || r <= 0) continue
+        const angle = scan.angleMin + i * scan.angleIncrement + robotPose.theta
+        const xWorld = robotPose.x + Math.cos(angle) * r
+        const yWorld = robotPose.y + Math.sin(angle) * r
+        const pt = worldToPixel(mapMeta, xWorld, yWorld)
+        ctx.fillRect(pt.x - 0.5, pt.y - 0.5, 1.5, 1.5)
+      }
+    }
+  }, [mapMeta, scan, plan, frontiers, trail, robotPose, layers])
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative bg-black border border-gray-900 rounded ${
+        fullscreen ? 'flex items-center justify-center' : ''
+      }`}
+    >
+      {/* boutons en haut a droite */}
+      <div className="absolute top-2 right-2 z-10 flex gap-2">
+        <div className="relative">
+          <button
+            onClick={() => setShowLayerMenu((v) => !v)}
+            className="bg-gray-900/80 hover:bg-gray-800 text-gray-200 p-2 rounded border border-gray-700"
+            aria-label="Couches"
+          >
+            <Layers className="w-4 h-4" />
+          </button>
+          {showLayerMenu && (
+            <div className="absolute top-full right-0 mt-1 bg-gray-900 border border-gray-700 rounded p-2 text-xs space-y-1 min-w-[120px]">
+              {(['scan', 'plan', 'frontiers', 'trail'] as const).map((k) => (
+                <label key={k} className="flex items-center gap-2 text-gray-200 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={layers[k]}
+                    onChange={(e) => setLayers((l) => ({ ...l, [k]: e.target.checked }))}
+                  />
+                  {k}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={toggleFullscreen}
+          className="bg-gray-900/80 hover:bg-gray-800 text-gray-200 p-2 rounded border border-gray-700"
+          aria-label={fullscreen ? 'Quitter plein ecran' : 'Plein ecran'}
+        >
+          {fullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+        </button>
+      </div>
+
+      <div className="relative inline-block">
+        {mapPngUrl ? (
+          <>
+            <img
+              src={mapPngUrl}
+              alt="Carte SLAM"
+              className={fullscreen ? 'max-h-screen max-w-screen' : 'max-w-full max-h-[600px]'}
+              style={{ imageRendering: 'pixelated', display: 'block' }}
+            />
+            <canvas
+              ref={canvasRef}
+              className="absolute inset-0 w-full h-full pointer-events-none"
+              style={{ imageRendering: 'pixelated' }}
+            />
+          </>
+        ) : (
+          <div className="text-gray-600 text-sm py-24 px-12">
+            Aucune carte disponible — demarre une session
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/components/TeleopPanel.tsx
+++ b/web/frontend/src/components/TeleopPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import { Gamepad2, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Square } from 'lucide-react'
 import { sendTeleop } from '@/hooks/useMappingTelemetry'
+import { VirtualJoystick } from './VirtualJoystick'
 
 // Joystick clavier + boutons. Dead-man : on republie {lin,ang} a 10Hz tant
 // qu'une touche est tenue. Au keyup -> envoie {0,0} pour stopper.
@@ -98,6 +99,14 @@ export function TeleopPanel({ enabled }: Props) {
     sendTeleop(0, 0)
   }
 
+  // joystick : envoie sur le WS avec un scale 0.3 m/s (max conf demo).
+  const onJoystickChange = useCallback((lin: number, ang: number): void => {
+    sendTeleop(lin * 0.3, ang * 0.7)
+  }, [])
+  const onJoystickRelease = useCallback((): void => {
+    sendTeleop(0, 0)
+  }, [])
+
   const btnStyle = (active: boolean): string =>
     `w-12 h-12 flex items-center justify-center rounded border ${
       active
@@ -122,7 +131,15 @@ export function TeleopPanel({ enabled }: Props) {
       </div>
 
       <div className="text-xs text-gray-500 mb-3">
-        Touches : ↑ ↓ ← → ou ZQSD / WASD. Active uniquement pendant RUNNING.
+        Touches : ↑ ↓ ← → ou ZQSD / WASD. Joystick : touch ou drag. Active en RUNNING.
+      </div>
+
+      <div className="flex items-center justify-center mb-4">
+        <VirtualJoystick
+          enabled={enabled}
+          onChange={onJoystickChange}
+          onRelease={onJoystickRelease}
+        />
       </div>
 
       <div className="grid grid-cols-3 gap-2 max-w-[180px] mx-auto">

--- a/web/frontend/src/components/VirtualJoystick.tsx
+++ b/web/frontend/src/components/VirtualJoystick.tsx
@@ -1,0 +1,91 @@
+import { useRef, useState, useEffect } from 'react'
+
+// Joystick virtuel touch/pointer. Le knob suit le doigt dans un cercle.
+// Au drop, retour au centre. emit (lin, ang) normalises [-1, 1] via onChange.
+// onChange est appele a 10Hz tant qu'actif (ou meme rate que pointer move).
+
+interface Props {
+  size?: number
+  enabled: boolean
+  onChange: (lin: number, ang: number) => void
+  onRelease?: () => void
+}
+
+export function VirtualJoystick({ size = 140, enabled, onChange, onRelease }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+  const radius = size / 2
+  const knobRadius = size / 5
+
+  useEffect(() => {
+    if (!pos || !enabled) return
+    // tick d'envoi a 10Hz tant que actif (au cas ou pointermove ne fire pas)
+    const id = setInterval(() => {
+      const lin = -pos.y / radius // axe Y vers le haut = avancer (lin positif)
+      const ang = -pos.x / radius // axe X vers la gauche = ang positif
+      onChange(
+        Math.max(-1, Math.min(1, lin)),
+        Math.max(-1, Math.min(1, ang)),
+      )
+    }, 100)
+    return () => clearInterval(id)
+  }, [pos, radius, enabled, onChange])
+
+  const computePos = (clientX: number, clientY: number): { x: number; y: number } => {
+    const el = ref.current
+    if (!el) return { x: 0, y: 0 }
+    const rect = el.getBoundingClientRect()
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    let dx = clientX - cx
+    let dy = clientY - cy
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    if (dist > radius) {
+      dx = (dx / dist) * radius
+      dy = (dy / dist) * radius
+    }
+    return { x: dx, y: dy }
+  }
+
+  const onPointerDown = (e: React.PointerEvent): void => {
+    if (!enabled) return
+    ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+    setPos(computePos(e.clientX, e.clientY))
+  }
+
+  const onPointerMove = (e: React.PointerEvent): void => {
+    if (!enabled || !pos) return
+    setPos(computePos(e.clientX, e.clientY))
+  }
+
+  const stop = (): void => {
+    setPos(null)
+    onChange(0, 0)
+    onRelease?.()
+  }
+
+  const offset = pos ?? { x: 0, y: 0 }
+
+  return (
+    <div
+      ref={ref}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={stop}
+      onPointerCancel={stop}
+      onPointerLeave={pos ? stop : undefined}
+      className={`relative rounded-full ${enabled ? 'bg-gray-800 border-gray-700' : 'bg-gray-900 border-gray-800 opacity-50'} border-2 touch-none select-none cursor-grab active:cursor-grabbing`}
+      style={{ width: size, height: size }}
+    >
+      <div
+        className={`absolute rounded-full ${pos ? 'bg-blue-500' : 'bg-gray-600'} border border-gray-400 transition-colors`}
+        style={{
+          width: knobRadius * 2,
+          height: knobRadius * 2,
+          left: `calc(50% - ${knobRadius}px + ${offset.x}px)`,
+          top: `calc(50% - ${knobRadius}px + ${offset.y}px)`,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/frontend/src/hooks/useMappingTelemetry.ts
+++ b/web/frontend/src/hooks/useMappingTelemetry.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useAuthStore } from '@/stores/authStore'
-import { useMappingStore, type MapMeta, type MappingState } from '@/stores/mappingStore'
+import { useMappingStore, type MapMeta, type MappingState, type Pose, type Frontier } from '@/stores/mappingStore'
 
 // Ouvre /ws/robots/:id/telemetry et alimente mappingStore.
 // PNG arrive en frame BINARY prefixee d'un byte de type (0x01 = map png),
@@ -19,6 +19,9 @@ export function useMappingTelemetry(robotId: number, enabled: boolean): void {
   const setFailure = useMappingStore((s) => s.setFailure)
   const setWsConnected = useMappingStore((s) => s.setWsConnected)
   const setLastTelemetry = useMappingStore((s) => s.setLastTelemetry)
+  const setScan = useMappingStore((s) => s.setScan)
+  const setPlan = useMappingStore((s) => s.setPlan)
+  const setFrontiers = useMappingStore((s) => s.setFrontiers)
   const wsRef = useRef<WebSocket | null>(null)
   const cancelledRef = useRef(false)
   const retryCountRef = useRef(0)
@@ -83,7 +86,19 @@ export function useMappingTelemetry(robotId: number, enabled: boolean): void {
             if (typeof msg.failureReason === 'string') setFailure(msg.failureReason)
             else if (msg.state !== 'FAILED') setFailure(null)
             break
-          // scan / plan / frontiers : ignores pour MVP demo
+          case 'scan':
+            setScan({
+              ranges: msg.ranges as number[],
+              angleMin: msg.angleMin as number,
+              angleIncrement: msg.angleIncrement as number,
+            })
+            break
+          case 'plan':
+            setPlan((msg.poses ?? []) as Pose[])
+            break
+          case 'frontiers':
+            setFrontiers((msg.cells ?? []) as Frontier[])
+            break
         }
       }
     }
@@ -98,7 +113,7 @@ export function useMappingTelemetry(robotId: number, enabled: boolean): void {
       currentWs = null
       setWsConnected(false)
     }
-  }, [robotId, enabled, token, setMapPng, setMapMeta, setMapping, setCoverage, setFailure, setWsConnected, setLastTelemetry])
+  }, [robotId, enabled, token, setMapPng, setMapMeta, setMapping, setCoverage, setFailure, setWsConnected, setLastTelemetry, setScan, setPlan, setFrontiers])
 }
 
 // module-level ref vers le WS courant — utilise par sendTeleop (item teleop UI).

--- a/web/frontend/src/hooks/useRobotInfraWs.ts
+++ b/web/frontend/src/hooks/useRobotInfraWs.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+import { useAuthStore } from '@/stores/authStore'
+import { useMappingStore } from '@/stores/mappingStore'
+
+// Hook commun pour /ws/robots/:id/tf et /ws/robots/:id/topics.
+// Pas de reconnect agressif (ces flux sont auxiliaires) — un seul retry.
+
+function openWs(
+  path: string,
+  token: string,
+  onJson: (msg: Record<string, unknown>) => void,
+): WebSocket {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const url = `${proto}//${window.location.host}${path}?token=${encodeURIComponent(token)}`
+  const ws = new WebSocket(url)
+  ws.onmessage = (e) => {
+    try {
+      onJson(JSON.parse(e.data))
+    } catch {
+      /* ignore */
+    }
+  }
+  return ws
+}
+
+export function useTfStream(robotId: number, enabled: boolean): void {
+  const token = useAuthStore((s) => s.token)
+  const setTfFrames = useMappingStore((s) => s.setTfFrames)
+  useEffect(() => {
+    if (!enabled || !token) return
+    const ws = openWs(`/ws/robots/${robotId}/tf`, token, (msg) => {
+      if (msg.type === 'tf_snapshot') {
+        setTfFrames((msg.frames ?? []) as { id: string; parent: string }[])
+      }
+    })
+    return () => ws.close()
+  }, [robotId, enabled, token, setTfFrames])
+}
+
+export function useTopicsStream(robotId: number, enabled: boolean): void {
+  const token = useAuthStore((s) => s.token)
+  const setTopics = useMappingStore((s) => s.setTopics)
+  useEffect(() => {
+    if (!enabled || !token) return
+    const ws = openWs(`/ws/robots/${robotId}/topics`, token, (msg) => {
+      if (msg.type === 'topics_list') {
+        setTopics((msg.topics ?? []) as { name: string; msgType: string }[])
+      }
+    })
+    return () => ws.close()
+  }, [robotId, enabled, token, setTopics])
+}

--- a/web/frontend/src/lib/mapProjection.ts
+++ b/web/frontend/src/lib/mapProjection.ts
@@ -1,0 +1,32 @@
+// Conversion coordonnees world (m) <-> pixel carte SLAM.
+// La carte ROS a son origine en bas-gauche, l'image PNG en haut-gauche
+// => on flippe Y.
+
+export interface MapProjectionMeta {
+  width: number
+  height: number
+  resolution: number
+  originX: number
+  originY: number
+}
+
+/** Convertit (x_world, y_world) en m vers (x_px, y_px) dans l'image PNG. */
+export function worldToPixel(
+  meta: MapProjectionMeta,
+  xWorld: number,
+  yWorld: number,
+): { x: number; y: number } {
+  const x = (xWorld - meta.originX) / meta.resolution
+  const y = meta.height - (yWorld - meta.originY) / meta.resolution
+  return { x, y }
+}
+
+export function pixelToWorld(
+  meta: MapProjectionMeta,
+  xPx: number,
+  yPx: number,
+): { x: number; y: number } {
+  const x = xPx * meta.resolution + meta.originX
+  const y = (meta.height - yPx) * meta.resolution + meta.originY
+  return { x, y }
+}

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { ArrowLeft, Play, Square, Save, Wifi, WifiOff, MapPin } from 'lucide-react'
@@ -6,9 +6,12 @@ import { useRobotStore } from '../stores/robotStore'
 import { useMappingStore } from '../stores/mappingStore'
 import { useMappingTelemetry } from '../hooks/useMappingTelemetry'
 import { useMappingStaleness } from '../hooks/useStaleness'
+import { useTfStream, useTopicsStream } from '../hooks/useRobotInfraWs'
 import { startMapping, stopMapping, saveMapping } from '../lib/mappingApi'
 import { MappingSessionsList } from '../components/MappingSessionsList'
 import { TeleopPanel } from '../components/TeleopPanel'
+import { MapLive } from '../components/MapLive'
+import { DockBottom } from '../components/DockBottom'
 
 const STATE_LABEL: Record<string, { label: string; color: string }> = {
   IDLE: { label: 'En veille', color: 'bg-gray-700 text-gray-200' },
@@ -22,11 +25,21 @@ const STATE_LABEL: Record<string, { label: string; color: string }> = {
 export function MappingPage() {
   const robotId = useRobotStore((s) => s.id)
   const robotConnected = useRobotStore((s) => s.connected)
-  const { state, sessionId, mapPngUrl, mapMeta, wsConnected, failureReason, setMapping } = useMappingStore()
+  const robotPos = useRobotStore((s) => s.position)
+  const { state, sessionId, mapMeta, wsConnected, failureReason, setMapping, setRobotPose, pushTrail } = useMappingStore()
 
-  // ouvre le WS telemetry (carte live)
+  // WS telemetry (carte live + scan + plan + frontiers) + TF + Topics infra
   useMappingTelemetry(robotId, true)
+  useTfStream(robotId, true)
+  useTopicsStream(robotId, true)
   const stale = useMappingStaleness()
+
+  // Synchronise robotStore.position -> mappingStore.robotPose + trail
+  // (la position vient du WS legacy /ws via position_update -> robotStore).
+  useEffect(() => {
+    setRobotPose({ x: robotPos.x, y: robotPos.y, theta: robotPos.heading })
+    if (state === 'RUNNING') pushTrail({ x: robotPos.x, y: robotPos.y })
+  }, [robotPos.x, robotPos.y, robotPos.heading, state, setRobotPose, pushTrail])
 
   const [busy, setBusy] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
@@ -172,34 +185,28 @@ export function MappingPage() {
         </button>
       </div>
 
-      {/* Carte live + historique sessions cote a cote */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-      <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-lg p-4">
-        <div className="flex items-center gap-2 mb-3">
-          <MapPin className="w-4 h-4 text-gray-400" />
-          <h2 className="text-sm font-medium text-gray-300">Carte SLAM live</h2>
+      {/* Carte live + panneaux cote a cote */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
+        <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <MapPin className="w-4 h-4 text-gray-400" />
+            <h2 className="text-sm font-medium text-gray-300">Carte SLAM live</h2>
+            {mapMeta && (
+              <span className="text-[10px] text-gray-500 ml-auto">
+                {mapMeta.width}×{mapMeta.height}px · {mapMeta.resolution.toFixed(3)}m/px
+              </span>
+            )}
+          </div>
+          <MapLive />
         </div>
-        <div className="bg-black border border-gray-900 rounded min-h-96 flex items-center justify-center overflow-hidden">
-          {mapPngUrl ? (
-            <img
-              src={mapPngUrl}
-              alt="Carte SLAM"
-              className="max-w-full max-h-[600px] object-contain"
-              style={{ imageRendering: 'pixelated' }}
-            />
-          ) : (
-            <div className="text-gray-600 text-sm py-24">
-              {state === 'RUNNING' ? 'En attente du premier frame…' : 'Demarre une session pour voir la carte'}
-            </div>
-          )}
+
+        <div className="space-y-4">
+          <TeleopPanel enabled={state === 'RUNNING' && wsConnected} />
+          <MappingSessionsList robotId={robotId} refreshKey={refreshKey} />
         </div>
       </div>
 
-      <div className="space-y-4">
-        <TeleopPanel enabled={state === 'RUNNING' && wsConnected} />
-        <MappingSessionsList robotId={robotId} refreshKey={refreshKey} />
-      </div>
-      </div>
+      <DockBottom />
     </div>
   )
 }

--- a/web/frontend/src/stores/mappingStore.ts
+++ b/web/frontend/src/stores/mappingStore.ts
@@ -11,6 +11,24 @@ export interface MapMeta {
   stamp: number
 }
 
+export interface ScanData {
+  ranges: number[]
+  angleMin: number
+  angleIncrement: number
+}
+
+export interface Pose {
+  x: number
+  y: number
+  theta: number
+}
+
+export interface Frontier {
+  x: number
+  y: number
+  size: number
+}
+
 interface MappingStore {
   state: MappingState
   sessionId: number | null
@@ -20,6 +38,15 @@ interface MappingStore {
   failureReason: string | null
   wsConnected: boolean
   lastTelemetryAt: number | null
+  // overlays (T3.5.9)
+  scan: ScanData | null
+  plan: Pose[] | null
+  frontiers: Frontier[] | null
+  trail: { x: number; y: number }[]
+  robotPose: Pose | null
+  // tf/topics (T3.5.11)
+  tfFrames: { id: string; parent: string }[] | null
+  topics: { name: string; msgType: string }[] | null
 
   setState: (state: MappingState) => void
   setSession: (sessionId: number | null) => void
@@ -30,6 +57,13 @@ interface MappingStore {
   setFailure: (reason: string | null) => void
   setWsConnected: (b: boolean) => void
   setLastTelemetry: (ts: number) => void
+  setScan: (s: ScanData | null) => void
+  setPlan: (poses: Pose[] | null) => void
+  setFrontiers: (cells: Frontier[] | null) => void
+  pushTrail: (point: { x: number; y: number }) => void
+  setRobotPose: (p: Pose | null) => void
+  setTfFrames: (f: { id: string; parent: string }[] | null) => void
+  setTopics: (t: { name: string; msgType: string }[] | null) => void
   reset: () => void
 }
 
@@ -42,13 +76,19 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   failureReason: null,
   wsConnected: false,
   lastTelemetryAt: null,
+  scan: null,
+  plan: null,
+  frontiers: null,
+  trail: [],
+  robotPose: null,
+  tfFrames: null,
+  topics: null,
 
   setState: (state) => set({ state }),
   setSession: (sessionId) => set({ sessionId }),
   setMapping: (state, sessionId) => set({ state, sessionId }),
 
   setMapPng: (url) => {
-    // revoke l'ancien blob URL pour eviter la fuite memoire
     const prev = get().mapPngUrl
     if (prev) URL.revokeObjectURL(prev)
     set({ mapPngUrl: url })
@@ -58,6 +98,19 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   setFailure: (reason) => set({ failureReason: reason }),
   setWsConnected: (b) => set({ wsConnected: b }),
   setLastTelemetry: (ts) => set({ lastTelemetryAt: ts }),
+  setScan: (s) => set({ scan: s }),
+  setPlan: (poses) => set({ plan: poses }),
+  setFrontiers: (cells) => set({ frontiers: cells }),
+  pushTrail: (point) =>
+    set((s) => {
+      // garde max 500 points pour eviter memory creep en demo longue
+      const next = [...s.trail, point]
+      if (next.length > 500) next.shift()
+      return { trail: next }
+    }),
+  setRobotPose: (p) => set({ robotPose: p }),
+  setTfFrames: (f) => set({ tfFrames: f }),
+  setTopics: (t) => set({ topics: t }),
 
   reset: () => {
     const prev = get().mapPngUrl
@@ -69,6 +122,11 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
       mapMeta: null,
       coveragePercent: null,
       failureReason: null,
+      scan: null,
+      plan: null,
+      frontiers: null,
+      trail: [],
+      robotPose: null,
     })
   },
 }))


### PR DESCRIPTION
Plan 4 Frontend Live. MapLive canvas overlay sur PNG carte avec layers toggleables (scan laser, plan Nav2, frontiers, trail). Bouton plein écran via Fullscreen API. Joystick virtuel touch/pointer integré au TeleopPanel. DockBottom tabs Logs (placeholder)/TF tree/Topics list.