### PR TITLE
fix(ux): bras statique + carte plein écran cam visible + GhostLayer + thème arcade + E2E golden

### DIFF
--- a/web/frontend/e2e/golden-path.spec.ts
+++ b/web/frontend/e2e/golden-path.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test'
+
+// Golden path E2E : parcours utilisateur complet. Pas de backend lance — on
+// stub /api/** + on injecte le token dans localStorage.
+
+const setupAuth = (role: 'USER' | 'ADMIN' = 'USER') => async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.addInitScript((r) => {
+    window.localStorage.setItem(
+      'roblaude-auth',
+      JSON.stringify({
+        state: { token: 'gp-token', user: { id: 1, email: 'gp@x', name: 'GP', role: r } },
+        version: 0,
+      }),
+    )
+  }, role)
+}
+
+const stubApi = async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.route('**/api/health', (route) => route.fulfill({ status: 200, body: '{"status":"ok"}' }))
+  await page.route('**/api/mapping/sessions**', (route) => route.fulfill({ status: 200, body: '[]' }))
+  await page.route('**/api/admin/ssh/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+  await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+}
+
+test.describe('Golden path utilisateur', () => {
+  test('Dashboard accessible apres login', async ({ page }) => {
+    await setupAuth('USER')(page)
+    await stubApi(page)
+    await page.goto('/')
+    // robot info ou link mapping visible
+    await expect(page.getByRole('link', { name: /Mode mapping|Cartographier/i }).first()).toBeVisible()
+  })
+
+  test('Page mapping shell complete', async ({ page }) => {
+    await setupAuth('USER')(page)
+    await stubApi(page)
+    await page.goto('/mapping')
+    await expect(page.getByRole('heading', { name: 'Mode mapping' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Demarrer/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Arreter/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Sauvegarder/ })).toBeVisible()
+    // Téléop visible
+    await expect(page.getByText('Téléop')).toBeVisible()
+    // DockBottom
+    await expect(page.getByText('TF tree')).toBeVisible()
+    await expect(page.getByText('Topics')).toBeVisible()
+  })
+
+  test('Toggle thème arcade applique class sur body', async ({ page }) => {
+    await setupAuth('USER')(page)
+    await stubApi(page)
+    await page.goto('/')
+    const arcadeBtn = page.getByRole('button', { name: /Mode arcade|Arcade ON/ })
+    await arcadeBtn.click()
+    await expect(page.locator('body')).toHaveClass(/theme-arcade/)
+  })
+
+  test('Admin SSH bloque pour USER', async ({ page }) => {
+    await setupAuth('USER')(page)
+    await stubApi(page)
+    await page.goto('/admin/ssh')
+    await expect(page).toHaveURL(/\/$/)
+  })
+
+  test('Admin SSH accessible pour ADMIN avec sections', async ({ page }) => {
+    await setupAuth('ADMIN')(page)
+    await stubApi(page)
+    await page.goto('/admin/ssh')
+    await expect(page.getByRole('heading', { name: 'SSH admin' })).toBeVisible()
+    await expect(page.getByText(/Terminal SSH|Console|journalctl|Historique audit/).first()).toBeVisible()
+  })
+})

--- a/web/frontend/src/components/ArmViewer.tsx
+++ b/web/frontend/src/components/ArmViewer.tsx
@@ -99,20 +99,16 @@ export function ArmViewer({ robotId, enabled = true }: Props) {
 
     sceneRef.current = { scene, camera, renderer, joints: [base, shoulder, elbow, wrist1, wrist2] }
 
+    // Pose de repos par defaut — bras un peu plie vers l'avant pour ne pas
+    // ressembler a un poteau droit, mais STATIQUE (pas d'auto-anim).
+    // Quand joint_states reels arrivent, ils ecrasent ces valeurs.
+    shoulder.rotation.x = -0.3
+    elbow.rotation.x = 0.8
+    wrist1.rotation.x = -0.2
+
     let rafId: number
-    const t0 = performance.now()
     const animate = (): void => {
       rafId = requestAnimationFrame(animate)
-      const t = (performance.now() - t0) / 1000
-      // si pas de data reelle, anime sinusoidal — verification visuelle ca tourne
-      const ref = sceneRef.current
-      if (ref && !hasRealData) {
-        ref.joints[0].rotation.y = Math.sin(t * 0.5) * 0.8
-        ref.joints[1].rotation.x = Math.sin(t * 0.7) * 0.4 - 0.3
-        ref.joints[2].rotation.x = Math.sin(t * 0.9 + 1) * 0.5 + 0.5
-        ref.joints[3].rotation.x = Math.sin(t * 1.1 + 2) * 0.4
-        ref.joints[4].rotation.y = Math.sin(t * 1.3) * 0.6
-      }
       renderer.render(scene, camera)
     }
     animate()
@@ -134,7 +130,7 @@ export function ArmViewer({ robotId, enabled = true }: Props) {
       container.removeChild(renderer.domElement)
       sceneRef.current = null
     }
-  }, [enabled, hasRealData])
+  }, [enabled])
 
   // listen joint_states via WS telemetry (re-utilise le meme endpoint)
   useEffect(() => {
@@ -198,8 +194,8 @@ export function ArmViewer({ robotId, enabled = true }: Props) {
       <div className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800">
         <div className="flex items-center gap-1.5 text-xs text-gray-300">
           <Bot className="w-3 h-3" /> Bras 3D
-          <span className={`text-[10px] ${hasRealData ? 'text-green-400' : 'text-yellow-400'}`}>
-            {hasRealData ? 'live' : 'demo'}
+          <span className={`text-[10px] ${hasRealData ? 'text-green-400' : 'text-gray-500'}`}>
+            {hasRealData ? 'live' : 'pose repos'}
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/web/frontend/src/components/GhostLayer.tsx
+++ b/web/frontend/src/components/GhostLayer.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { apiFetch } from '@/lib/api'
+import { History } from 'lucide-react'
+
+// Affiche les 2-3 derniers snapshots du robot en transparence superposes
+// sur la carte courante. Permet de voir comment la carte a evolue.
+// Endpoint utilise : GET /api/mapping/sessions?robotId=X qui inclut les
+// snapshots ; on prend les 3 plus recents et on charge leurs PNG.
+
+interface Props {
+  robotId: number
+  enabled: boolean
+  // dimensions cibles (px de la carte courante) pour les positionner
+  width: number
+  height: number
+}
+
+interface Snapshot {
+  id: number
+  createdAt: string
+}
+
+export function GhostLayer({ robotId, enabled, width, height }: Props) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([])
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await apiFetch(`/mapping/sessions?robotId=${robotId}`)
+        if (!res.ok) return
+        const sessions = await res.json() as Array<{ snapshots?: Snapshot[] }>
+        const all: Snapshot[] = []
+        for (const s of sessions) {
+          if (s.snapshots) all.push(...s.snapshots)
+        }
+        all.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        if (!cancelled) setSnapshots(all.slice(0, 3))
+      } catch {
+        /* ignore */
+      }
+    })()
+    return () => { cancelled = true }
+  }, [robotId, enabled])
+
+  if (!enabled || snapshots.length === 0) return null
+
+  // 3 calques d'opacite croissante : le plus ancien = plus transparent
+  const opacities = [0.15, 0.25, 0.35]
+
+  return (
+    <>
+      {snapshots.map((snap, i) => (
+        <img
+          key={snap.id}
+          src={`/api/mapping/snapshots/${snap.id}/download.png`}
+          alt={`ghost ${snap.id}`}
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            width,
+            height,
+            opacity: opacities[i] ?? 0.15,
+            imageRendering: 'pixelated',
+            mixBlendMode: 'screen',
+          }}
+        />
+      ))}
+      <div className="absolute top-2 left-2 z-10 bg-gray-900/80 border border-gray-700 rounded px-2 py-1 text-[10px] text-gray-300 flex items-center gap-1.5">
+        <History className="w-3 h-3" /> {snapshots.length} ghost{snapshots.length > 1 ? 's' : ''}
+      </div>
+    </>
+  )
+}

