### PR TITLE
test(e2e): suite mobile + UC-01 happy path + arrêt d'urgence + fix specs cassés

### DIFF
--- a/web/frontend/.gitignore
+++ b/web/frontend/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 playwright-report/
+test-results/

--- a/web/frontend/e2e/admin-ssh.spec.ts
+++ b/web/frontend/e2e/admin-ssh.spec.ts
@@ -34,7 +34,7 @@ test.describe('Page Admin SSH', () => {
 
     await expect(page.getByRole('heading', { name: 'SSH admin' })).toBeVisible()
     await expect(page.getByText('Console (commandes allowlist)')).toBeVisible()
-    await expect(page.getByText('journalctl')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'journalctl' })).toBeVisible()
     await expect(page.getByText('Historique audit SSH')).toBeVisible()
   })
 })

--- a/web/frontend/e2e/golden-path.spec.ts
+++ b/web/frontend/e2e/golden-path.spec.ts
@@ -16,10 +16,26 @@ const setupAuth = (role: 'USER' | 'ADMIN' = 'USER') => async (page: import('@pla
 }
 
 const stubApi = async (page: import('@playwright/test').Page): Promise<void> => {
+  // catch-all en premier = priorité la plus basse (Playwright évalue la route
+  // enregistrée en dernier en premier)
+  await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
   await page.route('**/api/health', (route) => route.fulfill({ status: 200, body: '{"status":"ok"}' }))
   await page.route('**/api/mapping/sessions**', (route) => route.fulfill({ status: 200, body: '[]' }))
   await page.route('**/api/admin/ssh/**', (route) => route.fulfill({ status: 200, body: '[]' }))
-  await page.route('**/api/**', (route) => route.fulfill({ status: 200, body: '[]' }))
+  // le dashboard attend {data, total} pour les missions et {data} pour le statut robot,
+  // sinon missions.filter() plante et démonte la page
+  await page.route('**/api/missions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [], total: 0 }) }),
+  )
+  await page.route('**/api/robots/1/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: { id: 1, name: 'Transbot-01', status: 'AVAILABLE', battery: 80, positionX: 0, positionY: 0, heading: 0 },
+      }),
+    }),
+  )
 }
 
 test.describe('Golden path utilisateur', () => {
@@ -46,7 +62,9 @@ test.describe('Golden path utilisateur', () => {
     await expect(page.getByText('Topics')).toBeVisible()
   })
 
-  test('Toggle thème arcade applique class sur body', async ({ page }) => {
+  test('Toggle thème arcade applique class sur body', async ({ page }, testInfo) => {
+    // le toggle arcade vit dans la sidebar desktop (hidden lg:flex) — absent en mobile
+    test.skip(testInfo.project.name === 'mobile', 'Toggle arcade = contrôle sidebar desktop')
     await setupAuth('USER')(page)
     await stubApi(page)
     await page.goto('/')

--- a/web/frontend/e2e/mission-flow.spec.ts
+++ b/web/frontend/e2e/mission-flow.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// E2E UC-01 (transport) : création de mission + arrêt d'urgence.
+// Pas de backend lancé — on stub /api/** et on injecte un token dans localStorage.
+
+const setupAuth = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      'roblaude-auth',
+      JSON.stringify({
+        state: { token: 'uc01-token', user: { id: 1, email: 'op@x', name: 'Op', role: 'USER' } },
+        version: 0,
+      }),
+    )
+  })
+}
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+})
+
+const ACCUEIL = { id: 1, name: 'Accueil', slug: 'accueil' }
+const BUREAU = { id: 2, name: 'Bureau 204', slug: 'bureau-204' }
+
+test.describe('UC-01 — flux mission transport', () => {
+  test('création mission → page détail', async ({ page }) => {
+    const mission = {
+      id: 42,
+      type: 'TRANSPORT',
+      status: 'PENDING',
+      userId: 1,
+      robotId: null,
+      fromPointId: 1,
+      toPointId: 2,
+      objectId: null,
+      failureReason: null,
+      graspAttempts: 0,
+      createdAt: '2026-06-14T10:00:00.000Z',
+      updatedAt: '2026-06-14T10:00:00.000Z',
+      fromPoint: ACCUEIL,
+      toPoint: BUREAU,
+      robot: null,
+    }
+
+    await setupAuth(page)
+    // catch-all d'abord (priorité la plus basse), puis les routes spécifiques
+    await page.route('**/api/**', (r) => r.fulfill(json({ data: [], total: 0 })))
+    await page.route('**/api/points', (r) => r.fulfill(json({ data: [ACCUEIL, BUREAU] })))
+    await page.route('**/api/robots', (r) => r.fulfill(json({ data: [{ id: 1, name: 'Transbot-01', status: 'AVAILABLE' }] })))
+    await page.route('**/api/missions**', (route) => {
+      const req = route.request()
+      const pathname = new URL(req.url()).pathname
+      if (req.method() === 'POST' && pathname.endsWith('/missions')) {
+        return route.fulfill({ ...json({ data: mission }), status: 201 })
+      }
+      if (pathname.endsWith('/missions/42')) {
+        return route.fulfill(json({ data: mission }))
+      }
+      return route.fulfill(json({ data: [], total: 0 }))
+    })
+
+    await page.goto('/missions/new')
+
+    const fromSelect = page.getByLabel('Point de depart')
+    await expect(fromSelect).toBeEnabled()
+    await fromSelect.selectOption('1')
+    await page.getByLabel('Point d arrivee').selectOption('2')
+
+    await page.getByRole('button', { name: 'Creer la mission' }).click()
+
+    await expect(page).toHaveURL(/\/missions\/42$/)
+    await expect(page.getByRole('heading', { name: 'Mission #42' })).toBeVisible()
+    await expect(page.getByText('Transport de document')).toBeVisible()
+  })
+
+  test('STOP — arrête la mission active', async ({ page }, testInfo) => {
+    // bouton STOP global = sidebar desktop (hidden lg:flex)
+    test.skip(testInfo.project.name === 'mobile', 'STOP global = contrôle sidebar desktop')
+
+    const mission = {
+      id: 7,
+      type: 'TRANSPORT',
+      status: 'NAVIGATING_TO_PICKUP',
+      userId: 1,
+      robotId: 1,
+      fromPointId: 1,
+      toPointId: 2,
+      objectId: null,
+      failureReason: null,
+      graspAttempts: 0,
+      createdAt: '2026-06-14T09:00:00.000Z',
+      updatedAt: '2026-06-14T09:30:00.000Z',
+      fromPoint: ACCUEIL,
+      toPoint: BUREAU,
+      robot: { id: 1, name: 'Transbot-01', status: 'BUSY' },
+    }
+
+    let stopCalled = false
+
+    await setupAuth(page)
+    await page.route('**/api/**', (r) => r.fulfill(json({ data: [], total: 0 })))
+    await page.route('**/api/missions**', (r) => r.fulfill(json({ data: [mission], total: 1 })))
+    await page.route('**/api/robots/1/status', (r) =>
+      r.fulfill(json({ data: { id: 1, name: 'Transbot-01', status: 'AVAILABLE', battery: 80, positionX: 0, positionY: 0, heading: 0 } })),
+    )
+    await page.route('**/api/missions/7/stop', (route) => {
+      stopCalled = true
+      return route.fulfill(json({ data: { ...mission, status: 'CANCELLED' } }))
+    })
+
+    // le bouton STOP demande confirmation via window.confirm
+    page.on('dialog', (d) => d.accept())
+
+    await page.goto('/')
+    // attend que les missions soient chargées (sinon STOP dit "aucune mission active")
+    await expect(page.getByText('#007')).toBeVisible()
+
+    const stopBtn = page.getByRole('button', { name: "Arrêt d'urgence du robot" })
+    await expect(stopBtn).toBeEnabled()
+    await stopBtn.click()
+
+    await expect(page.getByText('Mission #7 stoppée')).toBeVisible()
+    expect(stopCalled).toBe(true)
+  })
+})

--- a/web/frontend/playwright.config.ts
+++ b/web/frontend/playwright.config.ts
@@ -10,11 +10,20 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
+    // WebGL logiciel en headless — sinon Three.js (URDF/bras 3D) plante et
+    // démonte la page (pas de GPU dans le runner CI/headless).
+    launchOptions: {
+      args: ['--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader'],
+    },
   },
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 5'] },
     },
   ],
   webServer: {


### PR DESCRIPTION
Travail de Maxime (@TheKyyn).

Closes #100, #101, #148

- nouveau spec mission-flow (UC-01 happy path bout en bout + STOP)
- projet mobile ajouté dans playwright.config
- répare 4 specs cassés sur dev : WebGL headless, sélecteurs, stubs dashboard
- golden-path + admin-ssh remis au vert

Branche partie de #255, merge propre sur dev (0 conflit vérifié).