### PR TITLE
fix(arm): convention servos Yahboom 0..180 + presets HOME/salut/pince + fetch_urdf set -u

### DIFF
--- a/robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py
+++ b/robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py
@@ -133,12 +133,12 @@ def build_joint_states_payload(names, positions) -> dict:
 
 
 # Limites pour cmd/arm (securite avant que le msg ROS atteigne YB_Node).
-# Servos Yahboom M3 Pro = unites entieres int16, range typique -180..180
-# pour les axes, 0..180 pour la pince. Le `time` < 50 ms peut endommager
-# les servos (mouvement trop brusque), > 5000 ms = inutile pour pilotage live.
-ARM_JOINT_MIN = -180
+# Doc officielle Yahboom M3 Pro : tous les joints sont 0..180 (unsigned),
+# 90 = neutre. Voir armController.ts pour le mapping des roles.
+# time < 500 ms = saccade, > 5000 ms = bloque selon constructeur.
+ARM_JOINT_MIN = 0
 ARM_JOINT_MAX = 180
-ARM_TIME_MIN_MS = 50
+ARM_TIME_MIN_MS = 500
 ARM_TIME_MAX_MS = 5000
 
 

--- a/robot/roblaude_mqtt/test/test_arm_command.py
+++ b/robot/roblaude_mqtt/test/test_arm_command.py
@@ -20,38 +20,39 @@ def _load():
 
 
 def test_validate_arm_command_happy_path():
+    # Convention Yahboom : 0..180, HOME = [90, 120, 10, 20, 90, 0]
     fn = _load()
     joints, t = fn({
-        'joint1': 10, 'joint2': -20, 'joint3': 30,
-        'joint4': -40, 'joint5': 50, 'joint6': 90, 'time': 800,
+        'joint1': 90, 'joint2': 120, 'joint3': 10,
+        'joint4': 20, 'joint5': 90, 'joint6': 0, 'time': 2000,
     })
-    assert joints == [10, -20, 30, -40, 50, 90]
-    assert t == 800
+    assert joints == [90, 120, 10, 20, 90, 0]
+    assert t == 2000
 
 
 def test_validate_arm_command_clamps_angles():
+    # Yahboom : 0..180 unsigned
     fn = _load()
     joints, _ = fn({
-        'joint1': 999, 'joint2': -999, 'joint3': 0,
-        'joint4': 0, 'joint5': 0, 'joint6': 200, 'time': 500,
+        'joint1': 999, 'joint2': -50, 'joint3': 90,
+        'joint4': 90, 'joint5': 90, 'joint6': 250, 'time': 2000,
     })
-    # joint1 clamp a 180, joint2 a -180, joint6 a 180
-    assert joints[0] == 180
-    assert joints[1] == -180
-    assert joints[5] == 180
+    assert joints[0] == 180   # 999 clamp a 180 (max)
+    assert joints[1] == 0     # -50 clamp a 0 (min)
+    assert joints[5] == 180   # 250 clamp a 180
 
 
 def test_validate_arm_command_clamps_time():
     fn = _load()
     _, t_too_fast = fn({
-        'joint1': 0, 'joint2': 0, 'joint3': 0,
-        'joint4': 0, 'joint5': 0, 'joint6': 0, 'time': 10,
+        'joint1': 90, 'joint2': 90, 'joint3': 90,
+        'joint4': 90, 'joint5': 90, 'joint6': 0, 'time': 100,
     })
     _, t_too_slow = fn({
-        'joint1': 0, 'joint2': 0, 'joint3': 0,
-        'joint4': 0, 'joint5': 0, 'joint6': 0, 'time': 99999,
+        'joint1': 90, 'joint2': 90, 'joint3': 90,
+        'joint4': 90, 'joint5': 90, 'joint6': 0, 'time': 99999,
     })
-    assert t_too_fast == 50    # min
+    assert t_too_fast == 500   # min (selon doc Yahboom : < 500ms = saccade)
     assert t_too_slow == 5000  # max
 
 

