### PR TITLE
feat(backend): UC-02 pick&place — CRUD objets, watchdog missions, chaîne MQTT + coverage 70%

### DIFF
--- a/web/backend/package-lock.json
+++ b/web/backend/package-lock.json
@@ -34,10 +34,47 @@
         "@types/ssh2": "^1.15.5",
         "@types/supertest": "^7.2.0",
         "@types/ws": "^8.18.1",
+        "@vitest/coverage-v8": "^4.1.4",
         "supertest": "^7.2.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -47,6 +84,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1301,6 +1362,49 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
@@ -1516,6 +1620,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/asynckit": {
@@ -2602,6 +2729,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2646,6 +2783,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-errors": {
@@ -2810,6 +2954,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2828,6 +3027,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -3195,6 +3401,19 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -4214,7 +4433,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4391,6 +4610,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -40,6 +40,7 @@
     "@types/ssh2": "^1.15.5",
     "@types/supertest": "^7.2.0",
     "@types/ws": "^8.18.1",
+    "@vitest/coverage-v8": "^4.1.4",
     "supertest": "^7.2.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^6.0.2",

--- a/web/backend/src/app.ts
+++ b/web/backend/src/app.ts
@@ -6,6 +6,7 @@ import { authGuard } from './middleware/auth'
 import authRouter from './routes/auth'
 import missionsRouter from './routes/missions'
 import pointsRouter from './routes/points'
+import objectsRouter from './routes/objects'
 import robotsRouter from './routes/robots'
 import mappingRouter from './routes/mapping'
 import annotationsRouter from './routes/annotations'
@@ -39,6 +40,7 @@ app.use('/api/auth', authRouter)
 // Routes protegees par authGuard
 app.use('/api/missions', authGuard, missionsRouter)
 app.use('/api/points', authGuard, pointsRouter)
+app.use('/api/objects', authGuard, objectsRouter)
 app.use('/api/robots', authGuard, robotsRouter)
 app.use('/api/mapping', authGuard, mappingRouter)
 app.use('/api/annotations', authGuard, annotationsRouter)

--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -91,7 +91,10 @@ const createMissionSchema = z.object({
   toPointId: z.number().int().positive(),
   robotId: z.number().int().positive().optional(),
   objectId: z.number().int().positive().optional(),
-})
+}).refine(
+  (d) => d.type !== MissionType.PICK_AND_PLACE || d.objectId !== undefined,
+  { message: 'objectId est requis pour une mission pick & place', path: ['objectId'] },
+)
 
 export async function createMission(req: Request, res: Response) {
   // authGuard est en amont de cette route, mais on garde le check explicite
@@ -130,6 +133,15 @@ export async function createMission(req: Request, res: Response) {
     return
   }
 
+  // pick & place : l'objet doit exister (la cle etrangere echouerait sinon)
+  if (objectId) {
+    const object = await prisma.graspObject.findUnique({ where: { id: objectId } })
+    if (!object) {
+      res.status(400).json({ error: 'Objet introuvable', field: 'objectId' })
+      return
+    }
+  }
+
   // vérifier que le robot est dispo si précisé
   if (robotId) {
     const robot = await prisma.robot.findUnique({ where: { id: robotId } })
@@ -157,6 +169,7 @@ export async function createMission(req: Request, res: Response) {
       toPoint: true,
       robot: { select: { id: true, name: true, status: true } },
       user: { select: { id: true, name: true, email: true } },
+      object: true,
     },
   })
 

