### PR TITLE
fix(robot): agent micro-ROS sur le CP2104 (STM32), pas le CH340 + healthcheck

### DIFF
--- a/robot/README.md
+++ b/robot/README.md
@@ -97,4 +97,4 @@ Lancés depuis le Mac/PC, pas dans le container ROS2.
   un problème de câble**, c'est la cible série.
 - **Persistance** : `install_microros_service.sh` installe l'agent en service systemd
   (relink + restart auto) + un healthcheck (timer 2 min) qui capture le diag dans
-  `~/roblaude_diag/` à chaque incident.
+  `/var/log/roblaude/` à chaque incident.

--- a/robot/README.md
+++ b/robot/README.md
@@ -76,7 +76,10 @@ Lancés depuis le Mac/PC, pas dans le container ROS2.
 | `deploy_to_robot.sh` | Déploie le code vers le robot via rsync |
 | `connect.sh` | SSH + noVNC vers le robot |
 | `Docker_M3Pro_Joy.sh` | Lance le container ROS2 principal (nom fixe `m3pro_main`) |
-| `start_agent.sh` | Lance le container micro-ROS-agent (nom fixe `micro_ros_agent`) |
+| `start_agent.sh` | (legacy) lancement manuel de l'agent micro-ROS — remplacé par le service systemd |
+| `install_microros_service.sh` | Installe l'agent micro-ROS en service systemd + healthcheck (à lancer sur le Jetson) |
+| `roblaude-link-stm32.sh` | Lie `/dev/myserial` au STM32 (CP210x), jamais au CH340 (micro) |
+| `roblaude-stm32-healthcheck.sh` | Vérifie la session STM32, capture le diag et relance l'agent si KO |
 
 ## Notes matérielles
 
@@ -85,3 +88,13 @@ Lancés depuis le Mac/PC, pas dans le container ROS2.
 - **Caméra** : c'est une **Orbbec DaBai DCW2** (et non une RealSense comme indiqué
   initialement dans le CDC).
 - **LiDAR** : le M3 PRO produit 2 demi-scans (`/scan0` + `/scan1`) fusionnés en `/scan`.
+- **Série / STM32** : il y a **deux** adaptateurs USB-série. Le STM32 (base, batterie,
+  moteurs, bras) est un **CP2104 = `10c4:ea60`** → c'est lui que `/dev/myserial` doit
+  viser. Le **CH340 = `1a86`** est le **micro** (`speech.rules` le mappe sur `/dev/mic`).
+  Ne jamais pointer l'agent micro-ROS sur le CH340. L'ordre `ttyUSB0/1` change au boot,
+  donc on keye sur la puce, pas sur le numéro. Symptôme du mauvais port : l'agent affiche
+  `running... fd: 3` puis plus rien, `YB_Node` absent, `/battery` muet — **ce n'est pas
+  un problème de câble**, c'est la cible série.
+- **Persistance** : `install_microros_service.sh` installe l'agent en service systemd
+  (relink + restart auto) + un healthcheck (timer 2 min) qui capture le diag dans
+  `~/roblaude_diag/` à chaque incident.