--- a/robot/scripts/fetch_urdf_from_robot.sh
+++ b/robot/scripts/fetch_urdf_from_robot.sh
@@ -6,7 +6,9 @@
 #
 # Pre-requis : robot up, container m3pro tourne, /robot_state_publisher actif.
 
-set -euo pipefail
+set -eo pipefail
+# pas de -u car find_robot.sh teste $ROBOT_IP avant set, et certains
+# autres scripts du dossier supposent un environnement laxe.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/web/backend/src/controllers/armController.ts
+++ b/web/backend/src/controllers/armController.ts
@@ -6,13 +6,20 @@ import { robotMqtt } from '../services/mqtt'
 // Publie sur MQTT roblaude/{id}/cmd/arm, le mqtt_bridge.py cote robot
 // transforme en arm_msgs/ArmJoints et l'envoie a YB_Node -> servos.
 //
-// Limites cote backend (double securite avec celles du robot) :
-//  joint1..6 : int16, on accepte -180..180 (clamp dur robot a -180/180)
-//  time      : 50..5000 ms (mouvement instantane = casser les servos)
+// CONVENTION OFFICIELLE YAHBOOM M3 PRO (servos numeriques STM32) :
+//   joint1 : base yaw       (0 = gauche, 90 = face avant, 180 = droite)
+//   joint2 : epaule pitch   (0 = vertical haut, 90 = 45°, 180 = horizontal)
+//   joint3 : coude          (0 = tendu, 90 = 90° plie, 180 = replie a fond)
+//   joint4 : poignet pitch  (0 = en bas, 90 = neutre, 180 = en haut)
+//   joint5 : poignet roulis (rotation)
+//   joint6 : gripper        (0 = ferme, 180 = ouvert max)
+//   time   : duree en ms    (500..5000, < 500 = saccade, > 5000 = bloque)
+//
+// HOME officielle : [90, 120, 10, 20, 90, 0] time=2000.
 
-const ARM_MIN = -180
+const ARM_MIN = 0
 const ARM_MAX = 180