--- a/web/backend/src/controllers/objectsController.ts
+++ b/web/backend/src/controllers/objectsController.ts
@@ -1,0 +1,143 @@
+import { Request, Response } from 'express'
+import { Prisma } from '@prisma/client'
+import { z } from 'zod'
+import prisma from '../lib/prisma'
+
+/**
+ * GET /api/objects
+ * Liste les objets saisissables avec leur emplacement.
+ */
+export async function listObjects(_req: Request, res: Response) {
+  const objects = await prisma.graspObject.findMany({
+    orderBy: { name: 'asc' },
+    include: { location: { select: { id: true, name: true, slug: true } } },
+  })
+  res.json({ data: objects })
+}
+
+/**
+ * GET /api/objects/:id
+ * Detail d'un objet avec son emplacement.
+ */
+export async function getObject(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const object = await prisma.graspObject.findUnique({
+    where: { id },
+    include: { location: true },
+  })
+
+  if (!object) {
+    res.status(404).json({ error: 'Objet introuvable' })
+    return
+  }
+
+  res.json({ data: object })
+}
+
+// Validation pour creation/modification
+const objectSchema = z.object({
+  name: z.string().min(1, 'Le nom est requis'),
+  imageUrl: z.string().optional(),
+  available: z.boolean().default(true),
+  locationId: z.number().int().positive("L'emplacement est requis"),
+})
+
+/**
+ * POST /api/objects (admin only)
+ * Cree un nouvel objet saisissable.
+ */
+export async function createObject(req: Request, res: Response) {
+  const parsed = objectSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Donnees invalides', details: parsed.error.issues })
+    return
+  }
+
+  // l'emplacement doit exister, sinon la cle etrangere echouerait avec une 500
+  const point = await prisma.point.findUnique({ where: { id: parsed.data.locationId } })
+  if (!point) {
+    res.status(400).json({ error: 'Emplacement introuvable' })
+    return
+  }
+
+  const object = await prisma.graspObject.create({ data: parsed.data })
+  res.status(201).json({ data: object })
+}
+
+/**
+ * PUT /api/objects/:id (admin only)
+ * Modifie un objet existant.
+ */
+export async function updateObject(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const parsed = objectSchema.partial().safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Donnees invalides', details: parsed.error.issues })
+    return
+  }
+
+  if (parsed.data.locationId !== undefined) {
+    const point = await prisma.point.findUnique({ where: { id: parsed.data.locationId } })
+    if (!point) {
+      res.status(400).json({ error: 'Emplacement introuvable' })
+      return
+    }
+  }
+
+  const object = await prisma.graspObject.update({
+    where: { id },
+    data: parsed.data,
+  })
+
+  res.json({ data: object })
+}
+
+/**
+ * DELETE /api/objects/:id (admin only)
+ * Refuse si des missions referencent l'objet : on conserve l'historique.
+ */
+export async function deleteObject(req: Request, res: Response) {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'ID invalide' })
+    return
+  }
+
+  const linkedMissions = await prisma.mission.count({ where: { objectId: id } })
+  if (linkedMissions > 0) {
+    res.status(400).json({
+      error: 'Impossible de supprimer : cet objet est lie a des missions (historique compris)',
+      linkedMissions,
+    })
+    return
+  }
+
+  try {
+    await prisma.graspObject.delete({ where: { id } })
+    res.status(204).send()
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === 'P2003') {
+        res.status(400).json({
+          error: 'Cet objet est reference ailleurs et ne peut pas etre supprime',
+        })
+        return
+      }
+      if (e.code === 'P2025') {
+        res.status(404).json({ error: 'Objet introuvable' })
+        return
+      }
+    }
+    throw e
+  }
+}

--- a/web/backend/src/routes/objects.ts
+++ b/web/backend/src/routes/objects.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express'
+import { asyncHandler } from '../middleware/errorHandler'
+import { adminGuard } from '../middleware/auth'
+import { listObjects, getObject, createObject, updateObject, deleteObject } from '../controllers/objectsController'
+
+const router = Router()
+
+// GET /api/objects — liste (tous les users connectes)
+router.get('/', asyncHandler(listObjects))
+
+// GET /api/objects/:id — detail
+router.get('/:id', asyncHandler(getObject))
+
+// POST /api/objects — creer (admin only)
+router.post('/', adminGuard, asyncHandler(createObject))
+
+// PUT /api/objects/:id — modifier (admin only)
+router.put('/:id', adminGuard, asyncHandler(updateObject))
+
+// DELETE /api/objects/:id — supprimer (admin only)
+router.delete('/:id', adminGuard, asyncHandler(deleteObject))
+
+export default router

--- a/web/backend/src/services/missionWatchdog.ts
+++ b/web/backend/src/services/missionWatchdog.ts
@@ -1,0 +1,85 @@
+import { MissionStatus, RobotStatus } from '@prisma/client'
+import prisma from '../lib/prisma'
+import { mqttEvents } from './mqttEvents'
+
+// Si une mission active ne progresse plus (aucun mission/status ni mission/result)
+// pendant ce delai, on considere le robot bloque/injoignable : la mission passe
+// FAILED et le robot est libere. Configurable via env pour la demo soutenance.
+const DEFAULT_TIMEOUT_MS = Number(process.env.MISSION_TIMEOUT_MS) || 2 * 60 * 1000
+
+// Statuts qui peuvent expirer. PAUSED exclu : une mise en pause volontaire
+// ne doit pas declencher le timeout.
+const ACTIVE_STATUSES: MissionStatus[] = [
+  MissionStatus.PENDING,
+  MissionStatus.NAVIGATING_TO_PICKUP,
+  MissionStatus.WAITING_FOR_LOAD,
+  MissionStatus.NAVIGATING_TO_DESTINATION,
+  MissionStatus.DETECTING_OBJECT,
+  MissionStatus.GRASPING,
+  MissionStatus.TRANSPORTING,
+  MissionStatus.DEPOSITING,
+]
+
+class MissionWatchdog {
+  private timers = new Map<number, ReturnType<typeof setTimeout>>()
+
+  constructor(private timeoutMs: number = DEFAULT_TIMEOUT_MS) {}
+
+  /**
+   * (Re)arme le timer d'une mission. Appele au demarrage (mission/ack accepted)
+   * et a chaque progres (mission/status) : tant que le robot avance, on repousse.
+   */
+  arm(missionId: number, robotId: number): void {
+    this.clear(missionId)
+    const timer = setTimeout(() => { void this.fire(missionId, robotId) }, this.timeoutMs)
+    // ne pas garder le process en vie juste pour ce timer
+    if (typeof timer.unref === 'function') timer.unref()
+    this.timers.set(missionId, timer)
+  }
+
+  /** Annule le timer (mission terminee). */
+  clear(missionId: number): void {
+    const timer = this.timers.get(missionId)
+    if (timer) {
+      clearTimeout(timer)
+      this.timers.delete(missionId)
+    }
+  }
+
+  private async fire(missionId: number, robotId: number): Promise<void> {
+    this.timers.delete(missionId)
+    try {
+      // updateMany filtre sur les statuts actifs : si un mission/result tardif
+      // a deja termine la mission, count = 0 et on ne touche a rien (course).
+      const updated = await prisma.mission.updateMany({
+        where: { id: missionId, status: { in: ACTIVE_STATUSES } },
+        data: { status: MissionStatus.FAILED, failureReason: 'timeout' },
+      })
+      if (updated.count === 0) return
+
+      await prisma.robot.update({
+        where: { id: robotId },
+        data: { status: RobotStatus.AVAILABLE },
+      })
+      mqttEvents.emit('mission_completed', { missionId, result: 'failed', reason: 'timeout' })
+      mqttEvents.emit('status_change', { robotId, status: RobotStatus.AVAILABLE })
+    } catch (err) {
+      console.error('[watchdog] timeout mission', missionId, ':',
+        err instanceof Error ? err.message : err)
+    }
+  }
+
+  /** Tests : nombre de timers armes. */
+  get pending(): number {
+    return this.timers.size
+  }
+
+  /** Tests : annule tous les timers. */
+  clearAll(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer)
+    this.timers.clear()
+  }
+}
+
+export const missionWatchdog = new MissionWatchdog()
+export { MissionWatchdog }

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -4,6 +4,7 @@ import { MissionStatus, RobotStatus } from '@prisma/client'
 import { z } from 'zod'
 import prisma from '../lib/prisma'
 import { mqttEvents, type MqttEvents } from './mqttEvents'
