### PR TITLE
feat(plan5): backend SSH admin — allowlist + audit + endpoints exec/logs

### DIFF
--- a/web/backend/src/app.ts
+++ b/web/backend/src/app.ts
@@ -8,6 +8,7 @@ import pointsRouter from './routes/points'
 import robotsRouter from './routes/robots'
 import mappingRouter from './routes/mapping'
 import annotationsRouter from './routes/annotations'
+import sshRouter from './routes/ssh'
 
 const app = express()
 
@@ -34,6 +35,7 @@ app.use('/api/points', authGuard, pointsRouter)
 app.use('/api/robots', authGuard, robotsRouter)
 app.use('/api/mapping', authGuard, mappingRouter)
 app.use('/api/annotations', authGuard, annotationsRouter)
+app.use('/api/admin/ssh', authGuard, sshRouter)
 
 // error handler — doit etre en dernier
 app.use(errorHandler)

--- a/web/backend/src/controllers/sshController.ts
+++ b/web/backend/src/controllers/sshController.ts
@@ -1,0 +1,90 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+import prisma from '../lib/prisma'
+import { runOnce } from '../services/sshConnection'
+import { isAllowlistedCommand } from '../lib/sshAllowlist'
+
+// Exec SSH en mode ALLOWLIST uniquement (T3.5.12). Le mode ELEVATED (cmd libre
+// avec re-auth) est explicitement hors scope demo — voir docs/spec §5.5.
+
+const execSchema = z.object({
+  robotId: z.number().int().positive(),
+  command: z.string().min(1).max(200),
+})
+
+const logsSchema = z.object({
+  unit: z.string().regex(/^[\w.-]+$/).optional(),
+  lines: z.coerce.number().int().min(1).max(500).default(100),
+})
+
+export async function execAllowlist(req: Request, res: Response): Promise<void> {
+  const parsed = execSchema.safeParse(req.body)
+  if (!parsed.success) { res.status(400).json({ error: 'invalid body', issues: parsed.error.issues }); return }
+  const { robotId, command } = parsed.data
+  const userId = req.user?.userId
+  if (!userId) { res.status(401).json({ error: 'auth required' }); return }
+
+  if (!isAllowlistedCommand(command)) {
+    await prisma.sshAuditLog.create({
+      data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: -1, durationMs: 0 },
+    }).catch(() => {})
+    res.status(403).json({ error: 'command not allowed', command })
+    return
+  }
+
+  const startedAt = Date.now()
+  try {
+    const result = await runOnce(robotId, command, 10_000)
+    const durationMs = Date.now() - startedAt
+    await prisma.sshAuditLog.create({
+      data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: result.code, durationMs },
+    }).catch((err) => console.error('[ssh] audit log echec :', err.message))
+    res.json(result)
+  } catch (err) {
+    const durationMs = Date.now() - startedAt
+    const message = err instanceof Error ? err.message : 'ssh error'
+    await prisma.sshAuditLog.create({
+      data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: -1, durationMs },
+    }).catch(() => {})
+    res.status(502).json({ error: 'ssh failure', message })
+  }
+}
+
+/** GET /api/admin/robots/:id/logs — wrapper SSH journalctl, MVP demo. */
+export async function readLogs(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.params.id)
+  if (!Number.isInteger(robotId) || robotId <= 0) {
+    res.status(400).json({ error: 'invalid robotId' })
+    return
+  }
+  const parsed = logsSchema.safeParse(req.query)
+  if (!parsed.success) { res.status(400).json({ error: 'invalid query' }); return }
+  const { unit, lines } = parsed.data
+  const cmd = unit
+    ? `journalctl --no-pager -n ${lines} -u ${unit}`
+    : `journalctl --no-pager -n ${lines}`
+  // securite : on passe par l'allowlist meme si on construit la commande.
+  if (!isAllowlistedCommand(cmd)) {
+    res.status(403).json({ error: 'logs command rejected by allowlist' })
+    return
+  }
+  try {
+    const result = await runOnce(robotId, cmd, 10_000)
+    res.json({ command: cmd, stdout: result.stdout, exitCode: result.code })
+  } catch (err) {
+    res.status(502).json({ error: err instanceof Error ? err.message : 'ssh error' })
+  }
+}
+
+export async function listAuditLogs(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.query.robotId)
+  const take = Math.min(200, Number(req.query.take ?? 50))
+  const where = Number.isInteger(robotId) && robotId > 0 ? { robotId } : {}
+  const logs = await prisma.sshAuditLog.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take,
+    include: { user: { select: { id: true, name: true, email: true } } },
+  })
+  res.json(logs)
+}

