### PR TITLE
feat(front): UC-02 — page admin objets + sélecteur objet + timeline progression

### DIFF
--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { MissionsPage } from './pages/MissionsPage'
 import { MissionDetailPage } from './pages/MissionDetailPage'
 import { NewMissionPage } from './pages/NewMissionPage'
 import { AdminPage } from './pages/AdminPage'
+import { AdminObjectsPage } from './pages/AdminObjectsPage'
 import { ProfilePage } from './pages/ProfilePage'
 import { MappingPage } from './pages/MappingPage'
 import { AdminSshPage } from './pages/AdminSshPage'
@@ -40,6 +41,10 @@ export default function App() {
             <Route
               path="/admin"
               element={role === 'ADMIN' ? <AdminPage /> : <Navigate to="/" replace />}
+            />
+            <Route
+              path="/admin/objects"
+              element={role === 'ADMIN' ? <AdminObjectsPage /> : <Navigate to="/" replace />}
             />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/mapping" element={<MappingPage />} />

--- a/web/frontend/src/components/MissionProgress.tsx
+++ b/web/frontend/src/components/MissionProgress.tsx
@@ -1,0 +1,72 @@
+import { Check, X } from 'lucide-react'
+import type { MissionStatus, MissionType } from '../stores/missionStore'
+
+interface Step {
+  status: MissionStatus
+  label: string
+}
+
+// Pipeline ordonné par type de mission (les sous-états du robot).
+const TRANSPORT_STEPS: Step[] = [
+  { status: 'NAVIGATING_TO_PICKUP', label: 'Vers la collecte' },
+  { status: 'WAITING_FOR_LOAD', label: 'Chargement' },
+  { status: 'NAVIGATING_TO_DESTINATION', label: 'Transport' },
+  { status: 'COMPLETED', label: 'Livré' },
+]
+
+const PICK_AND_PLACE_STEPS: Step[] = [
+  { status: 'NAVIGATING_TO_PICKUP', label: "Vers l'objet" },
+  { status: 'DETECTING_OBJECT', label: 'Détection' },
+  { status: 'GRASPING', label: 'Saisie' },
+  { status: 'TRANSPORTING', label: 'Transport' },
+  { status: 'DEPOSITING', label: 'Dépôt' },
+  { status: 'COMPLETED', label: 'Terminé' },
+]
+
+export function MissionProgress({ status, type }: { status: MissionStatus; type: MissionType }) {
+  const steps = type === 'PICK_AND_PLACE' ? PICK_AND_PLACE_STEPS : TRANSPORT_STEPS
+  const failed = status === 'FAILED' || status === 'CANCELLED'
+  const completed = status === 'COMPLETED'
+  const currentIndex = steps.findIndex((s) => s.status === status)
+
+  return (
+    <ol className="flex items-center" aria-label="Progression de la mission">
+      {steps.map((step, i) => {
+        const done = completed || (currentIndex > -1 && i < currentIndex)
+        const current = !completed && !failed && i === currentIndex
+        const isLast = i === steps.length - 1
+
+        const dotClass = done
+          ? 'bg-emerald-500 text-white border-emerald-500'
+          : current
+            ? 'bg-primary text-primary-foreground border-primary status-pulse'
+            : 'bg-card text-muted-foreground border-border'
+
+        return (
+          <li key={step.status} className="flex items-center flex-1 last:flex-none">
+            <div className="flex flex-col items-center gap-1">
+              <span
+                className={`flex size-6 items-center justify-center rounded-full border text-[10px] font-mono ${dotClass}`}
+                aria-current={current ? 'step' : undefined}
+              >
+                {done ? <Check className="size-3.5" /> : i + 1}
+              </span>
+              <span className={`text-[10px] whitespace-nowrap ${current ? 'text-primary' : 'text-muted-foreground'}`}>
+                {step.label}
+              </span>
+            </div>
+            {!isLast && (
+              <span className={`h-px flex-1 mx-1 ${done ? 'bg-emerald-500/50' : 'bg-border'}`} aria-hidden />
+            )}
+          </li>
+        )
+      })}
+      {failed && (
+        <li className="ml-3 flex items-center gap-1 text-destructive text-[11px]" role="status">
+          <X className="size-3.5" />
+          {status === 'CANCELLED' ? 'Annulée' : 'Échec'}
+        </li>
+      )}
+    </ol>
+  )
+}

--- a/web/frontend/src/components/Sidebar.tsx
+++ b/web/frontend/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Map,
   Terminal,
   Sparkles,
+  Package,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
@@ -21,7 +22,8 @@ const NAV_ITEMS = [
   { to: '/missions/new', label: 'Nouvelle mission', code: '03', Icon: Plus, adminOnly: false },
   { to: '/mapping', label: 'Mode mapping', code: '04', Icon: Map, adminOnly: false },
   { to: '/admin', label: 'Admin', code: '05', Icon: Settings2, adminOnly: true },
-  { to: '/admin/ssh', label: 'SSH admin', code: '06', Icon: Terminal, adminOnly: true },
+  { to: '/admin/objects', label: 'Objets', code: '06', Icon: Package, adminOnly: true },
+  { to: '/admin/ssh', label: 'SSH admin', code: '07', Icon: Terminal, adminOnly: true },
   { to: '/profile', label: 'Profil', code: '07', Icon: User, adminOnly: false },
 ]
 

--- a/web/frontend/src/lib/objectsApi.ts
+++ b/web/frontend/src/lib/objectsApi.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from './api'
+
+export interface GraspObject {
+  id: number
+  name: string
+  imageUrl: string | null
+  available: boolean
+  locationId: number
+  location?: { id: number; name: string; slug: string }
+}
+
+export interface ObjectInput {
+  name: string
+  imageUrl?: string
+  available?: boolean
+  locationId: number
+}
+
+export async function listObjects(): Promise<GraspObject[]> {
+  const res = await apiFetch('/objects')
+  if (!res.ok) throw new Error(`listObjects ${res.status}`)
+  const json = (await res.json()) as { data: GraspObject[] }
+  return json.data
+}
+
+export async function createObject(input: ObjectInput): Promise<GraspObject> {
+  const res = await apiFetch('/objects', { method: 'POST', body: JSON.stringify(input) })
+  if (!res.ok) {
+    const e = (await res.json().catch(() => ({ error: `createObject ${res.status}` }))) as { error: string }
+    throw new Error(e.error)
+  }
+  const json = (await res.json()) as { data: GraspObject }
+  return json.data
+}
+
+export async function updateObject(id: number, input: Partial<ObjectInput>): Promise<GraspObject> {
+  const res = await apiFetch(`/objects/${id}`, { method: 'PUT', body: JSON.stringify(input) })
+  if (!res.ok) {
+    const e = (await res.json().catch(() => ({ error: `updateObject ${res.status}` }))) as { error: string }
+    throw new Error(e.error)
+  }
+  const json = (await res.json()) as { data: GraspObject }
+  return json.data
+}
+
+export async function deleteObject(id: number): Promise<void> {
+  const res = await apiFetch(`/objects/${id}`, { method: 'DELETE' })
+  if (!res.ok && res.status !== 204) {
+    const e = (await res.json().catch(() => ({ error: `deleteObject ${res.status}` }))) as { error: string }
+    throw new Error(e.error)
+  }
+}

--- a/web/frontend/src/pages/AdminObjectsPage.tsx
+++ b/web/frontend/src/pages/AdminObjectsPage.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { apiFetch } from '@/lib/api'
+import { listObjects, createObject, updateObject, deleteObject, type GraspObject } from '@/lib/objectsApi'
+
+interface PointLite {
+  id: number
+  name: string
+}
+
+interface ObjectForm {
+  id: number | null
+  name: string
+  imageUrl: string
+  available: boolean
+  locationId: string
+}
+
+const EMPTY_FORM: ObjectForm = { id: null, name: '', imageUrl: '', available: true, locationId: '' }
+
+export function AdminObjectsPage() {
+  const [objects, setObjects] = useState<GraspObject[]>([])
+  const [points, setPoints] = useState<PointLite[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [form, setForm] = useState<ObjectForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const isEditing = form.id !== null
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const [objs, pRes] = await Promise.all([listObjects(), apiFetch('/points')])
+      setObjects(objs)
+      if (pRes.ok) {
+        const j = (await pRes.json()) as { data: PointLite[] }
+        setPoints(j.data)
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  function resetForm() {
+    setForm(EMPTY_FORM)
+  }
+
+  function editObject(o: GraspObject) {
+    setForm({
+      id: o.id,
+      name: o.name,
+      imageUrl: o.imageUrl ?? '',
+      available: o.available,
+      locationId: String(o.locationId),
+    })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (!form.name.trim()) {
+      setError('Le nom est requis')
+      return
+    }
+    if (form.locationId === '') {
+      setError('Choisis un emplacement')
+      return
+    }
+
+    const payload = {
+      name: form.name.trim(),
+      imageUrl: form.imageUrl.trim() || undefined,
+      available: form.available,
+      locationId: Number(form.locationId),
+    }
+
+    setSubmitting(true)
+    try {
+      if (isEditing) await updateObject(form.id!, payload)
+      else await createObject(payload)
+      resetForm()
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Echec de l'enregistrement")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleDelete(o: GraspObject) {
+    if (!window.confirm(`Supprimer l'objet « ${o.name} » ?`)) return
+    setError(null)
+    try {
+      await deleteObject(o.id)
+      if (form.id === o.id) resetForm()
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Echec de la suppression')
+    }
+  }
+
+  const inputClass =
+    'w-full bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded-lg ' +
+    'px-3 py-2 focus:outline-none focus:border-violet-500'
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-semibold text-white mb-1">Objets saisissables</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Gestion des objets que le robot peut récupérer (missions pick &amp; place).
+      </p>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
+        >
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="mb-8 rounded-xl border border-gray-800 bg-gray-900/50 p-5">
+        <h2 className="text-sm font-semibold text-white mb-4">
+          {isEditing ? `Modifier l'objet #${form.id}` : 'Nouvel objet'}
+        </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="o-name" className="text-sm font-medium text-gray-300">Nom</label>
+            <input
+              id="o-name"
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              className={inputClass}
+              placeholder="Dossier patient"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="o-location" className="text-sm font-medium text-gray-300">Emplacement</label>
+            <select
+              id="o-location"
+              value={form.locationId}
+              onChange={(e) => setForm((f) => ({ ...f, locationId: e.target.value }))}
+              disabled={loading}
+              className={inputClass}
+            >
+              <option value="">— Choisir un point —</option>
+              {points.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5 sm:col-span-2">
+            <label htmlFor="o-image" className="text-sm font-medium text-gray-300">
+              Image URL <span className="text-gray-500">(optionnel)</span>
+            </label>
+            <input
+              id="o-image"
+              type="text"
+              value={form.imageUrl}
+              onChange={(e) => setForm((f) => ({ ...f, imageUrl: e.target.value }))}
+              className={inputClass}
+              placeholder="https://…"
+            />
+          </div>
+
+          <div className="flex items-center gap-2 sm:col-span-2">
+            <input
+              id="o-available"
+              type="checkbox"
+              checked={form.available}
+              onChange={(e) => setForm((f) => ({ ...f, available: e.target.checked }))}
+              className="size-4 accent-violet-600"
+            />
+            <label htmlFor="o-available" className="text-sm text-gray-300">Disponible</label>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 mt-5">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-sm
+                       font-medium rounded-lg transition-colors disabled:opacity-50"
+          >
+            {submitting ? 'Enregistrement…' : isEditing ? 'Enregistrer les modifications' : 'Creer l\'objet'}
+          </button>
+          {isEditing && (
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 text-sm
+                         rounded-lg hover:bg-gray-700 transition-colors"
+            >
+              Annuler
+            </button>
+          )}
+        </div>
+      </form>
+
+      <h2 className="text-sm font-semibold text-white mb-3">
+        Objets enregistrés {!loading && `(${objects.length})`}
+      </h2>
+      <div className="rounded-xl border border-gray-800 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-900 border-b border-gray-800">
+            <tr>
+              {['Nom', 'Emplacement', 'Disponible', 'Actions'].map((h) => (
+                <th key={h} className="text-left text-xs text-gray-500 font-medium uppercase tracking-wider px-4 py-3">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-800">
+            {loading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i} className="bg-gray-950">
+                  <td colSpan={4} className="px-4 py-3">
+                    <div className="h-4 bg-gray-800 rounded animate-pulse" />
+                  </td>
+                </tr>
+              ))
+            ) : objects.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-12 text-center text-gray-500">Aucun objet enregistré</td>
+              </tr>
+            ) : (
+              objects.map((o) => (
+                <tr key={o.id} className="bg-gray-950 hover:bg-gray-900 transition-colors">
+                  <td className="px-4 py-3 text-gray-200">{o.name}</td>
+                  <td className="px-4 py-3 text-gray-400">{o.location?.name ?? `#${o.locationId}`}</td>
+                  <td className="px-4 py-3">
+                    {o.available ? (
+                      <span className="text-emerald-400">Oui</span>
+                    ) : (
+                      <span className="text-gray-500">Non</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => editObject(o)}
+                        className="px-2.5 py-1 text-xs bg-gray-800 border border-gray-700 text-gray-300 rounded hover:bg-gray-700 transition-colors"
+                      >
+                        Modifier
+                      </button>
+                      <button
+                        onClick={() => handleDelete(o)}
+                        className="px-2.5 py-1 text-xs bg-red-500/10 border border-red-500/20 text-red-400 rounded hover:bg-red-500/20 transition-colors"
+                      >
+                        Supprimer
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/pages/DashboardPage.tsx
+++ b/web/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useRobotStore, type RobotStatus } from '../stores/robotStore'
 import { useMissionStore } from '../stores/missionStore'
 import { useAuthStore } from '../stores/authStore'
 import { StatusBadge } from '../components/StatusBadge'
+import { MissionProgress } from '../components/MissionProgress'
 import { RobotMap } from '../components/RobotMap'
 import {
   ArrowRight,
@@ -280,6 +281,28 @@ export function DashboardPage() {
           </Link>
         </section>
       </div>
+
+      {/* ============ Progression mission active (UC-01/UC-02) ============ */}
+      {activeMissions.length > 0 && (
+        <section className="relative rounded-sm border border-border bg-card/40 p-5 mb-4 overflow-hidden">
+          <CornerBrackets />
+          <div className="flex items-center justify-between mb-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-muted-foreground">
+              · Progression mission
+            </p>
+            <Link
+              to={`/missions/${activeMissions[0].id}`}
+              className="font-mono text-[10px] uppercase tracking-widest text-primary hover:text-primary/80"
+            >
+              #{String(activeMissions[0].id).padStart(3, '0')} ·{' '}
+              {activeMissions[0].type === 'TRANSPORT' ? 'Transport' : 'Pick & Place'}
+            </Link>
+          </div>
+          <div className="overflow-x-auto pb-1">
+            <MissionProgress status={activeMissions[0].status} type={activeMissions[0].type} />
+          </div>
+        </section>
+      )}
 
       {/* ============ System status grid ============ */}
       <section

--- a/web/frontend/src/pages/MissionDetailPage.tsx
+++ b/web/frontend/src/pages/MissionDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useMissionStore, type Mission } from '../stores/missionStore'
 import { StatusBadge } from '../components/StatusBadge'
+import { MissionProgress } from '../components/MissionProgress'
 import { apiFetch } from '@/lib/api'
 
 // Une mission ne peut plus etre annulee une fois terminee.
@@ -84,6 +85,12 @@ export function MissionDetailPage() {
           className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
         >
           {error}
+        </div>
+      )}
+
+      {mission && (
+        <div className="mb-5 overflow-x-auto">
+          <MissionProgress status={mission.status} type={mission.type} />
         </div>
       )}
 

--- a/web/frontend/src/pages/NewMissionPage.tsx
+++ b/web/frontend/src/pages/NewMissionPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useMissionStore, type MissionType } from '../stores/missionStore'
+import { listObjects, type GraspObject } from '@/lib/objectsApi'
 import { apiFetch } from '@/lib/api'
 
 // Le backend expose ces champs sur /api/points et /api/robots.
@@ -25,6 +26,8 @@ export function NewMissionPage() {
   const [fromPointId, setFromPointId] = useState<number | ''>('')
   const [toPointId, setToPointId] = useState<number | ''>('')
   const [robotId, setRobotId] = useState<number | ''>('')
+  const [objects, setObjects] = useState<GraspObject[]>([])
+  const [objectId, setObjectId] = useState<number | ''>('')
 
   const [loadingData, setLoadingData] = useState(true)
   const [submitting, setSubmitting] = useState(false)
@@ -35,9 +38,10 @@ export function NewMissionPage() {
     let cancelled = false
     ;(async () => {
       try {
-        const [pRes, rRes] = await Promise.all([
+        const [pRes, rRes, objs] = await Promise.all([
           apiFetch('/points'),
           apiFetch('/robots'),
+          listObjects(),
         ])
         if (cancelled) return
         if (pRes.ok) {
@@ -48,6 +52,7 @@ export function NewMissionPage() {
           const j = (await rRes.json()) as { data: RobotLite[] }
           setRobots(j.data)
         }
+        setObjects(objs)
       } catch {
         if (!cancelled) setError('Impossible de charger les points et robots')
       } finally {
@@ -71,6 +76,10 @@ export function NewMissionPage() {
       setError('Le depart et l arrivee doivent etre differents')
       return
     }
+    if (type === 'PICK_AND_PLACE' && objectId === '') {
+      setError('Choisis un objet a recuperer')
+      return
+    }
 
     setSubmitting(true)
     try {
@@ -79,6 +88,7 @@ export function NewMissionPage() {
         fromPointId: Number(fromPointId),
         toPointId: Number(toPointId),
         ...(robotId !== '' ? { robotId: Number(robotId) } : {}),
+        ...(type === 'PICK_AND_PLACE' && objectId !== '' ? { objectId: Number(objectId) } : {}),
       })
       navigate(`/missions/${mission.id}`)
     } catch (err) {
@@ -120,13 +130,40 @@ export function NewMissionPage() {
           <select
             id="type"
             value={type}
-            onChange={(e) => setType(e.target.value as MissionType)}
+            onChange={(e) => {
+              const t = e.target.value as MissionType
+              setType(t)
+              if (t !== 'PICK_AND_PLACE') setObjectId('')
+            }}
             className={selectClass}
           >
             <option value="TRANSPORT">Transport de document</option>
             <option value="PICK_AND_PLACE">Recuperation d objet</option>
           </select>
         </div>
+
+        {/* Objet a recuperer — uniquement pour un pick & place (UC-02) */}
+        {type === 'PICK_AND_PLACE' && (
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="object" className="text-sm font-medium text-gray-300">
+              Objet a recuperer
+            </label>
+            <select
+              id="object"
+              value={objectId}
+              onChange={(e) => setObjectId(e.target.value ? Number(e.target.value) : '')}
+              disabled={loadingData}
+              className={selectClass}
+            >
+              <option value="">— Choisir un objet —</option>
+              {objects.map((o) => (
+                <option key={o.id} value={o.id} disabled={!o.available}>
+                  {o.name}{o.available ? '' : ' (indisponible)'}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Point de depart */}
         <div className="flex flex-col gap-1.5">

--- a/web/frontend/src/stores/missionStore.ts
+++ b/web/frontend/src/stores/missionStore.ts
@@ -44,7 +44,7 @@ interface MissionStore {
   setFilters: (filters: Partial<MissionFilters>) => void
   // override : filtres ponctuels non persistes (ex: dashboard = stats globales)
   fetchMissions: (override?: Partial<MissionFilters>) => Promise<void>
-  createMission: (data: { type: MissionType; fromPointId: number; toPointId: number; robotId?: number }) => Promise<Mission>
+  createMission: (data: { type: MissionType; fromPointId: number; toPointId: number; robotId?: number; objectId?: number }) => Promise<Mission>
   cancelMission: (id: number) => Promise<void>
   setCurrentMission: (mission: Mission | null) => void
 }


### PR DESCRIPTION
Travail de Maxime (@TheKyyn).

Closes #139, #137, #138

- page admin objets (CRUD) + objectsApi
- formulaire mission : sélection d'un objet pour pick&place
- timeline de progression mission (dashboard + page détail) via MissionProgress

Merge propre sur dev (0 conflit vérifié).