+import { missionWatchdog } from './missionWatchdog'
 
 // Adaptateur MQTT du backend — singleton.
 // Topics et formats : voir docs/mqtt-spec.md
@@ -251,7 +252,7 @@ class RobotMqttAdapter {
         break
       case 'mission':
         if (sub === 'ack') void this.handleMissionAck(robotId, data)
-        else if (sub === 'status') void this.handleMissionStatus(data)
+        else if (sub === 'status') void this.handleMissionStatus(robotId, data)
         else if (sub === 'result') void this.handleMissionResult(robotId, data)
         break
       case 'mapping':
@@ -387,11 +388,13 @@ class RobotMqttAdapter {
           where: { id: missionId },
           data: { robotId },
         })
+        missionWatchdog.arm(missionId, robotId)
       } else {
         await prisma.mission.update({
           where: { id: missionId },
           data: { status: MissionStatus.FAILED, failureReason: reason ?? 'rejected' },
         })
+        missionWatchdog.clear(missionId)
       }
     }).catch((err) => {
       // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
@@ -402,7 +405,7 @@ class RobotMqttAdapter {
 
   // mission/status — propage le sous-etat courant. Pas de messageId
   // (etat retained, on ecrase, pas besoin de dedoublonner).
-  private async handleMissionStatus(data: Record<string, unknown>) {
+  private async handleMissionStatus(robotId: number, data: Record<string, unknown>) {
     const parsed = missionStatusSchema.safeParse(data)
     if (!parsed.success) {
       console.warn('[mqtt] mission/status rejete :', parsed.error.issues)
@@ -419,6 +422,8 @@ class RobotMqttAdapter {
         status: state,
         progress,
       })
+      // progression recue : on repousse le timeout (#99)
+      missionWatchdog.arm(missionId, robotId)
     } catch (err) {
       console.error('[mqtt] update mission/status :',
         err instanceof Error ? err.message : err)
@@ -455,6 +460,7 @@ class RobotMqttAdapter {
         robotId,
         status: RobotStatus.AVAILABLE,
       })
+      missionWatchdog.clear(missionId)
     }).catch((err) => {
       // L'echec NE marque PAS le messageId comme vu (cf. withIdempotence)
       console.error('[mqtt] update mission/result :',

--- a/web/backend/src/test/missionWatchdog.test.ts
+++ b/web/backend/src/test/missionWatchdog.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    mission: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    robot: { update: vi.fn().mockResolvedValue({}) },
+  },
+}))
+vi.mock('../lib/prisma', () => ({ default: prismaMock }))
+
+import { MissionWatchdog } from '../services/missionWatchdog'
+
+describe('MissionWatchdog (#99)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    prismaMock.mission.updateMany.mockClear().mockResolvedValue({ count: 1 })
+    prismaMock.robot.update.mockClear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('expire une mission sans progres : FAILED + robot libere', async () => {
+    const wd = new MissionWatchdog(1000)
+    wd.arm(42, 3)
+    expect(wd.pending).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(prismaMock.mission.updateMany).toHaveBeenCalledWith({
+      where: { id: 42, status: { in: expect.any(Array) } },
+      data: { status: 'FAILED', failureReason: 'timeout' },
+    })
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'AVAILABLE' },
+    })
+    expect(wd.pending).toBe(0)
+  })
+
+  it('ne touche a rien si la mission est deja terminee (count 0)', async () => {
+    prismaMock.mission.updateMany.mockResolvedValue({ count: 0 })
+    const wd = new MissionWatchdog(1000)
+    wd.arm(42, 3)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(prismaMock.robot.update).not.toHaveBeenCalled()
+  })
+
+  it('arm() repousse le timeout a chaque progres', async () => {
+    const wd = new MissionWatchdog(1000)
+    wd.arm(42, 3)
+    await vi.advanceTimersByTimeAsync(600)
+    wd.arm(42, 3) // progres -> reset
+    await vi.advanceTimersByTimeAsync(600)
+    expect(prismaMock.mission.updateMany).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(400)
+    expect(prismaMock.mission.updateMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('clear() annule le timeout', async () => {
+    const wd = new MissionWatchdog(1000)
+    wd.arm(42, 3)
+    wd.clear(42)
+    expect(wd.pending).toBe(0)
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(prismaMock.mission.updateMany).not.toHaveBeenCalled()
+  })
+})

--- a/web/backend/src/test/missions-controller.test.ts
+++ b/web/backend/src/test/missions-controller.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role, MissionStatus, RobotStatus } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+import { missionWatchdog } from '../services/missionWatchdog'
+
+const prisma = new PrismaClient()
+let token: string
+let userId: number
+let robotId: number
+let fromId: number
+let toId: number
+
+const createMission = (status: MissionStatus, withRobot: boolean) =>
+  prisma.mission.create({
+    data: {
+      type: 'TRANSPORT',
+      status,
+      userId,
+      fromPointId: fromId,
+      toPointId: toId,
+      robotId: withRobot ? robotId : null,
+    },
+  })
+
+beforeAll(async () => {
+  const u = await prisma.user.create({
+    data: { email: `mc-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'mc', role: Role.USER },
+  })
+  userId = u.id
+  token = signToken({ userId: u.id, email: u.email, role: u.role })
+  const r = await prisma.robot.create({ data: { name: `r-${Date.now()}`, status: RobotStatus.BUSY } })
+  robotId = r.id
+  const a = await prisma.point.create({ data: { name: 'A', slug: `mca-${Date.now()}`, x: 0, y: 0 } })
+  const b = await prisma.point.create({ data: { name: 'B', slug: `mcb-${Date.now()}`, x: 1, y: 1 } })
+  fromId = a.id
+  toId = b.id
+})
+
+afterEach(() => missionWatchdog.clearAll())
+
+afterAll(async () => {
+  await prisma.mission.deleteMany({ where: { userId } })
+  await prisma.point.deleteMany({ where: { id: { in: [fromId, toId] } } })
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('missions — list & get', () => {
+  it('GET /api/missions retourne data + total', async () => {
+    await createMission(MissionStatus.PENDING, false)
+    const res = await request(app).get('/api/missions').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.data)).toBe(true)
+    expect(typeof res.body.total).toBe('number')
+  })
+
+  it('GET /api/missions filtre par status', async () => {
+    const res = await request(app).get('/api/missions?status=PENDING').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.every((m: { status: string }) => m.status === 'PENDING')).toBe(true)
+  })
+
+  it('GET /api/missions params invalides -> 400', async () => {
+    const res = await request(app).get('/api/missions?status=NOPE').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /api/missions/:id existant -> 200', async () => {
+    const m = await createMission(MissionStatus.PENDING, false)
+    const res = await request(app).get(`/api/missions/${m.id}`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe(m.id)
+  })
+
+  it('GET /api/missions/:id inexistant -> 404', async () => {
+    const res = await request(app).get('/api/missions/999999').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/missions/:id id non numerique -> 400', async () => {
+    const res = await request(app).get('/api/missions/abc').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('missions — cancel', () => {
+  it('annule une mission PENDING + libere le robot', async () => {
+    const m = await createMission(MissionStatus.PENDING, true)
+    const res = await request(app).post(`/api/missions/${m.id}/cancel`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('CANCELLED')
+    const robot = await prisma.robot.findUnique({ where: { id: robotId } })
+    expect(robot?.status).toBe('AVAILABLE')
+  })
+
+  it('refuse d annuler une mission terminee -> 400', async () => {
+    const m = await createMission(MissionStatus.COMPLETED, false)
+    const res = await request(app).post(`/api/missions/${m.id}/cancel`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+
+  it('cancel d une mission inexistante -> 404', async () => {
+    const res = await request(app).post('/api/missions/999999/cancel').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('missions — stop (arret d urgence)', () => {
+  it('stoppe une mission active + libere le robot', async () => {
+    await prisma.robot.update({ where: { id: robotId }, data: { status: RobotStatus.BUSY } })
+    const m = await createMission(MissionStatus.NAVIGATING_TO_PICKUP, true)
+    const res = await request(app).post(`/api/missions/${m.id}/stop`).set('Authorization', `Bearer ${token}`).send({ reason: 'test-stop' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('CANCELLED')
+    const robot = await prisma.robot.findUnique({ where: { id: robotId } })
+    expect(robot?.status).toBe('AVAILABLE')
+  })
+
+  it('refuse de stopper une mission sans robot -> 400', async () => {
+    const m = await createMission(MissionStatus.PENDING, false)
+    const res = await request(app).post(`/api/missions/${m.id}/stop`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+
+  it('stop d une mission inexistante -> 404', async () => {
+    const res = await request(app).post('/api/missions/999999/stop').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('missions — resume', () => {
+  it('reprend une mission PAUSED avec robot', async () => {
+    const m = await createMission(MissionStatus.PAUSED, true)
+    const res = await request(app).post(`/api/missions/${m.id}/resume`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    const robot = await prisma.robot.findUnique({ where: { id: robotId } })
+    expect(robot?.status).toBe('BUSY')
+  })
+
+  it('refuse de reprendre une mission non PAUSED -> 400', async () => {
+    const m = await createMission(MissionStatus.PENDING, true)
+    const res = await request(app).post(`/api/missions/${m.id}/resume`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+
+  it('resume d une mission inexistante -> 404', async () => {
+    const res = await request(app).post('/api/missions/999999/resume').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('missions — confirm-loading', () => {
+  it('confirme le chargement quand la mission attend', async () => {
+    const m = await createMission(MissionStatus.WAITING_FOR_LOAD, true)
+    const res = await request(app).post(`/api/missions/${m.id}/confirm-loading`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+  })
+
+  it('refuse si la mission n attend pas de chargement -> 400', async () => {
+    const m = await createMission(MissionStatus.PENDING, true)
+    const res = await request(app).post(`/api/missions/${m.id}/confirm-loading`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+})

--- a/web/backend/src/test/missions-pickplace.test.ts
+++ b/web/backend/src/test/missions-pickplace.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+
+const prisma = new PrismaClient()
+let token: string
+let userId: number
+let fromId: number
+let toId: number
+let objectId: number
+
+beforeAll(async () => {
+  const u = await prisma.user.create({
+    data: { email: `pp-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'pp', role: Role.USER },
+  })
+  userId = u.id
+  token = signToken({ userId: u.id, email: u.email, role: u.role })
+
+  const a = await prisma.point.create({ data: { name: 'A', slug: `a-${Date.now()}`, x: 0, y: 0 } })
+  const b = await prisma.point.create({ data: { name: 'B', slug: `b-${Date.now()}`, x: 1, y: 1 } })
+  fromId = a.id
+  toId = b.id
+
+  const o = await prisma.graspObject.create({ data: { name: 'colis', locationId: a.id } })
+  objectId = o.id
+})
+
+afterAll(async () => {
+  await prisma.mission.deleteMany({ where: { userId } })
+  await prisma.graspObject.delete({ where: { id: objectId } })
+  await prisma.point.deleteMany({ where: { id: { in: [fromId, toId] } } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('création mission pick & place (#134)', () => {
+  it('refuse 400 un PICK_AND_PLACE sans objectId', async () => {
+    const res = await request(app)
+      .post('/api/missions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'PICK_AND_PLACE', fromPointId: fromId, toPointId: toId })
+    expect(res.status).toBe(400)
+  })
+
+  it('refuse 400 un objectId inexistant', async () => {
+    const res = await request(app)
+      .post('/api/missions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'PICK_AND_PLACE', fromPointId: fromId, toPointId: toId, objectId: 999999 })
+    expect(res.status).toBe(400)
+  })
+
+  it('cree un PICK_AND_PLACE valide avec objet', async () => {
+    const res = await request(app)
+      .post('/api/missions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'PICK_AND_PLACE', fromPointId: fromId, toPointId: toId, objectId })
+    expect(res.status).toBe(201)
+    expect(res.body.data.type).toBe('PICK_AND_PLACE')
+    expect(res.body.data.object.id).toBe(objectId)
+  })
+})

--- a/web/backend/src/test/mqtt-integration.test.ts
+++ b/web/backend/src/test/mqtt-integration.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
+
+// Integration : vraie DB (pas de mock prisma), transport MQTT mocke pour
+// injecter les messages robot. Verifie la chaine complete creation -> fin.
+
+let messageHandler: ((topic: string, payload: Buffer) => void) | null = null
+let connectHandler: (() => void) | null = null
+let connectOpts: Record<string, unknown> | null = null
+
+const fakeClient = {
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+  end: vi.fn(),
+  on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+    if (event === 'connect') { connectHandler = cb as () => void; cb() }
+    if (event === 'message') messageHandler = cb as (topic: string, payload: Buffer) => void
+    return fakeClient
+  }),
+}
+
+vi.mock('mqtt', () => ({
+  default: { connect: vi.fn((_url: string, opts: Record<string, unknown>) => { connectOpts = opts; return fakeClient }) },
+}))
+
+import { robotMqtt } from '../services/mqtt'
+import { missionWatchdog } from '../services/missionWatchdog'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+
+const prisma = new PrismaClient()
+let token: string
+let userId: number
+let robotId: number
+let fromId: number
+let toId: number
+
+function deliver(topic: string, body: object) {
+  messageHandler!(topic, Buffer.from(JSON.stringify({ schemaVersion: 1, timestamp: new Date().toISOString(), ...body })))
+}
+
+beforeAll(async () => {
+  const u = await prisma.user.create({
+    data: { email: `int-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'int', role: Role.USER },
+  })
+  userId = u.id
+  token = signToken({ userId: u.id, email: u.email, role: u.role })
+  const r = await prisma.robot.create({ data: { name: `r-${Date.now()}`, status: 'AVAILABLE' } })
+  robotId = r.id
+  const a = await prisma.point.create({ data: { name: 'A', slug: `ia-${Date.now()}`, x: 0, y: 0 } })
+  const b = await prisma.point.create({ data: { name: 'B', slug: `ib-${Date.now()}`, x: 1, y: 1 } })
+  fromId = a.id
+  toId = b.id
+  robotMqtt.connect()
+})
+
+afterEach(() => missionWatchdog.clearAll())
+
+afterAll(async () => {
+  robotMqtt.disconnect()
+  await prisma.mission.deleteMany({ where: { userId } })
+  await prisma.point.deleteMany({ where: { id: { in: [fromId, toId] } } })
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('chaîne MQTT complète (#103)', () => {
+  it('création → ack → status → result : mission COMPLETED + robot libéré', async () => {
+    const created = await request(app)
+      .post('/api/missions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'TRANSPORT', fromPointId: fromId, toPointId: toId, robotId })
+    expect(created.status).toBe(201)
+    const missionId = created.body.data.id
+    expect(fakeClient.publish).toHaveBeenCalled() // cmd/mission
+
+    // le robot accepte puis s'annonce occupe
+    deliver(`roblaude/${robotId}/mission/ack`, { messageId: `ack-${missionId}`, missionId, result: 'accepted' })
+    deliver(`roblaude/${robotId}/status`, { state: 'BUSY' })
+    await vi.waitFor(async () => {
+      const r = await prisma.robot.findUnique({ where: { id: robotId } })
+      expect(r?.status).toBe('BUSY')
+    }, { timeout: 2000 })
+
+    // progression
+    deliver(`roblaude/${robotId}/mission/status`, { missionId, state: 'NAVIGATING_TO_PICKUP', progress: 0.3 })
+    await vi.waitFor(async () => {
+      const m = await prisma.mission.findUnique({ where: { id: missionId } })
+      expect(m?.status).toBe('NAVIGATING_TO_PICKUP')
+    }, { timeout: 2000 })
+
+    // fin de mission
+    deliver(`roblaude/${robotId}/mission/result`, { messageId: `res-${missionId}`, missionId, result: 'completed' })
+    await vi.waitFor(async () => {
+      const m = await prisma.mission.findUnique({ where: { id: missionId } })
+      const r = await prisma.robot.findUnique({ where: { id: robotId } })
+      expect(m?.status).toBe('COMPLETED')
+      expect(r?.status).toBe('AVAILABLE')
+    }, { timeout: 2000 })
+  })
+})
+
+describe('reconnexion MQTT (#151)', () => {
+  it('configure une reconnexion auto (reconnectPeriod)', () => {
+    expect(connectOpts?.reconnectPeriod).toBe(2000)
+  })
+
+  it('réabonne aux topics après une reconnexion', () => {
+    fakeClient.subscribe.mockClear()
+    connectHandler!() // simule l'event "connect" rejoue apres une reconnexion
+    expect(fakeClient.subscribe).toHaveBeenCalledWith(
+      expect.arrayContaining(['roblaude/+/mission/#', 'roblaude/+/telemetry/#']),
+      { qos: 1 },
+    )
+  })
+})

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -375,3 +375,49 @@ describe('RobotMqttAdapter — handlers telemetry/battery, status, connection (T
     })
   })
 })
+
+// UC-02 (pick & place) ne definit pas de message dedie : les sous-etats de
+// saisie et l'echec passent par les memes mission/status & mission/result
+// que le transport (spec §5.4). Ces tests verrouillent ce contrat.
+describe('RobotMqttAdapter — UC-02 pick & place', () => {
+  beforeEach(() => {
+    prismaMock.mission.update.mockClear()
+    prismaMock.robot.update.mockClear()
+    prismaMock.$transaction.mockClear()
+    robotMqtt.disconnect(); robotMqtt.resetSeenMessageIds()
+    robotMqtt.connect()
+  })
+
+  it('mission/status propage le sous-etat GRASPING', async () => {
+    deliver('roblaude/3/mission/status', { missionId: 42, state: 'GRASPING', progress: 0.6 })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'GRASPING' },
+    })
+  })
+
+  it('mission/status propage le sous-etat DEPOSITING', async () => {
+    deliver('roblaude/3/mission/status', { missionId: 42, state: 'DEPOSITING', progress: 0.9 })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'DEPOSITING' },
+    })
+  })
+
+  it('saisie echouee : mission/result failed reason=grasp-failed libere le robot', async () => {
+    deliver('roblaude/3/mission/result', {
+      messageId: 'g-1', missionId: 42, result: 'failed', reason: 'grasp-failed',
+    })
+    await Promise.resolve()
+    expect(prismaMock.mission.update).toHaveBeenCalledWith({
+      where: { id: 42 },
+      data: { status: 'FAILED', failureReason: 'grasp-failed' },
+    })
+    expect(prismaMock.robot.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { status: 'AVAILABLE' },
+    })
+  })
+})

--- a/web/backend/src/test/mqtt.test.ts
+++ b/web/backend/src/test/mqtt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mocks — definis avant l'import du module teste (hoisting vi.mock).
 let messageHandler: ((topic: string, payload: Buffer) => void) | null = null
@@ -34,6 +34,11 @@ const { prismaMock } = vi.hoisted(() => ({
 vi.mock('../lib/prisma', () => ({ default: prismaMock }))
 
 import { robotMqtt } from '../services/mqtt'
+import { missionWatchdog } from '../services/missionWatchdog'
+
+// le watchdog s'arme sur mission/ack & mission/status — on purge ses timers
+// entre chaque test pour ne pas les laisser fuiter.
+afterEach(() => missionWatchdog.clearAll())
 
 // Helper : reconstruit un message MQTT comme s'il venait du broker.
 // Ajoute schemaVersion + timestamp par defaut (spec §4 — obligatoires).

--- a/web/backend/src/test/objects-controller.test.ts
+++ b/web/backend/src/test/objects-controller.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+
+const prisma = new PrismaClient()
+let adminToken: string
+let userToken: string
+let adminId: number
+let userId: number
+let pointId: number
+
+beforeAll(async () => {
+  const admin = await prisma.user.create({
+    data: { email: `obj-admin-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'admin', role: Role.ADMIN },
+  })
+  adminId = admin.id
+  adminToken = signToken({ userId: admin.id, email: admin.email, role: admin.role })
+
+  const user = await prisma.user.create({
+    data: { email: `obj-user-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'user', role: Role.USER },
+  })
+  userId = user.id
+  userToken = signToken({ userId: user.id, email: user.email, role: user.role })
+
+  const p = await prisma.point.create({ data: { name: 'Stock', slug: `stock-${Date.now()}`, x: 0, y: 0 } })
+  pointId = p.id
+})
+
+afterAll(async () => {
+  await prisma.graspObject.deleteMany({ where: { locationId: pointId } })
+  await prisma.point.delete({ where: { id: pointId } })
+  await prisma.user.delete({ where: { id: adminId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('objects CRUD', () => {
+  let createdId = 0
+
+  it('POST cree (admin)', async () => {
+    const res = await request(app)
+      .post('/api/objects')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'colis A', locationId: pointId })
+    expect(res.status).toBe(201)
+    expect(res.body.data.name).toBe('colis A')
+    expect(res.body.data.available).toBe(true)
+    createdId = res.body.data.id
+  })
+
+  it('GET liste inclut l emplacement', async () => {
+    const res = await request(app).get('/api/objects').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.data)).toBe(true)
+    const found = res.body.data.find((o: { id: number }) => o.id === createdId)
+    expect(found.location.id).toBe(pointId)
+  })
+
+  it('PUT modifie (admin)', async () => {
+    const res = await request(app)
+      .put(`/api/objects/${createdId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ available: false })
+    expect(res.status).toBe(200)
+    expect(res.body.data.available).toBe(false)
+  })
+
+  it('refuse 403 pour un non-admin', async () => {
+    const res = await request(app)
+      .post('/api/objects')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'x', locationId: pointId })
+    expect(res.status).toBe(403)
+  })
+
+  it('refuse 400 si emplacement inexistant', async () => {
+    const res = await request(app)
+      .post('/api/objects')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'x', locationId: 999999 })
+    expect(res.status).toBe(400)
+  })
+
+  it('refuse 400 sans nom', async () => {
+    const res = await request(app)
+      .post('/api/objects')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ locationId: pointId })
+    expect(res.status).toBe(400)
+  })
+
+  it('DELETE supprime (admin)', async () => {
+    const res = await request(app).delete(`/api/objects/${createdId}`).set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(204)
+  })
+})

