### PR TITLE
bras 3D miroir de la derniere commande + fix proxy urdf

### DIFF
--- a/web/frontend/e2e/mission-flow.spec.ts
+++ b/web/frontend/e2e/mission-flow.spec.ts
@@ -115,7 +115,7 @@ test.describe('UC-01 — flux mission transport', () => {
 
     await page.goto('/')
     // attend que les missions soient chargées (sinon STOP dit "aucune mission active")
-    await expect(page.getByText('#007')).toBeVisible()
+    await expect(page.getByRole('link', { name: '#007 · Transport' })).toBeVisible()
 
     const stopBtn = page.getByRole('button', { name: "Arrêt d'urgence du robot" })
     await expect(stopBtn).toBeEnabled()

--- a/web/frontend/src/components/ArmController.tsx
+++ b/web/frontend/src/components/ArmController.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { Bot, Send, RotateCcw, AlertTriangle, Power, PowerOff, Crosshair } from 'lucide-react'
 import { toast } from 'sonner'
 import { commandArm, commandArmPreset, type ArmCommand, type ArmPresetName } from '@/lib/armApi'
+import { useMappingStore } from '@/stores/mappingStore'
 
 // Controle direct du bras 6-DOF Yahboom M3 Pro.
 // joint1..5 : axes du bras (-180..180 degres)
@@ -38,6 +39,13 @@ export function ArmController({ robotId }: Props) {
   const [busy, setBusy] = useState(false)
   const [armed, setArmed] = useState(false)  // safety toggle
   const lastSentRef = useRef<number>(0)
+  const setArmPose = useMappingStore((s) => s.setArmPose)
+
+  // miroir 3D : le bras est open-loop (joint_states=0), donc on pousse la pose
+  // affichee dans le store pour que URDFViewer la reflete (montage = HOME, sliders, presets)
+  useEffect(() => {
+    setArmPose(pose)
+  }, [pose, setArmPose])
 
   const send = useCallback(async (cmd: ArmCommand): Promise<void> => {
     if (!armed) {

--- a/web/frontend/src/components/URDFViewer.tsx
+++ b/web/frontend/src/components/URDFViewer.tsx
@@ -3,6 +3,8 @@ import * as THREE from 'three'
 import URDFLoader from 'urdf-loader'
 import { Bot, Maximize2, Minimize2, X, AlertTriangle } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
+import { useMappingStore } from '@/stores/mappingStore'
+import { armPoseToUrdfJoints } from '@/lib/armUrdf'
 
 // Viewer 3D fidele du bras Yahboom M3 Pro via urdf-loader.
 // Charge l'URDF reel servi par le backend (/robot_assets/m3pro.urdf.xml)
@@ -22,6 +24,7 @@ interface JointMap {
 
 export function URDFViewer({ robotId, enabled = true }: Props) {
   const token = useAuthStore((s) => s.token)
+  const armPose = useMappingStore((s) => s.armPose)
   const containerRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<{
     scene: THREE.Scene
@@ -128,6 +131,9 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
         if (msg.type !== 'joint_states') return
         const ref = sceneRef.current
         if (!ref || !ref.joints || !Array.isArray(msg.names) || !Array.isArray(msg.positions)) return
+        // robot open-loop : joint_states publie 0 partout (pas d'encodeurs).
+        // on ignore ces messages nuls pour ne pas ecraser la pose miroir.
+        if (msg.positions.every((p: number) => p === 0)) return
         // mappe par nom (vraie cinematique URDF, pas un mapping invente)
         for (let i = 0; i < msg.names.length; i++) {
           const jointName = msg.names[i]
@@ -143,6 +149,17 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
     }
     return () => ws.close()
   }, [enabled, token, robotId])
+
+  // miroir : applique la derniere pose commandee (degres) sur le modele 3D.
+  // sert tant que le robot reste open-loop — sinon les joint_states reels prennent le relais.
+  useEffect(() => {
+    if (status !== 'ready' || !armPose) return
+    const ref = sceneRef.current
+    if (!ref?.joints) return
+    for (const [name, val] of Object.entries(armPoseToUrdfJoints(armPose))) {
+      ref.joints[name]?.setJointValue(val)
+    }
+  }, [armPose, status])
 
   useEffect(() => {
     const onFs = (): void => setFullscreen(!!document.fullscreenElement)

--- a/web/frontend/src/lib/armUrdf.test.ts
+++ b/web/frontend/src/lib/armUrdf.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { servoDegToUrdfRad, armPoseToUrdfJoints, ARM_JOINT_MAP } from './armUrdf'
+
+describe('servoDegToUrdfRad', () => {
+  it('90 deg (neutre) -> 0 rad', () => {
+    expect(servoDegToUrdfRad(90)).toBeCloseTo(0)
+  })
+  it('180 deg -> +pi/2', () => {
+    expect(servoDegToUrdfRad(180)).toBeCloseTo(Math.PI / 2)
+  })
+  it('0 deg -> -pi/2', () => {
+    expect(servoDegToUrdfRad(0)).toBeCloseTo(-Math.PI / 2)
+  })
+})
+
+describe('armPoseToUrdfJoints', () => {
+  it('mappe les 5 joints du bras sur les noms URDF', () => {
+    const home = { joint1: 90, joint2: 120, joint3: 10, joint4: 20, joint5: 90 }
+    const j = armPoseToUrdfJoints(home)
+    expect(Object.keys(j).sort()).toEqual(Object.values(ARM_JOINT_MAP).sort())
+    expect(j['arm1_Joint']).toBeCloseTo(0) // 90 -> 0
+    expect(j['arm2_Joint']).toBeCloseTo((30 * Math.PI) / 180) // 120 -> +30deg
+    expect(j['arm3_Joint']).toBeCloseTo((-80 * Math.PI) / 180) // 10 -> -80deg
+  })
+  it('garde le vrai nom URDF avec la typo arm4_Joiint', () => {
+    expect(ARM_JOINT_MAP.joint4).toBe('arm4_Joiint')
+  })
+})

--- a/web/frontend/src/lib/armUrdf.ts
+++ b/web/frontend/src/lib/armUrdf.ts
@@ -1,0 +1,32 @@
+import type { ArmCommand } from './armApi'
+
+// Mapping pose commandee (degres Yahboom) -> joints du modele URDF (radians).
+// Sert au "miroir" : le M3 Pro est open-loop (/joint_states=0), donc le viewer 3D
+// suit la derniere commande envoyee au lieu d'un feedback inexistant.
+
+// noms reels des joints dans l'URDF Yahboom — arm4 a une typo "Joiint" cote source, on la garde
+export const ARM_JOINT_MAP: Record<string, string> = {
+  joint1: 'arm1_Joint',
+  joint2: 'arm2_Joint',
+  joint3: 'arm3_Joint',
+  joint4: 'arm4_Joiint',
+  joint5: 'arm5_Joint',
+}
+
+type ArmPoseDeg = Pick<ArmCommand, 'joint1' | 'joint2' | 'joint3' | 'joint4' | 'joint5'>
+
+// convention Yahboom : servo 0..180, 90 = neutre. URDF en radians, 0 = neutre.
+export function servoDegToUrdfRad(deg: number): number {
+  return ((deg - 90) * Math.PI) / 180
+}
+
+// pose (degres) -> { nomJointUrdf: radians }. joint6 (pince) non mappe :
+// la pince URDF est a 2 doigts (rlink/llink), pas un joint unique.
+export function armPoseToUrdfJoints(pose: ArmPoseDeg): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const [key, urdfName] of Object.entries(ARM_JOINT_MAP)) {
+    const deg = pose[key as keyof ArmPoseDeg]
+    if (typeof deg === 'number') out[urdfName] = servoDegToUrdfRad(deg)
+  }
+  return out
+}

--- a/web/frontend/src/stores/mappingStore.ts
+++ b/web/frontend/src/stores/mappingStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import type { ArmCommand } from '@/lib/armApi'
 
 export type MappingState = 'IDLE' | 'STARTING' | 'RUNNING' | 'STOPPING' | 'STOPPED' | 'FAILED'
 
@@ -47,6 +48,8 @@ interface MappingStore {
   // tf/topics (T3.5.11)
   tfFrames: { id: string; parent: string }[] | null
   topics: { name: string; msgType: string }[] | null
+  // derniere pose bras commandee (degres) — miroir 3D, le robot est open-loop
+  armPose: ArmCommand | null
 
   setState: (state: MappingState) => void
   setSession: (sessionId: number | null) => void
@@ -64,6 +67,7 @@ interface MappingStore {
   setRobotPose: (p: Pose | null) => void
   setTfFrames: (f: { id: string; parent: string }[] | null) => void
   setTopics: (t: { name: string; msgType: string }[] | null) => void
+  setArmPose: (p: ArmCommand) => void
   reset: () => void
 }
 
@@ -83,6 +87,7 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   robotPose: null,
   tfFrames: null,
   topics: null,
+  armPose: null,
 
   setState: (state) => set({ state }),
   setSession: (sessionId) => set({ sessionId }),
@@ -111,6 +116,7 @@ export const useMappingStore = create<MappingStore>((set, get) => ({
   setRobotPose: (p) => set({ robotPose: p }),
   setTfFrames: (f) => set({ tfFrames: f }),
   setTopics: (t) => set({ topics: t }),
+  setArmPose: (p) => set({ armPose: p }),
 
   reset: () => {
     const prev = get().mapPngUrl

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
         ws: true,
         changeOrigin: true,
       },
+      // urdf + meshes STL servis par le backend, sinon le fallback SPA renvoie index.html
+      '/robot_assets': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Ce qui a été fait

Le bras 3D du mode mapping affichait une mauvaise pose et l'URDF ne se chargeait même pas. Deux bugs distincts :

- **Proxy vite manquant** : `/robot_assets` n'était pas proxifié vers le backend → le fallback SPA renvoyait `index.html` à la place de l'URDF/meshes → URDFLoader plantait (`robot.children` undefined). Ajout d'une règle proxy.
- **Pose figée fausse** : le viewer suivait `/joint_states`, mais le M3 Pro est open-loop (pas d'encodeurs → tout à 0), donc le bras s'affichait à plat. Le viewer reflète maintenant la dernière commande connue (HOME au montage, puis sliders/presets) via le store. Conversion servo°→rad URDF isolée dans `lib/armUrdf.ts` (testée).

Le miroir marche même en mode "Désarmé" → retour visuel sans toucher au robot.

## Tests
- [x] Lint OK
- [x] TypeCheck OK
- [x] Tests unitaires (vitest 9/9, dont 5 nouveaux sur la conversion)
- [x] E2E Playwright (24 passed, 2 skip desktop-only)
- [x] Validé visuellement (chromium WebGL logiciel) : bras en pose HOME

## Notes / limites connues
- Calibration deg→rad par joint **non validée contre le bras réel** (batterie < 12 V → mouvement NO-GO). La pose est cohérente/crédible, pas garantie pixel-perfect — à recaler en session robot mobile.
- Pince (joint6) non mappée : la pince URDF est à 2 doigts (rlink/llink), laissée hors miroir volontairement.
- Le fix proxy est dev-only (en prod, front+API même origine).