### PR TITLE
fix(db): migrations Prisma manquantes (mapping/SSH) + CI migrate deploy (#259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      # cree les tables a partir du schema Prisma (test d'integration mapping-db)
-      - run: npx prisma db push --skip-generate
+      # applique les migrations comme en prod (Render) — detecte un drift schema/migrations
+      - run: npx prisma migrate deploy
       - run: npm test -- --passWithNoTests
 

--- a/web/backend/prisma/migrations/20260615072705_mapping_ssh_annotations/migration.sql
+++ b/web/backend/prisma/migrations/20260615072705_mapping_ssh_annotations/migration.sql
@@ -1,0 +1,101 @@
+-- CreateTable
+CREATE TABLE `MappingSession` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `robotId` INTEGER NOT NULL,
+    `startedById` INTEGER NOT NULL,
+    `state` ENUM('STARTING', 'RUNNING', 'STOPPING', 'STOPPED', 'FAILED') NOT NULL,
+    `failureReason` VARCHAR(191) NULL,
+    `startedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `endedAt` DATETIME(3) NULL,
+    `coverageM2` DOUBLE NULL,
+    `durationSec` INTEGER NULL,
+
+    INDEX `MappingSession_robotId_startedAt_idx`(`robotId`, `startedAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `MapSnapshot` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `sessionId` INTEGER NOT NULL,
+    `robotId` INTEGER NOT NULL,
+    `name` VARCHAR(191) NOT NULL,
+    `pgmPath` VARCHAR(191) NOT NULL,
+    `yamlPath` VARCHAR(191) NOT NULL,
+    `pngPath` VARCHAR(191) NOT NULL,
+    `widthPx` INTEGER NOT NULL,
+    `heightPx` INTEGER NOT NULL,
+    `resolutionM` DOUBLE NOT NULL,
+    `originX` DOUBLE NOT NULL,
+    `originY` DOUBLE NOT NULL,
+    `originTheta` DOUBLE NOT NULL,
+    `sizeBytes` INTEGER NOT NULL,
+    `isCurrent` BOOLEAN NOT NULL DEFAULT false,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `MapSnapshot_robotId_createdAt_idx`(`robotId`, `createdAt`),
+    INDEX `MapSnapshot_robotId_isCurrent_idx`(`robotId`, `isCurrent`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Annotation` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `mapSnapshotId` INTEGER NOT NULL,
+    `sessionId` INTEGER NULL,
+    `label` VARCHAR(191) NOT NULL,
+    `icon` VARCHAR(191) NULL,
+    `color` VARCHAR(191) NOT NULL DEFAULT '#3b82f6',
+    `x` DOUBLE NOT NULL,
+    `y` DOUBLE NOT NULL,
+    `createdById` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    INDEX `Annotation_mapSnapshotId_idx`(`mapSnapshotId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `SshAuditLog` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `robotId` INTEGER NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `mode` ENUM('ALLOWLIST', 'ELEVATED') NOT NULL,
+    `command` TEXT NOT NULL,
+    `exitCode` INTEGER NULL,
+    `durationMs` INTEGER NULL,
+    `ipAddr` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `SshAuditLog_robotId_createdAt_idx`(`robotId`, `createdAt`),
+    INDEX `SshAuditLog_userId_createdAt_idx`(`userId`, `createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `MappingSession` ADD CONSTRAINT `MappingSession_robotId_fkey` FOREIGN KEY (`robotId`) REFERENCES `Robot`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `MappingSession` ADD CONSTRAINT `MappingSession_startedById_fkey` FOREIGN KEY (`startedById`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `MapSnapshot` ADD CONSTRAINT `MapSnapshot_sessionId_fkey` FOREIGN KEY (`sessionId`) REFERENCES `MappingSession`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `MapSnapshot` ADD CONSTRAINT `MapSnapshot_robotId_fkey` FOREIGN KEY (`robotId`) REFERENCES `Robot`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Annotation` ADD CONSTRAINT `Annotation_mapSnapshotId_fkey` FOREIGN KEY (`mapSnapshotId`) REFERENCES `MapSnapshot`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Annotation` ADD CONSTRAINT `Annotation_sessionId_fkey` FOREIGN KEY (`sessionId`) REFERENCES `MappingSession`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Annotation` ADD CONSTRAINT `Annotation_createdById_fkey` FOREIGN KEY (`createdById`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `SshAuditLog` ADD CONSTRAINT `SshAuditLog_robotId_fkey` FOREIGN KEY (`robotId`) REFERENCES `Robot`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `SshAuditLog` ADD CONSTRAINT `SshAuditLog_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/web/backend/src/test/arm-controller.test.ts
+++ b/web/backend/src/test/arm-controller.test.ts
@@ -23,7 +23,7 @@ describe('POST /api/robots/:id/arm', () => {
     const res = await request(app)
       .post('/api/robots/1/arm')
       .set('Authorization', `Bearer ${token}`)
-      .send({ joint1: 10, joint2: -20, joint3: 30, joint4: -40, joint5: 50, joint6: 90, time: 800 })
+      .send({ joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90, joint6: 0, time: 800 })
     expect(res.status).toBe(202)
     expect(res.body.ok).toBe(true)
   })


### PR DESCRIPTION
Closes #259

Les 4 tables `MappingSession`, `MapSnapshot`, `Annotation`, `SshAuditLog` étaient dans schema.prisma mais dans aucune migration (créées en `db push` en dev). Une instance fraîche via `migrate deploy` (Render, CI) ne les avait pas → mapping/SSH/annotations cassés.

- nouvelle migration `20260615072705_mapping_ssh_annotations` (4 tables + index + FK)
- vérifiée byte-identique au DDL généré par Prisma (`migrate diff --from-empty`), schema valide
- CI backend : `db push` → `migrate deploy` pour appliquer/valider les migrations comme en prod (c'est ce qui masquait le drift)

⚠️ Sur une DB de dev qui a déjà les tables (db push), faire une fois :
`npx prisma migrate resolve --applied 20260615072705_mapping_ssh_annotations`
Sur une instance neuve, rien à faire.