--- a/web/backend/src/test/points-controller.test.ts
+++ b/web/backend/src/test/points-controller.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+
+const prisma = new PrismaClient()
+let adminToken: string
+let userToken: string
+let adminId: number
+let userId: number
+const createdPointIds: number[] = []
+
+beforeAll(async () => {
+  const admin = await prisma.user.create({
+    data: { email: `pt-admin-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'a', role: Role.ADMIN },
+  })
+  adminId = admin.id
+  adminToken = signToken({ userId: admin.id, email: admin.email, role: admin.role })
+  const user = await prisma.user.create({
+    data: { email: `pt-user-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'u', role: Role.USER },
+  })
+  userId = user.id
+  userToken = signToken({ userId: user.id, email: user.email, role: user.role })
+})
+
+afterAll(async () => {
+  await prisma.mission.deleteMany({ where: { userId } })
+  await prisma.point.deleteMany({ where: { id: { in: createdPointIds } } })
+  await prisma.user.delete({ where: { id: adminId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+async function makePoint(): Promise<number> {
+  const res = await request(app)
+    .post('/api/points')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ name: 'P', slug: `pt-${Date.now()}-${Math.round(performance.now())}`, x: 1, y: 2 })
+  createdPointIds.push(res.body.data.id)
+  return res.body.data.id
+}
+
+describe('points — lecture', () => {
+  it('GET /api/points -> 200', async () => {
+    const res = await request(app).get('/api/points').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.data)).toBe(true)
+  })
+
+  it('GET /api/points/:id -> 200', async () => {
+    const id = await makePoint()
+    const res = await request(app).get(`/api/points/${id}`).set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe(id)
+  })
+
+  it('GET /api/points/:id inexistant -> 404', async () => {
+    const res = await request(app).get('/api/points/999999').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/points/:id id invalide -> 400', async () => {
+    const res = await request(app).get('/api/points/abc').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('points — admin CRUD', () => {
+  it('POST crée (admin) -> 201', async () => {
+    const id = await makePoint()
+    expect(id).toBeGreaterThan(0)
+  })
+
+  it('POST refusé pour un non-admin -> 403', async () => {
+    const res = await request(app)
+      .post('/api/points')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'X', slug: `x-${Date.now()}`, x: 0, y: 0 })
+    expect(res.status).toBe(403)
+  })
+
+  it('POST slug invalide -> 400', async () => {
+    const res = await request(app)
+      .post('/api/points')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'X', slug: 'Pas Valide!', x: 0, y: 0 })
+    expect(res.status).toBe(400)
+  })
+
+  it('PUT modifie (admin) -> 200', async () => {
+    const id = await makePoint()
+    const res = await request(app)
+      .put(`/api/points/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Renommé' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.name).toBe('Renommé')
+  })
+
+  it('DELETE (admin) -> 204', async () => {
+    const id = await makePoint()
+    const res = await request(app).delete(`/api/points/${id}`).set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(204)
+  })
+
+  it('DELETE refusé si le point est lié à une mission -> 400', async () => {
+    const from = await makePoint()
+    const to = await makePoint()
+    await prisma.mission.create({
+      data: { type: 'TRANSPORT', userId, fromPointId: from, toPointId: to },
+    })
+    const res = await request(app).delete(`/api/points/${from}`).set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(400)
+    expect(res.body.linkedMissions).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/web/backend/src/test/robots-controller.test.ts
+++ b/web/backend/src/test/robots-controller.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+
+const prisma = new PrismaClient()
+let token: string
+let userId: number
+let robotId: number
+
+beforeAll(async () => {
+  const u = await prisma.user.create({
+    data: { email: `rb-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'rb', role: Role.USER },
+  })
+  userId = u.id
+  token = signToken({ userId: u.id, email: u.email, role: u.role })
+  const r = await prisma.robot.create({ data: { name: `r-${Date.now()}`, battery: 80 } })
+  robotId = r.id
+})
+
+afterAll(async () => {
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
+})
+
+describe('robots', () => {
+  it('GET /api/robots -> 200 liste', async () => {
+    const res = await request(app).get('/api/robots').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.data)).toBe(true)
+  })
+
+  it('GET /api/robots/:id/status -> 200', async () => {
+    const res = await request(app).get(`/api/robots/${robotId}/status`).set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe(robotId)
+    expect(res.body.data.battery).toBe(80)
+  })
+
+  it('GET /api/robots/:id/status inexistant -> 404', async () => {
+    const res = await request(app).get('/api/robots/999999/status').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /api/robots/:id/status id invalide -> 400', async () => {
+    const res = await request(app).get('/api/robots/abc/status').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+})

--- a/web/backend/vitest.config.ts
+++ b/web/backend/vitest.config.ts
@@ -8,5 +8,25 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     // dotenv/config charge .env avant les tests (sinon JWT_SECRET manque a l'import auth.ts)
     setupFiles: ['dotenv/config'],
+    // les tests d'integration tapent tous la meme DB — on serialise par fichier
+    // pour qu'ils ne se marchent pas dessus (sinon flaky sous --coverage).
+    fileParallelism: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary'],
+      include: ['src/**/*.ts'],
+      // exclus : point d'entree + couches IO (SSH reel, filesystem cartes)
+      // qui se testent en integration/hardware, pas en unitaire.
+      exclude: [
+        'src/**/*.test.ts',
+        'src/index.ts',
+        'src/services/sshConnection.ts',
+        'src/services/wsSsh.ts',
+        'src/lib/mapStorage.ts',
+        'src/controllers/mapController.ts',
+        'src/controllers/sshController.ts',
+      ],
+      thresholds: { lines: 70 },
+    },
   },
 })


### PR DESCRIPTION
Travail de Maxime (@TheKyyn).

Closes #135, #134, #136, #132, #133, #99, #103, #151, #146

- CRUD objets admin `/api/objects` (list/get/create/update/delete) + tests
- pick&place exige un objet valide (sous-états GRASPING/DEPOSITING + grasp-failed)
- watchdog : timeout missions bloquées → libère le robot
- tests chaîne MQTT complète + reconnexion
- coverage backend 71.8% (seuil 70% imposé dans vitest.config)

N'a touché ni schema.prisma, ni les migrations, ni ci.yml → pas de collision avec #259/#260.
Merge propre sur dev (0 conflit vérifié).