--- a/web/backend/src/lib/sshAllowlist.ts
+++ b/web/backend/src/lib/sshAllowlist.ts
@@ -1,0 +1,28 @@
+// Allowlist de commandes SSH safe (lecture seule en mode ALLOWLIST).
+// Le mode ELEVATED (commande libre) viendra plus tard avec re-auth interactive.
+
+const ALLOWLIST_PATTERNS: RegExp[] = [
+  // ROS — introspection topics/nodes/params
+  /^ros2 topic list( -t)?$/,
+  /^ros2 topic echo \/\S+( --once)?$/,
+  /^ros2 topic info \/\S+$/,
+  /^ros2 node list$/,
+  /^ros2 node info \/\S+$/,
+  /^ros2 param list( \/\S+)?$/,
+  // diagnostics systeme — lecture seule
+  /^uptime$/,
+  /^free -h$/,
+  /^df -h$/,
+  /^uname -a$/,
+  /^cat \/proc\/uptime$/,
+  /^journalctl --no-pager -n \d{1,4}( -u [\w.-]+)?$/,
+  /^docker ps$/,
+  /^docker logs --tail \d{1,4} [\w.-]+$/,
+]
+
+/** Renvoie true si la commande est dans l'allowlist (match exact). */
+export function isAllowlistedCommand(cmd: string): boolean {
+  const trimmed = cmd.trim()
+  if (trimmed.length === 0 || trimmed.length > 200) return false
+  return ALLOWLIST_PATTERNS.some((re) => re.test(trimmed))
+}

--- a/web/backend/src/routes/ssh.ts
+++ b/web/backend/src/routes/ssh.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+import { adminGuard } from '../middleware/auth'
+import { execAllowlist, readLogs, listAuditLogs } from '../controllers/sshController'
+
+// SSH admin routes (T3.5.12). Toutes sous /api/admin/ssh derriere authGuard+adminGuard.
+
+const router = Router()
+router.use(adminGuard)
+router.post('/exec', execAllowlist)
+router.get('/audit', listAuditLogs)
+router.get('/robots/:id/logs', readLogs)
+
+export default router

--- a/web/backend/src/test/sshAllowlist.test.ts
+++ b/web/backend/src/test/sshAllowlist.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { isAllowlistedCommand } from '../lib/sshAllowlist'
+
+describe('sshAllowlist', () => {
+  const allowed = [
+    'ros2 topic list',
+    'ros2 topic list -t',
+    'ros2 topic echo /scan --once',
+    'ros2 node list',
+    'uptime',
+    'free -h',
+    'df -h',
+    'journalctl --no-pager -n 100',
+    'journalctl --no-pager -n 50 -u roblaude.service',
+    'docker ps',
+    'docker logs --tail 100 m3pro',
+  ]
+  const rejected = [
+    'rm -rf /',
+    'cat /etc/passwd',
+    'ros2 topic list; rm -rf /',
+    'sudo reboot',
+    'echo hello',
+    '',
+    'a'.repeat(250),
+    'ros2 topic list -t || ls',
+  ]
+
+  it.each(allowed)('autorise: %s', (cmd) => {
+    expect(isAllowlistedCommand(cmd)).toBe(true)
+  })
+
+  it.each(rejected)('refuse: %s', (cmd) => {
+    expect(isAllowlistedCommand(cmd)).toBe(false)
+  })
+})


### PR DESCRIPTION
Plan 5 backend uniquement. MVP démo : pas de terminal interactif xterm.js (skip pour focus démo).

**Backend**
- `sshAllowlist.ts` — 14 patterns regex de commandes safe (ros2 introspect, journalctl read-only, docker ps/logs)
- POST `/api/admin/ssh/exec` (adminGuard) — exécute via sshConnection, audit DB (succès+refus+erreurs)
- GET `/api/admin/ssh/robots/:id/logs?unit=...&lines=...` — wrapper journalctl
- GET `/api/admin/ssh/audit` — liste les derniers audits

**Hors scope (vs plan complet)**
- Mode ELEVATED (commande libre + re-auth) → pas démo
- WS terminal interactif xterm.js (T3.5.13) → pas démo
- Front Logs viewer → intégré au Plan 6 polish (consomme `/api/admin/ssh/robots/:id/logs`)

**Tests** : 101/101 (15 nouveaux sur sshAllowlist)