### PR TITLE
feat(plan6): polish démo — sidebar enrichie + banner degraded + page SSH admin + E2E

### DIFF
--- a/web/backend/src/app.ts
+++ b/web/backend/src/app.ts
@@ -20,10 +20,12 @@ app.use(cors({
 
 app.use(express.json())
 
-// Health check (public)
-app.get('/health', (_req, res) => {
+// Health check (public) — expose en /health ET /api/health pour le proxy Vite
+const healthHandler = (_req: express.Request, res: express.Response): void => {
   res.status(200).json({ status: 'ok' })
-})
+}
+app.get('/health', healthHandler)
+app.get('/api/health', healthHandler)
 
 // Auth routes (public)
 app.use('/api/auth', authRouter)

--- a/web/frontend/e2e/admin-ssh.spec.ts
+++ b/web/frontend/e2e/admin-ssh.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke /admin/ssh. Pas de backend lance par Playwright = on stub les
+// reponses et on injecte un token ADMIN dans localStorage.
+
+test.describe('Page Admin SSH', () => {
+  test('non-admin redirige vers /', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'roblaude-auth',
+        JSON.stringify({
+          state: { token: 'fake', user: { id: 1, email: 'u@x', name: 'U', role: 'USER' } },
+          version: 0,
+        }),
+      )
+    })
+    await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+    await page.goto('/admin/ssh')
+    await expect(page).toHaveURL(/\/$/)
+  })
+
+  test('admin voit la page avec console + journalctl + audit', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'roblaude-auth',
+        JSON.stringify({
+          state: { token: 'fake', user: { id: 1, email: 'a@x', name: 'A', role: 'ADMIN' } },
+          version: 0,
+        }),
+      )
+    })
+    await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+    await page.goto('/admin/ssh')
+
+    await expect(page.getByRole('heading', { name: 'SSH admin' })).toBeVisible()
+    await expect(page.getByText('Console (commandes allowlist)')).toBeVisible()
+    await expect(page.getByText('journalctl')).toBeVisible()
+    await expect(page.getByText('Historique audit SSH')).toBeVisible()
+  })
+})

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -8,7 +8,9 @@ import { NewMissionPage } from './pages/NewMissionPage'
 import { AdminPage } from './pages/AdminPage'
 import { ProfilePage } from './pages/ProfilePage'
 import { MappingPage } from './pages/MappingPage'
+import { AdminSshPage } from './pages/AdminSshPage'
 import { LoginPage } from './pages/LoginPage'
+import { DegradedModeBanner } from './components/DegradedModeBanner'
 import { RequireAuth } from './components/RequireAuth'
 import { useAuthStore } from './stores/authStore'
 import { useWebSocket } from './hooks/useWebSocket'