--- a/robot/scripts/install_microros_service.sh
+++ b/robot/scripts/install_microros_service.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# install_microros_service.sh — installe (idempotent) le bridge micro-ROS STM32
+# en service systemd + son healthcheck. A lancer SUR le Jetson.
+#
+# Corrige le bug historique : l'agent etait pointe sur le CH340 (1a86 = micro)
+# au lieu du STM32 (CP2104 = 10c4:ea60) -> "running... fd:3" sans jamais de
+# session, YB_Node absent, /battery muet. Ici on keye sur la puce CP210x.
+#
+# Usage (depuis le Mac) :
+#   ./robot/scripts/deploy_to_robot.sh            # pousse les scripts
+#   ssh jetson@<robot> 'bash /home/jetson/roblaude_ws/scripts/install_microros_service.sh'
+set -e
+
+SRC="$(cd "$(dirname "$0")" && pwd)"
+
+echo "━━━ 1/4 : helpers dans /usr/local/bin ━━━"
+sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"       /usr/local/bin/roblaude-link-stm32.sh
+sudo install -m 0755 "$SRC/roblaude-stm32-healthcheck.sh" /usr/local/bin/roblaude-stm32-healthcheck.sh
+
+echo "━━━ 2/4 : units systemd ━━━"
+sudo install -m 0644 "$SRC/systemd/micro-ros-agent.service"            /etc/systemd/system/micro-ros-agent.service
+sudo install -m 0644 "$SRC/systemd/roblaude-stm32-healthcheck.service" /etc/systemd/system/roblaude-stm32-healthcheck.service
+sudo install -m 0644 "$SRC/systemd/roblaude-stm32-healthcheck.timer"   /etc/systemd/system/roblaude-stm32-healthcheck.timer
+
+echo "━━━ 3/4 : on coupe l'ancien autostart GUI fragile (si present) ━━━"
+GUI=/home/jetson/.config/autostart/start.desktop
+[ -f "$GUI" ] && mv "$GUI" "$GUI.disabled-by-roblaude-systemd" && echo "   start.desktop desactive"
+
+echo "━━━ 4/4 : (re)demarrage des services ━━━"
+sudo systemctl daemon-reload
+sudo systemctl enable --now micro-ros-agent.service
+sudo systemctl enable --now roblaude-stm32-healthcheck.timer
+sleep 10
+
+echo ""
+echo "━━━ verif ━━━"
+echo "myserial : $(readlink -f /dev/myserial)"
+echo "agent    : $(systemctl is-active micro-ros-agent.service)"
+echo "timer    : $(systemctl is-active roblaude-stm32-healthcheck.timer)"
+sudo /usr/local/bin/roblaude-stm32-healthcheck.sh

--- a/robot/scripts/install_microros_service.sh
+++ b/robot/scripts/install_microros_service.sh
@@ -17,6 +17,9 @@ echo "━━━ 1/4 : helpers dans /usr/local/bin ━━━"
 sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"       /usr/local/bin/roblaude-link-stm32.sh
 sudo install -m 0755 "$SRC/roblaude-stm32-healthcheck.sh" /usr/local/bin/roblaude-stm32-healthcheck.sh
 
+echo "━━━ 1bis/4 : dossier diag root-owned ━━━"
+sudo install -d -o root -g root -m 0755 /var/log/roblaude
+
 echo "━━━ 2/4 : units systemd ━━━"
 sudo install -m 0644 "$SRC/systemd/micro-ros-agent.service"            /etc/systemd/system/micro-ros-agent.service
 sudo install -m 0644 "$SRC/systemd/roblaude-stm32-healthcheck.service" /etc/systemd/system/roblaude-stm32-healthcheck.service

--- a/robot/scripts/roblaude-link-stm32.sh
+++ b/robot/scripts/roblaude-link-stm32.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Lie /dev/myserial au STM32 (puce CP210x, VID 10c4:ea60).
+# NE JAMAIS lier le CH340 (1a86) : c'est le micro du robot (cf speech.rules).
+# On keye sur la puce, pas sur ttyUSB0/1 : l'ordre d'enumeration change au boot.
+set -u
+for i in $(seq 1 90); do
+  for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
+    [ -e "$d" ] || continue
+    ln -sf "$d" /dev/myserial
+    echo "myserial -> $(readlink -f /dev/myserial) (STM32 CP210x)"
+    exit 0
+  done
+  sleep 1
+done
+echo "STM32 CP210x introuvable dans /dev/serial/by-id" >&2
+exit 1

--- a/robot/scripts/roblaude-stm32-healthcheck.sh
+++ b/robot/scripts/roblaude-stm32-healthcheck.sh
@@ -4,10 +4,14 @@
 # capturer le diag pour ne plus rediagnostiquer de zero, puis relink + restart.
 set -u
 SVC=micro-ros-agent.service
-DIAGDIR=/home/jetson/roblaude_diag
+# Tourne en root (oneshot systemd) : on garde le diag dans un dossier root-owned,
+# pas dans /home/jetson (sinon un compte jetson compromis pourrait piéger le chemin
+# par symlink et faire écrire root ailleurs). 0755 => lisible sans sudo.
+DIAGDIR=/var/log/roblaude
 STAMP=/run/roblaude-stm32-last-restart
 COOLDOWN=300
-mkdir -p "$DIAGDIR"
+[ -L "$DIAGDIR" ] && { echo "$DIAGDIR est un symlink, abort" >&2; exit 1; }
+install -d -o root -g root -m 0755 "$DIAGDIR" 2>/dev/null || mkdir -p "$DIAGDIR"
 reason=""
 
 # 1. container agent vivant ?