-const TIME_MIN = 50
+const TIME_MIN = 500
 const TIME_MAX = 5000
 
 const armSchema = z.object({
@@ -38,28 +45,22 @@ const armSchema = z.object({
 //   joint5 : poignet yaw (rotation finale)
 //   joint6 : pince (0 = ouverte, 180 = fermee)
 
-// IMPORTANT : la convention angulaire Yahboom (signe positif/negatif des
-// servos) n'est PAS validee physiquement. Ces valeurs sont une premiere
-// approximation et DOIVENT etre ajustees par l'utilisateur via la fonction
-// de calibration cote frontend (bouton "Enregistrer pose courante").
-//
-// Symptome observe en demo (PR #256) : preset startup envoyait le bras
-// fortement vers le bas alors qu'on voulait juste un leger flechissement,
-// suggerant que joint2 negatif = abaisser, pas lever (inverse de ce que
-// j'avais suppose).
-//
-// Time augmente a 3000ms par defaut = mouvement doux, sans a-coup.
+// Poses officielles Yahboom M3 Pro. Source : doc constructeur fournie
+// par l'utilisateur (cf. commit msg PR #256). Convention 0..180, gripper
+// ferme = 0, ouvert max = 180.
 
 export const ARM_PRESETS = {
-  // Position au demarrage : valeurs prudentes proches du repos
-  // (pas de gros mouvement tant que pas calibre).
-  startup: { joint1: 0, joint2: 0, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 3000 },
-  // Position avant extinction : bras replie sur lui-meme, pince fermee.
-  // A valider physiquement par l'utilisateur.
-  shutdown: { joint1: 0, joint2: 60, joint3: -60, joint4: 0, joint5: 0, joint6: 180, time: 3000 },
-  // Reference "verticale" : bras tout droit pointant vers le haut.
-  // Si en pratique ca pointe ailleurs, l'utilisateur doit ajuster.
-  vertical: { joint1: 0, joint2: -90, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 3000 },
+  // HOME officielle Yahboom — pose recommandee au repos / debut+fin de session.
+  // Servos chauffent moins en position depliee, c'est la safe spot du M3 Pro.
+  startup: { joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90, joint6: 0, time: 2000 },
+  // Shutdown = HOME aussi (idem pose de repos)
+  shutdown: { joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90, joint6: 0, time: 2000 },
+  // Salut : bras leve, gripper ferme (gesture demo).
+  salut: { joint1: 90, joint2: 60, joint3: 30, joint4: 60, joint5: 90, joint6: 0, time: 2000 },
+  // Vertical pur : joint2=0 = bras pointant vers le haut.
+  vertical: { joint1: 90, joint2: 0, joint3: 0, joint4: 90, joint5: 90, joint6: 0, time: 2000 },
+  // Gripper teste : ouvre la pince au max.
+  gripperOpen: { joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90, joint6: 180, time: 1500 },
 } as const
 
 type PresetName = keyof typeof ARM_PRESETS

--- a/web/backend/src/controllers/armController.ts
+++ b/web/backend/src/controllers/armController.ts
@@ -38,15 +38,28 @@ const armSchema = z.object({
 //   joint5 : poignet yaw (rotation finale)
 //   joint6 : pince (0 = ouverte, 180 = fermee)
 
+// IMPORTANT : la convention angulaire Yahboom (signe positif/negatif des
+// servos) n'est PAS validee physiquement. Ces valeurs sont une premiere
+// approximation et DOIVENT etre ajustees par l'utilisateur via la fonction
+// de calibration cote frontend (bouton "Enregistrer pose courante").
+//
+// Symptome observe en demo (PR #256) : preset startup envoyait le bras
+// fortement vers le bas alors qu'on voulait juste un leger flechissement,
+// suggerant que joint2 negatif = abaisser, pas lever (inverse de ce que
+// j'avais suppose).
+//
+// Time augmente a 3000ms par defaut = mouvement doux, sans a-coup.
+
 export const ARM_PRESETS = {
-  // Position quand le robot s'allume : bras pret a travailler,
-  // legerement plie vers l'avant, pince mi-ouverte.
-  startup: { joint1: 0, joint2: -30, joint3: 60, joint4: 30, joint5: 0, joint6: 90, time: 1500 },
-  // Position avant extinction : bras replie sur lui-meme contre le corps,
-  // pince fermee. Evite que le bras tombe / traine au sol au shutdown.
-  shutdown: { joint1: 0, joint2: 80, joint3: -80, joint4: 0, joint5: 0, joint6: 180, time: 1500 },
-  // Reference de calibration : bras tout droit vertical.
-  vertical: { joint1: 0, joint2: -90, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 2000 },
+  // Position au demarrage : valeurs prudentes proches du repos
+  // (pas de gros mouvement tant que pas calibre).
+  startup: { joint1: 0, joint2: 0, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 3000 },
+  // Position avant extinction : bras replie sur lui-meme, pince fermee.
+  // A valider physiquement par l'utilisateur.
+  shutdown: { joint1: 0, joint2: 60, joint3: -60, joint4: 0, joint5: 0, joint6: 180, time: 3000 },
+  // Reference "verticale" : bras tout droit pointant vers le haut.
+  // Si en pratique ca pointe ailleurs, l'utilisateur doit ajuster.
+  vertical: { joint1: 0, joint2: -90, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 3000 },
 } as const
 
 type PresetName = keyof typeof ARM_PRESETS

--- a/web/backend/src/controllers/armController.ts
+++ b/web/backend/src/controllers/armController.ts
@@ -25,6 +25,32 @@ const armSchema = z.object({
   time: z.number().int().gte(TIME_MIN).lte(TIME_MAX).default(500),
 })
 
+// Poses predefinies calibrees par rapport au repere physique
+// "bras vertical pointant vers le haut" (cf. spec arm-control-design).
+// L'utilisateur peut ajuster ces valeurs par essai/erreur ; idealement
+// elles vivront dans un fichier de config robot un jour.
+//
+// Convention Yahboom M3 Pro (apres calibration physique):
+//   joint1 : base yaw   (0 = face avant robot)
+//   joint2 : epaule pitch (negatif = vers le haut, positif = vers le bas)
+//   joint3 : coude pitch (0 = bras tendu, positif = replie vers le haut)
+//   joint4 : poignet pitch (0 = aligne, positif = baisse)
+//   joint5 : poignet yaw (rotation finale)
+//   joint6 : pince (0 = ouverte, 180 = fermee)
+
+export const ARM_PRESETS = {
+  // Position quand le robot s'allume : bras pret a travailler,
+  // legerement plie vers l'avant, pince mi-ouverte.
+  startup: { joint1: 0, joint2: -30, joint3: 60, joint4: 30, joint5: 0, joint6: 90, time: 1500 },
+  // Position avant extinction : bras replie sur lui-meme contre le corps,
+  // pince fermee. Evite que le bras tombe / traine au sol au shutdown.
+  shutdown: { joint1: 0, joint2: 80, joint3: -80, joint4: 0, joint5: 0, joint6: 180, time: 1500 },
+  // Reference de calibration : bras tout droit vertical.
+  vertical: { joint1: 0, joint2: -90, joint3: 0, joint4: 0, joint5: 0, joint6: 90, time: 2000 },
+} as const
+
+type PresetName = keyof typeof ARM_PRESETS
+
 export async function commandArm(req: Request, res: Response): Promise<void> {
   const robotId = Number(req.params.id)
   if (!Number.isInteger(robotId) || robotId <= 0) {
@@ -41,6 +67,29 @@ export async function commandArm(req: Request, res: Response): Promise<void> {
     res.status(503).json({ error: 'mqtt not connected' })
     return
   }
-  // 202 Accepted — le mouvement reel prendra `time` ms cote robot
   res.status(202).json({ ok: true, sent: parsed.data })
+}
+
+export async function commandArmPreset(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.params.id)
+  if (!Number.isInteger(robotId) || robotId <= 0) {
+    res.status(400).json({ error: 'invalid robotId' })
+    return
+  }
+  const presetName = req.params.preset as PresetName
+  const preset = ARM_PRESETS[presetName]
+  if (!preset) {
+    res.status(400).json({ error: 'unknown preset', available: Object.keys(ARM_PRESETS) })
+    return
+  }
+  const ok = robotMqtt.publishCommand(robotId, 'arm', preset)
+  if (!ok) {
+    res.status(503).json({ error: 'mqtt not connected' })
+    return
+  }
+  res.status(202).json({ ok: true, preset: presetName, sent: preset })
+}
+
+export function listArmPresets(_req: Request, res: Response): void {
+  res.json(ARM_PRESETS)
 }

--- a/web/backend/src/routes/robots.ts
+++ b/web/backend/src/routes/robots.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { asyncHandler } from '../middleware/errorHandler'
 import { listRobots, getRobotStatus } from '../controllers/robotsController'
 import { getMapMetadata, getMapImage } from '../controllers/mapController'
-import { commandArm } from '../controllers/armController'
+import { commandArm, commandArmPreset, listArmPresets } from '../controllers/armController'
 
 const router = Router()
 
@@ -20,5 +20,11 @@ router.get('/:id/map.png', asyncHandler(getMapImage))
 
 // POST /api/robots/:id/arm — commande bras 6-DOF (5 axes + pince joint6)
 router.post('/:id/arm', asyncHandler(commandArm))
+
+// GET /api/robots/arm/presets — liste des presets disponibles (startup, shutdown, vertical)
+router.get('/arm/presets', listArmPresets)
+
+// POST /api/robots/:id/arm/preset/:preset — applique un preset predefini
+router.post('/:id/arm/preset/:preset', asyncHandler(commandArmPreset))
 
 export default router

--- a/web/frontend/src/components/ArmController.tsx
+++ b/web/frontend/src/components/ArmController.tsx
@@ -16,23 +16,25 @@ interface Props {
   robotId: number
 }
 
+// HOME officielle Yahboom M3 Pro — pose de repos par defaut.
 const REST_POSE: ArmCommand = {
-  joint1: 0, joint2: 0, joint3: 0, joint4: 0, joint5: 0, joint6: 90,
-  time: 1000,
+  joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90, joint6: 0,
+  time: 2000,
 }
 
+// Convention Yahboom : tous les joints sont 0..180, 90 = neutre.
 const SLIDERS = [
-  { key: 'joint1', label: 'Base (yaw)', min: -180, max: 180 },
-  { key: 'joint2', label: 'Épaule', min: -90, max: 90 },
-  { key: 'joint3', label: 'Coude', min: -90, max: 90 },
-  { key: 'joint4', label: 'Poignet 1', min: -90, max: 90 },
-  { key: 'joint5', label: 'Poignet 2', min: -180, max: 180 },
-  { key: 'joint6', label: '🤖 Pince', min: 0, max: 180 },
+  { key: 'joint1', label: 'Base (yaw) — 0=gauche, 90=face, 180=droite', min: 0, max: 180 },
+  { key: 'joint2', label: 'Épaule — 0=vertical, 90=45°, 180=horizontal', min: 0, max: 180 },
+  { key: 'joint3', label: 'Coude — 0=tendu, 90=plié, 180=replié', min: 0, max: 180 },
+  { key: 'joint4', label: 'Poignet pitch — 0=bas, 90=neutre, 180=haut', min: 0, max: 180 },
+  { key: 'joint5', label: 'Poignet roulis (rotation)', min: 0, max: 180 },
+  { key: 'joint6', label: '🤖 Gripper — 0=fermé, 180=ouvert', min: 0, max: 180 },
 ] as const
 
 export function ArmController({ robotId }: Props) {
   const [pose, setPose] = useState<ArmCommand>(REST_POSE)
-  const [timeMs, setTimeMs] = useState(1500)  // 1.5s par defaut, mouvement doux
+  const [timeMs, setTimeMs] = useState(2000)  // doc Yahboom : 2s = recommande
   const [busy, setBusy] = useState(false)
   const [armed, setArmed] = useState(false)  // safety toggle
   const lastSentRef = useRef<number>(0)
@@ -171,40 +173,55 @@ export function ArmController({ robotId }: Props) {
         </button>
       </div>
 
-      {/* Presets pre-configures. Convention angulaire non encore validee :
-          l'utilisateur doit confirmer les valeurs par essai et eventuellement
-          enregistrer ses propres poses via le store local (todo). */}
+      {/* Presets officiels Yahboom — convention 0..180, gripper 0=fermé, 180=ouvert */}
       <div className="border-t border-gray-800 pt-2">
         <div className="flex items-center justify-between mb-1.5">
           <div className="text-[10px] text-gray-500 font-mono uppercase tracking-wider">
-            Poses prédéfinies
+            Poses prédéfinies (Yahboom)
           </div>
-          <span className="text-[9px] text-yellow-500">non calibrées</span>
         </div>
-        <div className="grid grid-cols-3 gap-1">
+        <div className="grid grid-cols-2 gap-1 mb-1">
           <button
             onClick={() => void applyPreset('startup')}
             disabled={busy || !armed}
             className="flex items-center justify-center gap-1 px-2 py-1.5 bg-green-700 hover:bg-green-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
-            title="Pose au démarrage : bras prêt à travailler (légèrement plié vers l'avant)"
+            title="HOME officielle : [90, 120, 10, 20, 90, 0]"
           >
-            <Power className="w-3 h-3" /> Démarrage
+            <Power className="w-3 h-3" /> HOME
           </button>
+          <button
+            onClick={() => void applyPreset('salut')}
+            disabled={busy || !armed}
+            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-blue-700 hover:bg-blue-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Salut : bras levé [90, 60, 30, 60, 90, 0]"
+          >
+            👋 Salut
+          </button>
+        </div>
+        <div className="grid grid-cols-3 gap-1">
           <button
             onClick={() => void applyPreset('vertical')}
             disabled={busy || !armed}
-            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-cyan-700 hover:bg-cyan-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
-            title="Référence physique : bras tout droit vertical comme un pic"
+            className="flex items-center justify-center gap-1 px-1.5 py-1.5 bg-cyan-700 hover:bg-cyan-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Bras vertical : joint2=0"
           >
-            <Crosshair className="w-3 h-3" /> Vertical
+            <Crosshair className="w-3 h-3" /> Vert
+          </button>
+          <button
+            onClick={() => void applyPreset('gripperOpen')}
+            disabled={busy || !armed}
+            className="flex items-center justify-center gap-1 px-1.5 py-1.5 bg-purple-700 hover:bg-purple-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Ouvre la pince max (joint6=180)"
+          >
+            🖐 Pince
           </button>
           <button
             onClick={() => void applyPreset('shutdown')}
             disabled={busy || !armed}
-            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-orange-700 hover:bg-orange-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
-            title="Pose au rangement : bras replié sur lui-même, pince fermée"
+            className="flex items-center justify-center gap-1 px-1.5 py-1.5 bg-orange-700 hover:bg-orange-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Rangement (= HOME, sûre pour shutdown)"
           >
-            <PowerOff className="w-3 h-3" /> Rangement
+            <PowerOff className="w-3 h-3" /> Off
           </button>
         </div>
       </div>

--- a/web/frontend/src/components/ArmController.tsx
+++ b/web/frontend/src/components/ArmController.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback } from 'react'
-import { Bot, Send, RotateCcw, AlertTriangle } from 'lucide-react'
+import { Bot, Send, RotateCcw, AlertTriangle, Power, PowerOff, Crosshair } from 'lucide-react'
 import { toast } from 'sonner'
-import { commandArm, type ArmCommand } from '@/lib/armApi'
+import { commandArm, commandArmPreset, type ArmCommand, type ArmPresetName } from '@/lib/armApi'
 
 // Controle direct du bras 6-DOF Yahboom M3 Pro.
 // joint1..5 : axes du bras (-180..180 degres)
@@ -69,6 +69,28 @@ export function ArmController({ robotId }: Props) {
     void send(REST_POSE)
   }
 
+  const applyPreset = useCallback(async (preset: ArmPresetName): Promise<void> => {
+    if (!armed) {
+      toast.warning('Active "ARMÉ" pour appliquer un preset au vrai bras')
+      return
+    }
+    setBusy(true)
+    try {
+      const sent = await commandArmPreset(robotId, preset)
+      // sync l'UI avec ce qu'on a envoye (sauf time, le slider ne le gere pas)
+      setPose({
+        joint1: sent.joint1, joint2: sent.joint2, joint3: sent.joint3,
+        joint4: sent.joint4, joint5: sent.joint5, joint6: sent.joint6,
+      })
+      const label = preset === 'startup' ? 'Démarrage' : preset === 'shutdown' ? 'Rangement' : 'Vertical (référence)'
+      toast.success(`Preset "${label}" envoyé`)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : `erreur preset ${preset}`)
+    } finally {
+      setBusy(false)
+    }
+  }, [armed, robotId])
+
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
       <div className="flex items-center justify-between mb-3">
@@ -131,7 +153,7 @@ export function ArmController({ robotId }: Props) {
         />
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex gap-2 mb-2">
         <button
           onClick={() => void send(pose)}
           disabled={busy || !armed}
@@ -143,10 +165,43 @@ export function ArmController({ robotId }: Props) {
           onClick={resetPose}
           disabled={busy || !armed}
           className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-200 text-xs rounded font-medium"
-          title="Pose repos : tous joints à 0, pince à 90"
+          title="Pose repos manuelle : tous joints à 0, pince à 90"
         >
           <RotateCcw className="w-3 h-3" /> Repos
         </button>
+      </div>
+
+      {/* Presets calibres par rapport au repere physique "bras vertical" */}
+      <div className="border-t border-gray-800 pt-2">
+        <div className="text-[10px] text-gray-500 mb-1.5 font-mono uppercase tracking-wider">
+          Poses prédéfinies
+        </div>
+        <div className="grid grid-cols-3 gap-1">
+          <button
+            onClick={() => void applyPreset('startup')}
+            disabled={busy || !armed}
+            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-green-700 hover:bg-green-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Pose au démarrage : bras prêt à travailler (légèrement plié vers l'avant)"
+          >
+            <Power className="w-3 h-3" /> Démarrage
+          </button>
+          <button
+            onClick={() => void applyPreset('vertical')}
+            disabled={busy || !armed}
+            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-cyan-700 hover:bg-cyan-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Référence physique : bras tout droit vertical comme un pic"
+          >
+            <Crosshair className="w-3 h-3" /> Vertical
+          </button>
+          <button
+            onClick={() => void applyPreset('shutdown')}
+            disabled={busy || !armed}
+            className="flex items-center justify-center gap-1 px-2 py-1.5 bg-orange-700 hover:bg-orange-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-[10px] rounded font-medium"
+            title="Pose au rangement : bras replié sur lui-même, pince fermée"
+          >
+            <PowerOff className="w-3 h-3" /> Rangement
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/web/frontend/src/components/ArmController.tsx
+++ b/web/frontend/src/components/ArmController.tsx
@@ -32,7 +32,7 @@ const SLIDERS = [
 
 export function ArmController({ robotId }: Props) {
   const [pose, setPose] = useState<ArmCommand>(REST_POSE)
-  const [timeMs, setTimeMs] = useState(500)
+  const [timeMs, setTimeMs] = useState(1500)  // 1.5s par defaut, mouvement doux
   const [busy, setBusy] = useState(false)
   const [armed, setArmed] = useState(false)  // safety toggle
   const lastSentRef = useRef<number>(0)
@@ -171,10 +171,15 @@ export function ArmController({ robotId }: Props) {
         </button>
       </div>
 
-      {/* Presets calibres par rapport au repere physique "bras vertical" */}
+      {/* Presets pre-configures. Convention angulaire non encore validee :
+          l'utilisateur doit confirmer les valeurs par essai et eventuellement
+          enregistrer ses propres poses via le store local (todo). */}
       <div className="border-t border-gray-800 pt-2">
-        <div className="text-[10px] text-gray-500 mb-1.5 font-mono uppercase tracking-wider">
-          Poses prédéfinies
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="text-[10px] text-gray-500 font-mono uppercase tracking-wider">
+            Poses prédéfinies
+          </div>
+          <span className="text-[9px] text-yellow-500">non calibrées</span>
         </div>
         <div className="grid grid-cols-3 gap-1">
           <button

--- a/web/frontend/src/lib/armApi.ts
+++ b/web/frontend/src/lib/armApi.ts
@@ -21,7 +21,7 @@ export async function commandArm(robotId: number, cmd: ArmCommand): Promise<void
   }
 }
 
-export type ArmPresetName = 'startup' | 'shutdown' | 'vertical'
+export type ArmPresetName = 'startup' | 'shutdown' | 'salut' | 'vertical' | 'gripperOpen'
 
 export async function commandArmPreset(robotId: number, preset: ArmPresetName): Promise<ArmCommand> {
   const res = await apiFetch(`/robots/${robotId}/arm/preset/${preset}`, {

--- a/web/frontend/src/lib/armApi.ts
+++ b/web/frontend/src/lib/armApi.ts
@@ -20,3 +20,17 @@ export async function commandArm(robotId: number, cmd: ArmCommand): Promise<void
     throw new Error(body.error ?? `commandArm ${res.status}`)
   }
 }
+
+export type ArmPresetName = 'startup' | 'shutdown' | 'vertical'
+
+export async function commandArmPreset(robotId: number, preset: ArmPresetName): Promise<ArmCommand> {
+  const res = await apiFetch(`/robots/${robotId}/arm/preset/${preset}`, {
+    method: 'POST',
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? `commandArmPreset ${res.status}`)
+  }
+  const data = await res.json() as { sent: ArmCommand }
+  return data.sent
+}


### PR DESCRIPTION
Aligne le contrôle bras sur la doc constructeur Yahboom M3 Pro.

- Servos passés en 0..180 (unsigned, 90 = neutre) au lieu de -180..180
- time min relevé à 500ms (< 500 = saccade selon doc), max 5000ms
- presets refaits : HOME [90,120,10,20,90,0], salut, vertical, gripperOpen, shutdown=HOME
- retrait du warning UI "non calibrés" (valeurs désormais sourcées doc)
- limites alignées robot (mqtt_bridge.py) + backend (armController.ts) + tests
- fix fetch_urdf : drop set -u (find_robot.sh teste $ROBOT_IP avant le set)

CI verte (backend + frontend), tests arm 6/6.