### PR TITLE
feat(backend): couleur GraspObject + targetColor dans cmd/mission

### DIFF
--- a/docs/mqtt-spec.md
+++ b/docs/mqtt-spec.md
@@ -145,12 +145,15 @@ manquant) est **loggé puis ignoré** — jamais de crash.
   "type": "TRANSPORT",
   "fromPoint": { "slug": "accueil",     "x": 1.20, "y": 3.40, "theta": 0.00 },
   "toPoint":   { "slug": "bureau-201",  "x": 8.05, "y": 2.10, "theta": 1.57 },
-  "objectId": null
+  "objectId": null,
+  "targetColor": null
 }
 ```
 
 - `type` : `TRANSPORT` (UC-01) ou `PICK_AND_PLACE` (UC-02).
 - `objectId` : `null` pour un transport, l'id de l'objet pour un pick & place.
+- `targetColor` : couleur hex de l'objet (`#rrggbb`) pour un pick & place, `null`
+  pour un transport. Le robot en dérive la plage HSV de détection (UC-02).
 
 **`cmd/cancel`**, **`cmd/resume`**, **`cmd/loading-confirmed`** — même forme
 

--- a/web/backend/prisma/migrations/20260615140000_graspobject_color/migration.sql
+++ b/web/backend/prisma/migrations/20260615140000_graspobject_color/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `GraspObject` ADD COLUMN `color` VARCHAR(191) NOT NULL DEFAULT '#ff0000';

--- a/web/backend/prisma/schema.prisma
+++ b/web/backend/prisma/schema.prisma
@@ -52,6 +52,9 @@ model GraspObject {
   id        Int      @id @default(autoincrement())
   name      String
   imageUrl  String?
+  // couleur cible pour la detection vision du robot (UC-02). Hex, le robot en
+  // derive la plage HSV. Defaut rouge, comme la couleur par defaut du detecteur.
+  color     String   @default("#ff0000")
   available Boolean  @default(true)
   locationId Int
   location  Point    @relation(fields: [locationId], references: [id])

--- a/web/backend/src/controllers/missionsController.ts
+++ b/web/backend/src/controllers/missionsController.ts
@@ -184,6 +184,8 @@ export async function createMission(req: Request, res: Response) {
       fromPoint: { x: fromPoint.x, y: fromPoint.y, theta: fromPoint.theta, slug: fromPoint.slug },
       toPoint: { x: toPoint.x, y: toPoint.y, theta: toPoint.theta, slug: toPoint.slug },
       objectId: mission.objectId,
+      // couleur de l'objet -> le robot impose la cible HSV au detecteur (UC-02)
+      targetColor: mission.object?.color ?? null,
     })
   }
 

--- a/web/backend/src/controllers/objectsController.ts
+++ b/web/backend/src/controllers/objectsController.ts
@@ -43,6 +43,8 @@ export async function getObject(req: Request, res: Response) {
 const objectSchema = z.object({
   name: z.string().min(1, 'Le nom est requis'),
   imageUrl: z.string().optional(),
+  // hex pour la detection vision (le robot en derive la plage HSV)
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Couleur hex attendue (#rrggbb)').optional(),
   available: z.boolean().default(true),
   locationId: z.number().int().positive("L'emplacement est requis"),
 })


### PR DESCRIPTION
## Ce qui a été fait
Régularise `GraspObject.color` (couleur cible UC-02) côté backend, jusqu'ici hors `dev` alors que la colonne existait en base locale par `ALTER` manuel.

- Migration `20260615140000_graspobject_color` : `ALTER TABLE GraspObject ADD COLUMN color` (défaut `#ff0000`).
- `schema.prisma` : champ `color` sur `GraspObject` (≠ `Annotation.color`, qui reste la couleur d'annotation carte).
- `targetColor` propagé dans `cmd/mission` (controllers missions + objects), `mqtt-spec.md` à jour.

## Check fait
- Historique migrations **linéaire** (après `mapping_ssh_annotations`).
- Changement `schema.prisma` isolé → pas de conflit avec `Annotation.color`.

## Caveat local
- La base de dev locale a déjà la colonne (ajout manuel) → `prisma migrate deploy` local peut renvoyer « duplicate column ». Sur base fraîche / CI, OK. À résoudre côté poste (drop manuel ou `migrate resolve`).