--- a/web/frontend/src/components/MapLive.tsx
+++ b/web/frontend/src/components/MapLive.tsx
@@ -5,6 +5,8 @@ import { useMappingStore } from '@/stores/mappingStore'
 import { worldToPixel, pixelToWorld } from '@/lib/mapProjection'
 import { getHeatmapCells, recordVisit, CELL_SIZE_M } from '@/lib/heatmapAccumulator'
 import { createAnnotation, type Annotation } from '@/lib/annotationsApi'
+import { GhostLayer } from './GhostLayer'
+import { useRobotStore } from '@/stores/robotStore'
 
 // Carte SLAM live avec overlay canvas (scan, plan, frontiers, trail, heatmap)
 // + annotations cliquables + mode plein ecran.
@@ -16,6 +18,7 @@ interface LayerToggles {
   trail: boolean
   heatmap: boolean
   annotations: boolean
+  ghost: boolean
 }
 
 interface PendingAnnotation {
@@ -34,6 +37,7 @@ interface Props {
 
 export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotationCreated }: Props) {
   const { mapPngUrl, mapMeta, scan, plan, frontiers, trail, robotPose } = useMappingStore()
+  const robotId = useRobotStore((s) => s.id)
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [fullscreen, setFullscreen] = useState(false)
@@ -44,25 +48,25 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
     trail: true,
     heatmap: false,
     annotations: true,
+    ghost: false,
   })
   const [showLayerMenu, setShowLayerMenu] = useState(false)
   const [pending, setPending] = useState<PendingAnnotation | null>(null)
   const [pendingLabel, setPendingLabel] = useState('')
 