@@ -34,6 +38,7 @@ fi
 
 # --- incident ---
 F="$DIAGDIR/incident_$(date +%Y%m%d-%H%M%S).log"
+[ -L "$F" ] && rm -f "$F"   # jamais suivre un symlink piégé
 {
   echo "REASON: $reason"; date; uptime
   echo "--- myserial ---"; ls -l /dev/myserial 2>&1; ls -l /dev/serial/by-id 2>&1
@@ -50,4 +55,5 @@ if [ $((now-last)) -ge $COOLDOWN ]; then
 else
   echo "cooldown actif, pas de restart"
 fi
-ls -1t "$DIAGDIR"/incident_*.log 2>/dev/null | tail -n +31 | xargs -r rm -f
+# garde les 30 plus recents (noms horodates -> tri lexical = chronologique)
+find "$DIAGDIR" -maxdepth 1 -name 'incident_*.log' -type f | sort | head -n -30 | while read -r f; do rm -f -- "$f"; done

--- a/robot/scripts/roblaude-stm32-healthcheck.sh
+++ b/robot/scripts/roblaude-stm32-healthcheck.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Healthcheck STM32 <-> micro-ROS (timer systemd, toutes les 2 min).
+# But : detecter tot une regression (agent sur le mauvais port, session morte)
+# capturer le diag pour ne plus rediagnostiquer de zero, puis relink + restart.
+set -u
+SVC=micro-ros-agent.service
+DIAGDIR=/home/jetson/roblaude_diag
+STAMP=/run/roblaude-stm32-last-restart
+COOLDOWN=300
+mkdir -p "$DIAGDIR"
+reason=""
+
+# 1. container agent vivant ?
+docker ps --format '{{.Names}}' | grep -q '^micro_ros_agent$' || reason="container micro_ros_agent absent"
+
+# 2. myserial pointe bien sur le CP210x (jamais le CH340) ?
+if [ -z "$reason" ]; then
+  tgt=$(readlink -f /dev/myserial 2>/dev/null || true)
+  cp=""
+  for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
+    [ -e "$d" ] && cp=$(readlink -f "$d") && break
+  done
+  [ -n "$cp" ] && [ "$tgt" != "$cp" ] && reason="myserial->$tgt mais STM32(CP210x)=$cp"
+fi
+
+# 3. YB_Node present dans le graphe ROS ? (best-effort)
+if [ -z "$reason" ]; then
+  docker exec -e ROS_DOMAIN_ID=30 -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 m3pro \
+    bash -lc 'source /opt/ros/humble/setup.bash; timeout 8 ros2 node list 2>/dev/null | grep -q YB_Node' \
+    || reason="YB_Node absent du graphe ROS"
+fi
+
+[ -z "$reason" ] && { echo "OK"; exit 0; }
+
+# --- incident ---
+F="$DIAGDIR/incident_$(date +%Y%m%d-%H%M%S).log"
+{
+  echo "REASON: $reason"; date; uptime
+  echo "--- myserial ---"; ls -l /dev/myserial 2>&1; ls -l /dev/serial/by-id 2>&1
+  echo "--- docker ps ---"; docker ps 2>&1
+  echo "--- agent log ---"; docker logs --tail 40 micro_ros_agent 2>&1
+  echo "--- dmesg usb ---"; dmesg 2>/dev/null | grep -Ei 'ch34|cp210|ttyusb|usb .*disconnect|Cannot enable|enumerate' | tail -30
+} > "$F" 2>&1
+echo "incident: $reason -> $F"
+
+/usr/local/bin/roblaude-link-stm32.sh || true
+now=$(date +%s); last=$(cat "$STAMP" 2>/dev/null || echo 0)
+if [ $((now-last)) -ge $COOLDOWN ]; then
+  echo "$now" > "$STAMP"; systemctl restart "$SVC"; echo "restart $SVC"
+else
+  echo "cooldown actif, pas de restart"
+fi
+ls -1t "$DIAGDIR"/incident_*.log 2>/dev/null | tail -n +31 | xargs -r rm -f

--- a/robot/scripts/start_agent.sh
+++ b/robot/scripts/start_agent.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# start_agent.sh — Lance le container micro-ROS-agent avec nom fixe
-#
-# Identique a la logique Docker_M3Pro_Joy.sh : nom fixe "micro_ros_agent"
-# -> pas de nouveau container a chaque reboot.
+# start_agent.sh — (LEGACY) lancement manuel de l'agent micro-ROS.
+# Prefere le service systemd : install_microros_service.sh. Ici on garde le
+# lancement manuel pour le debug, mais on relie d'abord /dev/myserial au bon
+# port (CP210x = STM32, jamais le CH340 = micro) via le helper partage.
 
 CONTAINER_NAME="micro_ros_agent"
 IMAGE="192.168.2.51:5000/micro-ros-agent:humble"
+
+# Garde-fou : /dev/myserial doit viser le STM32 (CP210x), pas le micro (CH340).
+[ -x "$(dirname "$0")/roblaude-link-stm32.sh" ] && "$(dirname "$0")/roblaude-link-stm32.sh" || true
 
 # Attend Docker
 while ! systemctl is-active --quiet docker; do

--- a/robot/scripts/systemd/micro-ros-agent.service
+++ b/robot/scripts/systemd/micro-ros-agent.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=RobLaude micro-ROS Agent bridge STM32 -> ROS 2
+Requires=docker.service
+After=docker.service systemd-udev-settle.service
+Wants=network-online.target systemd-udev-settle.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+TimeoutStartSec=120
+TimeoutStopSec=20
+
+# Lie /dev/myserial au CP210x (STM32) — jamais le CH340 (micro). Cf roblaude-link-stm32.sh
+ExecStartPre=/usr/local/bin/roblaude-link-stm32.sh
+ExecStartPre=-/usr/bin/docker rm -f micro_ros_agent
+ExecStart=/usr/bin/docker run --rm --init --name micro_ros_agent --net=host --privileged -v /dev:/dev -v /dev/shm:/dev/shm 192.168.2.51:5000/micro-ros-agent:humble serial --dev /dev/myserial -b 2000000 -v4
+ExecStop=/usr/bin/docker stop -t 10 micro_ros_agent
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/scripts/systemd/roblaude-stm32-healthcheck.service
+++ b/robot/scripts/systemd/roblaude-stm32-healthcheck.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=RobLaude STM32 micro-ROS healthcheck
+After=micro-ros-agent.service docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/roblaude-stm32-healthcheck.sh

--- a/robot/scripts/systemd/roblaude-stm32-healthcheck.service
+++ b/robot/scripts/systemd/roblaude-stm32-healthcheck.service
@@ -5,3 +5,11 @@ After=micro-ros-agent.service docker.service
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/roblaude-stm32-healthcheck.sh
+# Tourne en root (besoin de systemctl restart + docker) mais on cadre les degats.
+NoNewPrivileges=yes
+ProtectHome=yes
+# ProtectHome cache /home => HOME indefini => warning docker. /tmp est prive (PrivateTmp).
+Environment=HOME=/tmp
+ProtectSystem=full
+PrivateTmp=yes
+ReadWritePaths=/var/log/roblaude /run

--- a/robot/scripts/systemd/roblaude-stm32-healthcheck.timer
+++ b/robot/scripts/systemd/roblaude-stm32-healthcheck.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=RobLaude STM32 healthcheck (toutes les 2 min)
+
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=120
+AccuracySec=10
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Cause réelle

Le service systemd pointait `/dev/myserial` sur le **CH340 (`1a86` = le micro)** au lieu du **STM32 = CP2104 (`10c4:ea60`)**. L'agent ouvrait donc un port valide branché sur le micro → `running... fd: 3` éternel, aucune session, `YB_Node` absent, `/battery` muet. Ce n'était **ni le câble, ni le hub, ni l'alim** : le STM32 était énuméré et sain depuis le début (confirmé en pointant un agent sur le CP2104 → session + YB_Node + /battery 10,5 V immédiat).

## Fix

- `roblaude-link-stm32.sh` : lie `/dev/myserial` au CP210x, jamais au CH340. Keye sur la puce (l'ordre ttyUSB0/1 change au boot).
- `systemd/micro-ros-agent.service` : ExecStartPre utilise le helper.
- `roblaude-stm32-healthcheck.sh` + timer (2 min) : vérifie la vraie santé (YB_Node + /battery), capture le diag dans `~/roblaude_diag/` à chaque incident, relink + restart avec cooldown.
- `install_microros_service.sh` : installeur idempotent.
- `start_agent.sh` (legacy) : garde-fou relink avant lancement.

Déployé et vérifié sur le robot : myserial → CP2104, agent active, timer active, healthcheck OK, YB_Node présent.