### PR TITLE
fix(robot): scan_restamper restampe a now-0.2s, fini les drops slam

### DIFF
--- a/robot/roblaude_nav/roblaude_nav/scan_restamper.py
+++ b/robot/roblaude_nav/roblaude_nav/scan_restamper.py
@@ -16,9 +16,16 @@ Impact sur slam_toolbox :
 
 Solution :
   Souscrire a /scan_multi, copier le message, ecraser msg.header.stamp avec
-  self.get_clock().now() (temps wall present), republier sur /scan_fixed.
-  Slam_toolbox abonne a /scan_fixed -> trouve immediatement la TF dans le
-  cache -> match -> publie TF map->odom -> debloque toute la stack.
+  un temps wall LEGEREMENT dans le passe (now - stamp_offset), republier sur
+  /scan_fixed. Slam_toolbox abonne a /scan_fixed -> trouve la TF dans le cache
+  -> match -> publie TF map->odom -> debloque toute la stack.
+
+  Pourquoi pas now() pile : la TF odom->base_footprint (EKF Yahboom) arrive
+  avec un petit retard. Si on stampe le scan a now(), la TF a cet instant
+  n'est pas encore publiee -> le scan attend dans la queue du message_filter
+  -> queue full -> drop (vu IRL meme robot a l'arret). On recule le stamp de
+  ~0.2s pour tomber sur une pose odom deja dispo. Biais negligeable a vitesse
+  d'exploration (~2-4cm a 5cm/px).
 
 Note : on ne touche PAS a l'odom ni a la TF. L'ekf_filter_node (lance par
 base_bringup Yahboom) publie deja /odom et TF odom->base_link avec stamps
@@ -27,6 +34,7 @@ corrects, pas de drift cote EKF.
 
 import rclpy
 from rclpy.node import Node
+from rclpy.duration import Duration
 from sensor_msgs.msg import LaserScan
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 
@@ -35,6 +43,11 @@ class ScanRestamper(Node):
     def __init__(self):
         super().__init__('scan_restamper')
 
+        # recul du stamp pour rester derriere la derniere TF odom dispo.
+        # ajustable a chaud sans rebuild : -p stamp_offset:=0.15
+        self.declare_parameter('stamp_offset', 0.2)
+        self._offset = Duration(seconds=self.get_parameter('stamp_offset').value)
+
         qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE)
         self.pub = self.create_publisher(LaserScan, '/scan_fixed', qos)
         self.sub = self.create_subscription(LaserScan, '/scan_multi', self.on_scan, qos)
@@ -42,11 +55,12 @@ class ScanRestamper(Node):
         self._count = 0
         self.create_timer(5.0, self._report)
         self.get_logger().info(
-            'scan_restamper ready : /scan_multi -> /scan_fixed (stamps -> now)'
+            f'scan_restamper ready : /scan_multi -> /scan_fixed '
+            f'(stamps -> now - {self.get_parameter("stamp_offset").value}s)'
         )
 
     def on_scan(self, msg: LaserScan):
-        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.stamp = (self.get_clock().now() - self._offset).to_msg()
         self.pub.publish(msg)
         self._count += 1
 


### PR DESCRIPTION
## Ce qui a été fait
Le LiDAR Yahboom estampille les scans dans le futur → slam_toolbox droppe tout (« Message Filter dropping... queue is full »). Le `scan_restamper` republie maintenant avec `now() - 0.2s` (offset, pas `now()` brut, sinon la TF odom EKF n'est pas encore dispo). Résultat : 0 drop avec slam seul.

## Périmètre
- 1 fichier : `robot/roblaude_nav/roblaude_nav/scan_restamper.py` (+19/-5).
- Aucun impact web (CI frontend/backend non concernée par ce node ROS).

## Notes
- Validé en session (snapshot robot : `/scan_multi` OK).
- Branche derrière dev (sans #264) mais changement isolé → pas de conflit.