+  // CSS fullscreen (au lieu de Fullscreen API) — comme ca les siblings
+  // fixed (CameraView, ArmViewer, MiniMapPip) restent visibles dans le DOM.
   const toggleFullscreen = useCallback((): void => {
-    const el = containerRef.current
-    if (!el) return
-    if (!document.fullscreenElement) {
-      void el.requestFullscreen()
-    } else {
-      void document.exitFullscreen()
-    }
+    setFullscreen((f) => !f)
   }, [])
 
+  // Echap pour sortir du plein ecran (cohherent avec Fullscreen API natif)
   useEffect(() => {
-    const onFs = (): void => setFullscreen(!!document.fullscreenElement)
-    document.addEventListener('fullscreenchange', onFs)
-    return () => document.removeEventListener('fullscreenchange', onFs)
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setFullscreen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
   }, [])
 
   // accumule les visites du robot pour la heatmap
@@ -227,8 +231,10 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
   return (
     <div
       ref={containerRef}
-      className={`relative bg-black border border-gray-900 rounded ${
-        fullscreen ? 'flex items-center justify-center' : ''
+      className={`bg-black border border-gray-900 rounded ${
+        fullscreen
+          ? 'fixed inset-0 z-40 flex items-center justify-center'
+          : 'relative'
       }`}
     >
       {/* boutons en haut a droite */}
@@ -243,7 +249,7 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
           </button>
           {showLayerMenu && (
             <div className="absolute top-full right-0 mt-1 bg-gray-900 border border-gray-700 rounded p-2 text-xs space-y-1 min-w-[140px]">
-              {(['scan', 'plan', 'frontiers', 'trail', 'heatmap', 'annotations'] as const).map((k) => (
+              {(['scan', 'plan', 'frontiers', 'trail', 'heatmap', 'annotations', 'ghost'] as const).map((k) => (
                 <label key={k} className="flex items-center gap-2 text-gray-200 cursor-pointer">
                   <input
                     type="checkbox"
@@ -276,6 +282,12 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
               alt="Carte SLAM"
               className={fullscreen ? 'max-h-screen max-w-screen' : 'max-w-full max-h-[600px]'}
               style={{ imageRendering: 'pixelated', display: 'block' }}
+            />
+            <GhostLayer
+              robotId={robotId}
+              enabled={layers.ghost}
+              width={mapMeta?.width ?? 0}
+              height={mapMeta?.height ?? 0}
             />
             <canvas
               ref={canvasRef}

--- a/web/frontend/src/components/Sidebar.tsx
+++ b/web/frontend/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import { useRobotStore } from '../stores/robotStore'
 import { StopButton } from './StopButton'
+import { useThemeStore } from '../stores/themeStore'
 import {
   LayoutDashboard,
   ListChecks,
@@ -11,6 +12,7 @@ import {
   LogOut,
   Map,
   Terminal,
+  Sparkles,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
@@ -26,6 +28,8 @@ const NAV_ITEMS = [
 export function Sidebar() {
   const { user, logout } = useAuthStore()
   const { connected, status } = useRobotStore()
+  const arcade = useThemeStore((s) => s.arcade)
+  const toggleArcade = useThemeStore((s) => s.toggleArcade)
 
   return (
     <aside
@@ -110,6 +114,18 @@ export function Sidebar() {
 
       {/* Footer */}
       <div className="px-4 py-4 border-t border-border space-y-3">
+        <button
+          onClick={toggleArcade}
+          className={`w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs rounded border transition-colors ${
+            arcade
+              ? 'bg-primary/20 border-primary text-primary'
+              : 'border-border text-muted-foreground hover:text-foreground'
+          }`}
+          aria-pressed={arcade}
+        >
+          <Sparkles className="w-3 h-3" /> {arcade ? 'Arcade ON' : 'Mode arcade'}
+        </button>
+
         <StopButton />
 
         <div className="flex items-center gap-2.5 pt-1">

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -216,3 +216,36 @@ body {
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+
+/* ============================================================
+   Theme ARCADE (toggle via class .theme-arcade sur <body>)
+   Scanlines CRT + glow neon + accent cyan.
+   ============================================================ */
+
+body.theme-arcade {
+  --primary: oklch(0.78 0.18 200);  /* cyan neon */
+  --accent-legacy: #00ffff;
+}
+
+body.theme-arcade::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 255, 255, 0.03) 0,
+    rgba(0, 255, 255, 0.03) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  pointer-events: none;
+  z-index: 1000;
+  mix-blend-mode: overlay;
+}
+
+body.theme-arcade h1,
+body.theme-arcade h2,
+body.theme-arcade .text-foreground {
+  text-shadow: 0 0 8px rgba(0, 255, 255, 0.4);
+}

--- a/web/frontend/src/stores/themeStore.ts
+++ b/web/frontend/src/stores/themeStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+// Toggle thème arcade — persiste dans localStorage et applique la classe
+// `theme-arcade` sur <body> au mount via subscribe.
+
+interface ThemeStore {
+  arcade: boolean
+  toggleArcade: () => void
+  setArcade: (v: boolean) => void
+}
+
+export const useThemeStore = create<ThemeStore>()(
+  persist(
+    (set) => ({
+      arcade: false,
+      toggleArcade: () => set((s) => ({ arcade: !s.arcade })),
+      setArcade: (v) => set({ arcade: v }),
+    }),
+    { name: 'roblaude-theme' },
+  ),
+)
+
+// Applique la classe sur <body> a chaque changement.
+if (typeof document !== 'undefined') {
+  const apply = (arcade: boolean): void => {
+    document.body.classList.toggle('theme-arcade', arcade)
+  }
+  // initial
+  apply(useThemeStore.getState().arcade)
+  useThemeStore.subscribe((state) => apply(state.arcade))
+}


### PR DESCRIPTION
**Fix bugs UX**
- **ArmViewer** : plus d'auto-animation sinusoidale en l'absence de joint_states. Pose de repos statique (épaule pliée légère). Badge "pose repos" gris au lieu de "demo" jaune.
- **MapLive plein écran** : passe de Fullscreen API → CSS `fixed inset-0 z-40`. Du coup CameraView, ArmViewer et MiniMapPip restent visibles (Fullscreen API masque tous les siblings). Échap pour sortir.

**Features**
- **GhostLayer** : superposition des 3 derniers snapshots du robot en transparence (opacity 0.15/0.25/0.35 + mix-blend-mode screen). Toggle dans le menu Layers.
- **Thème arcade** : toggle dans la sidebar (icône Sparkles). Active class `theme-arcade` sur body → scanlines CRT + glow néon cyan sur les titres. Persisté en localStorage.
- **E2E golden path** : 5 tests Playwright couvrant Dashboard, Mapping shell, toggle arcade, RBAC SSH admin (USER bloqué / ADMIN OK).