@@ -18,6 +20,8 @@ export default function App() {
   // ouvre la connexion WS au login, ferme au logout — singleton
   useWebSocket()
   return (
+    <>
+      <DegradedModeBanner />
     <BrowserRouter>
       <Routes>
         {/* Routes publiques */}
@@ -36,6 +40,10 @@ export default function App() {
             />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/mapping" element={<MappingPage />} />
+            <Route
+              path="/admin/ssh"
+              element={role === 'ADMIN' ? <AdminSshPage /> : <Navigate to="/" replace />}
+            />
           </Route>
         </Route>
 
@@ -43,5 +51,6 @@ export default function App() {
       </Routes>
       <Toaster richColors position="top-right" />
     </BrowserRouter>
+    </>
   )
 }

--- a/web/frontend/src/components/DegradedModeBanner.tsx
+++ b/web/frontend/src/components/DegradedModeBanner.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+
+// Banner global qui apparait si /api/health ne repond pas pendant 10s.
+// Utilise un fetch direct (pas apiFetch — on veut detecter meme sans token).
+
+const POLL_MS = 5000
+const FAIL_THRESHOLD = 2 // 2 echecs consecutifs = on affiche
+
+export function DegradedModeBanner() {
+  const [failCount, setFailCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    const check = async (): Promise<void> => {
+      try {
+        const ctrl = new AbortController()
+        const t = setTimeout(() => ctrl.abort(), 3000)
+        const res = await fetch('/api/health', { signal: ctrl.signal })
+        clearTimeout(t)
+        if (cancelled) return
+        if (res.ok) setFailCount(0)
+        else setFailCount((c) => c + 1)
+      } catch {
+        if (!cancelled) setFailCount((c) => c + 1)
+      }
+    }
+    void check()
+    const id = setInterval(check, POLL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  if (failCount < FAIL_THRESHOLD) return null
+
+  return (
+    <div className="fixed top-0 inset-x-0 z-50 bg-red-700 text-white text-sm px-4 py-2 flex items-center gap-2 shadow-lg">
+      <AlertTriangle className="w-4 h-4 shrink-0" />
+      <span>Backend hors-ligne — les actions seront indisponibles. Reconnexion auto…</span>
+    </div>
+  )
+}

--- a/web/frontend/src/components/Sidebar.tsx
+++ b/web/frontend/src/components/Sidebar.tsx
@@ -9,14 +9,18 @@ import {
   Settings2,
   User,
   LogOut,
+  Map,
+  Terminal,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
-  { to: '/', label: 'Dashboard', code: '01', Icon: LayoutDashboard },
-  { to: '/missions', label: 'Missions', code: '02', Icon: ListChecks },
-  { to: '/missions/new', label: 'Nouvelle mission', code: '03', Icon: Plus },
-  { to: '/admin', label: 'Admin', code: '04', Icon: Settings2 },
-  { to: '/profile', label: 'Profil', code: '05', Icon: User },
+  { to: '/', label: 'Dashboard', code: '01', Icon: LayoutDashboard, adminOnly: false },
+  { to: '/missions', label: 'Missions', code: '02', Icon: ListChecks, adminOnly: false },
+  { to: '/missions/new', label: 'Nouvelle mission', code: '03', Icon: Plus, adminOnly: false },
+  { to: '/mapping', label: 'Mode mapping', code: '04', Icon: Map, adminOnly: false },
+  { to: '/admin', label: 'Admin', code: '05', Icon: Settings2, adminOnly: true },
+  { to: '/admin/ssh', label: 'SSH admin', code: '06', Icon: Terminal, adminOnly: true },
+  { to: '/profile', label: 'Profil', code: '07', Icon: User, adminOnly: false },
 ]
 
 export function Sidebar() {
@@ -67,7 +71,7 @@ export function Sidebar() {
 
       {/* Nav */}
       <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
-        {NAV_ITEMS.map(({ to, label, code, Icon }) => (
+        {NAV_ITEMS.filter((item) => !item.adminOnly || user?.role === 'ADMIN').map(({ to, label, code, Icon }) => (
           <NavLink
             key={to}
             to={to}

--- a/web/frontend/src/lib/sshApi.ts
+++ b/web/frontend/src/lib/sshApi.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from './api'
+
+export interface SshAuditEntry {
+  id: number
+  robotId: number
+  userId: number
+  user: { id: number; name: string; email: string } | null
+  mode: 'ALLOWLIST' | 'ELEVATED'
+  command: string
+  exitCode: number | null
+  durationMs: number | null
+  createdAt: string
+}
+
+export async function fetchSshAudit(robotId?: number, take = 50): Promise<SshAuditEntry[]> {
+  const params = new URLSearchParams()
+  if (robotId) params.set('robotId', String(robotId))
+  params.set('take', String(take))
+  const res = await apiFetch(`/admin/ssh/audit?${params}`)
+  if (!res.ok) throw new Error(`fetchSshAudit ${res.status}`)
+  return res.json()
+}
+
+export async function fetchRobotLogs(
+  robotId: number,
+  opts: { unit?: string; lines?: number } = {},
+): Promise<{ command: string; stdout: string; exitCode: number }> {
+  const params = new URLSearchParams()
+  if (opts.unit) params.set('unit', opts.unit)
+  if (opts.lines) params.set('lines', String(opts.lines))
+  const res = await apiFetch(`/admin/ssh/robots/${robotId}/logs?${params}`)
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? `fetchRobotLogs ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function execSsh(
+  robotId: number,
+  command: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const res = await apiFetch('/admin/ssh/exec', {
+    method: 'POST',
+    body: JSON.stringify({ robotId, command }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? `execSsh ${res.status}`)
+  }
+  return res.json()
+}

--- a/web/frontend/src/pages/AdminSshPage.tsx
+++ b/web/frontend/src/pages/AdminSshPage.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowLeft, Terminal, RefreshCw, FileText, Shield } from 'lucide-react'
+import { toast } from 'sonner'
+import { useRobotStore } from '../stores/robotStore'
+import { fetchSshAudit, fetchRobotLogs, execSsh, type SshAuditEntry } from '../lib/sshApi'
+
+// Page admin /admin/ssh. Affiche :
+// - les derniers audits SSH (qui a lance quoi quand)
+// - un viewer journalctl (poll manuel via bouton refresh)
+// - une console allowlist (input + bouton exec)
+
+const SUGGESTED_CMDS = [
+  'uptime',
+  'free -h',
+  'df -h',
+  'ros2 topic list',
+  'ros2 node list',
+  'docker ps',
+]
+
+export function AdminSshPage() {
+  const robotId = useRobotStore((s) => s.id)
+  const [audit, setAudit] = useState<SshAuditEntry[]>([])
+  const [logs, setLogs] = useState<string>('')
+  const [unit, setUnit] = useState('')
+  const [cmd, setCmd] = useState('')
+  const [output, setOutput] = useState<string>('')
+  const [loadingAudit, setLoadingAudit] = useState(false)
+  const [loadingLogs, setLoadingLogs] = useState(false)
+  const [running, setRunning] = useState(false)
+
+  const refreshAudit = async (): Promise<void> => {
+    setLoadingAudit(true)
+    try {
+      setAudit(await fetchSshAudit(robotId, 30))
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'erreur audit')
+    } finally {
+      setLoadingAudit(false)
+    }
+  }
+  const refreshLogs = async (): Promise<void> => {
+    setLoadingLogs(true)
+    try {
+      const r = await fetchRobotLogs(robotId, { unit: unit || undefined, lines: 200 })
+      setLogs(r.stdout || '(aucune ligne)')
+    } catch (e) {
+      setLogs(`erreur: ${e instanceof Error ? e.message : 'unknown'}`)
+    } finally {
+      setLoadingLogs(false)
+    }
+  }
+  const runCmd = async (c: string): Promise<void> => {
+    setRunning(true)
+    setOutput('')
+    try {
+      const r = await execSsh(robotId, c)
+      setOutput(`$ ${c}\n${r.stdout}${r.stderr ? `\n--stderr--\n${r.stderr}` : ''}\n(exit ${r.code})`)
+      void refreshAudit()
+    } catch (e) {
+      setOutput(`erreur: ${e instanceof Error ? e.message : 'unknown'}`)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  useEffect(() => {
+    void refreshAudit()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [robotId])
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link to="/" className="text-gray-400 hover:text-white">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div>
+            <h1 className="text-2xl font-semibold text-white">SSH admin</h1>
+            <p className="text-sm text-gray-500 mt-0.5">Allowlist + audit + journalctl</p>
+          </div>
+        </div>
+        <span className="flex items-center gap-1.5 text-yellow-400 text-xs">
+          <Shield className="w-4 h-4" /> admin uniquement
+        </span>
+      </div>
+
+      {/* Console allowlist */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Terminal className="w-4 h-4 text-gray-400" />
+          <h2 className="text-sm font-medium text-gray-300">Console (commandes allowlist)</h2>
+        </div>
+        <div className="flex flex-wrap gap-2 mb-3">
+          {SUGGESTED_CMDS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setCmd(s)}
+              className="text-xs px-2 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded border border-gray-700"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-2 mb-3">
+          <input
+            value={cmd}
+            onChange={(e) => setCmd(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && cmd && !running) void runCmd(cmd) }}
+            placeholder="ros2 topic list"
+            className="flex-1 bg-black border border-gray-700 rounded px-3 py-1.5 text-sm text-white font-mono"
+          />
+          <button
+            onClick={() => void runCmd(cmd)}
+            disabled={!cmd || running}
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded text-sm"
+          >
+            Exec
+          </button>
+        </div>
+        {output && (
+          <pre className="bg-black border border-gray-900 rounded p-3 text-xs text-gray-200 overflow-auto max-h-64 font-mono whitespace-pre-wrap">
+            {output}
+          </pre>
+        )}
+      </div>
+
+      {/* Logs */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <FileText className="w-4 h-4 text-gray-400" />
+            <h2 className="text-sm font-medium text-gray-300">journalctl</h2>
+          </div>
+          <div className="flex gap-2">
+            <input
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              placeholder="unit (optionnel, ex: roblaude.service)"
+              className="bg-black border border-gray-700 rounded px-2 py-1 text-xs text-white font-mono w-64"
+            />
+            <button
+              onClick={refreshLogs}
+              disabled={loadingLogs}
+              className="text-xs flex items-center gap-1 px-2 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded"
+            >
+              <RefreshCw className={`w-3 h-3 ${loadingLogs ? 'animate-spin' : ''}`} /> recharger
+            </button>
+          </div>
+        </div>
+        <pre className="bg-black border border-gray-900 rounded p-3 text-xs text-gray-300 overflow-auto max-h-96 font-mono whitespace-pre">
+          {logs || '(clique recharger)'}
+        </pre>
+      </div>
+
+      {/* Audit log */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-gray-300">Historique audit SSH</h2>
+          <button
+            onClick={refreshAudit}
+            disabled={loadingAudit}
+            className="text-gray-500 hover:text-white"
+          >
+            <RefreshCw className={`w-4 h-4 ${loadingAudit ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+        <div className="overflow-auto max-h-80">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-gray-500 border-b border-gray-800">
+                <th className="text-left py-1.5 px-2">Date</th>
+                <th className="text-left py-1.5 px-2">User</th>
+                <th className="text-left py-1.5 px-2">Mode</th>
+                <th className="text-left py-1.5 px-2">Commande</th>
+                <th className="text-right py-1.5 px-2">Exit</th>
+                <th className="text-right py-1.5 px-2">ms</th>
+              </tr>
+            </thead>
+            <tbody>
+              {audit.map((a) => (
+                <tr key={a.id} className="border-b border-gray-900 text-gray-300">
+                  <td className="py-1 px-2">{new Date(a.createdAt).toLocaleString('fr-FR')}</td>
+                  <td className="py-1 px-2">{a.user?.name ?? a.userId}</td>
+                  <td className="py-1 px-2">{a.mode}</td>
+                  <td className="py-1 px-2 font-mono">{a.command}</td>
+                  <td className={`py-1 px-2 text-right ${a.exitCode === 0 ? 'text-green-400' : 'text-red-400'}`}>
+                    {a.exitCode ?? '—'}
+                  </td>
+                  <td className="py-1 px-2 text-right text-gray-500">{a.durationMs ?? '—'}</td>
+                </tr>
+              ))}
+              {audit.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="text-center text-gray-500 py-4">Aucun audit log.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Plan 6 MVP démo.

**Sidebar enrichie** : ajout 'Mode mapping' (📍) + 'SSH admin' (terminal, admin-only). Filtrage adminOnly basé sur user.role.

**DegradedModeBanner** : banner rouge global fixé en haut si `/api/health` échoue 2 fois consécutives (poll 5s, timeout 3s).

**Page /admin/ssh** (admin uniquement) : 3 sections —
- Console allowlist (suggestions + input + exec)
- Viewer journalctl (unit optionnel + refresh)
- Historique audit SSH (table avec user, exit code, durée)

**Backend** : ajout `/api/health` (alias de `/health`) pour proxy Vite.

**E2E** : nouveau `admin-ssh.spec.ts` (2 tests : non-admin redirige, admin voit la page).

**Hors scope (vs plan complet 6)**
- AnnotationLayer clic-to-create — dépend de MapLive (#247)
- HeatmapLayer / GhostLayer / MiniMapPip — démo non critique
- Push notifications PWA — démo non critique
- Sons sur events / thème arcade — démo non critique