### PR TITLE
feat(web): page Réparation robot — santé live + réparations 1-clic

### DIFF
--- a/robot/scripts/install_microros_service.sh
+++ b/robot/scripts/install_microros_service.sh
@@ -14,8 +14,9 @@ set -e
 SRC="$(cd "$(dirname "$0")" && pwd)"
 
 echo "━━━ 1/4 : helpers dans /usr/local/bin ━━━"
-sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"       /usr/local/bin/roblaude-link-stm32.sh
+sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"        /usr/local/bin/roblaude-link-stm32.sh
 sudo install -m 0755 "$SRC/roblaude-stm32-healthcheck.sh" /usr/local/bin/roblaude-stm32-healthcheck.sh
+sudo install -m 0755 "$SRC/roblaude-robot-status.sh"      /usr/local/bin/roblaude-robot-status.sh
 
 echo "━━━ 1bis/4 : dossier diag root-owned ━━━"
 sudo install -d -o root -g root -m 0755 /var/log/roblaude

--- a/robot/scripts/roblaude-robot-status.sh
+++ b/robot/scripts/roblaude-robot-status.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Etat du robot en JSON (READ-ONLY, aucune action, aucune reparation).
+# Lu par le backend via SSH pour la page Reparation du front.
+set -u
+
+# 1. /dev/myserial pointe-t-il bien sur le STM32 (CP210x) ?
+myserial_ok=false
+tgt=$(readlink -f /dev/myserial 2>/dev/null || true)
+for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
+  [ -e "$d" ] || continue
+  [ "$(readlink -f "$d")" = "$tgt" ] && myserial_ok=true
+  break
+done
+
+# 2. service agent micro-ROS
+agent=$(systemctl is-active micro-ros-agent.service 2>/dev/null || echo unknown)
+
+# 3. container ROS principal
+m3pro=down
+docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^m3pro$' && m3pro=up
+
+# 4. YB_Node present = session STM32 vivante
+yb_node=false
+if [ "$m3pro" = up ]; then
+  docker exec -e ROS_DOMAIN_ID=30 -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 m3pro \
+    bash -lc 'source /opt/ros/humble/setup.bash; timeout 8 ros2 node list 2>/dev/null | grep -q YB_Node' \
+    && yb_node=true
+fi
+
+printf '{"myserial_ok":%s,"agent":"%s","m3pro":"%s","yb_node":%s}\n' \
+  "$myserial_ok" "$agent" "$m3pro" "$yb_node"

--- a/web/backend/src/app.ts
+++ b/web/backend/src/app.ts
@@ -11,6 +11,7 @@ import robotsRouter from './routes/robots'
 import mappingRouter from './routes/mapping'
 import annotationsRouter from './routes/annotations'
 import sshRouter from './routes/ssh'
+import robotOpsRouter from './routes/robotOps'
 
 const app = express()
 
@@ -45,6 +46,7 @@ app.use('/api/robots', authGuard, robotsRouter)
 app.use('/api/mapping', authGuard, mappingRouter)
 app.use('/api/annotations', authGuard, annotationsRouter)
 app.use('/api/admin/ssh', authGuard, sshRouter)
+app.use('/api/admin', authGuard, robotOpsRouter)
 
 // error handler — doit etre en dernier
 app.use(errorHandler)

--- a/web/backend/src/controllers/repairController.ts
+++ b/web/backend/src/controllers/repairController.ts
@@ -1,0 +1,105 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+import prisma from '../lib/prisma'
+import { runOnce } from '../services/sshConnection'
+import { REPAIR_ACTIONS, repairCommand, type RepairAction } from '../lib/repairActions'
+
+const repairSchema = z.object({
+  action: z.enum(REPAIR_ACTIONS as unknown as [string, ...string[]]),
+  confirm: z.boolean().optional(),
+})
+
+// Page Reparation (admin). getHealth = etat consolide du robot ; runRepair =
+// declenche une action de reparation a partir d'un enum ferme (cf repairActions).
+
+interface RobotStatusJson {
+  myserial_ok: boolean
+  agent: string
+  m3pro: string
+  yb_node: boolean
+}
+
+const STATUS_CMD = '/usr/local/bin/roblaude-robot-status.sh'
+
+/** GET /api/admin/robots/:id/health */
+export async function getHealth(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.params.id)
+  if (!Number.isInteger(robotId) || robotId <= 0) {
+    res.status(400).json({ error: 'invalid robotId' })
+    return
+  }
+
+  const robot = await prisma.robot
+    .findUnique({ where: { id: robotId }, select: { battery: true } })
+    .catch(() => null)
+
+  let probe: RobotStatusJson | null = null
+  let reachable = true
+  try {
+    const r = await runOnce(robotId, STATUS_CMD, 12_000)
+    probe = JSON.parse(r.stdout.trim()) as RobotStatusJson
+  } catch {
+    reachable = false
+  }
+
+  res.json({
+    reachable,
+    stm32: probe ? (probe.myserial_ok ? 'ok' : 'down') : 'unknown',
+    ybNode: probe ? (probe.yb_node ? 'ok' : 'down') : 'unknown',
+    agent: probe ? (probe.agent === 'active' ? 'active' : 'dead') : 'unknown',
+    m3pro: probe ? (probe.m3pro === 'up' ? 'up' : 'down') : 'unknown',
+    battery: robot?.battery ?? null,
+    ts: new Date().toISOString(),
+  })
+}
+
+/** POST /api/admin/robots/:id/repair  body { action, confirm? } */
+export async function runRepair(req: Request, res: Response): Promise<void> {
+  const robotId = Number(req.params.id)
+  if (!Number.isInteger(robotId) || robotId <= 0) {
+    res.status(400).json({ error: 'invalid robotId' })
+    return
+  }
+  const userId = req.user?.userId
+  if (!userId) {
+    res.status(401).json({ error: 'auth required' })
+    return
+  }
+
+  const parsed = repairSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'unknown action', issues: parsed.error.issues })
+    return
+  }
+  const action = parsed.data.action as RepairAction
+  // le reboot coupe tout -> on exige une confirmation explicite
+  if (action === 'reboot' && parsed.data.confirm !== true) {
+    res.status(400).json({ error: 'reboot requires confirm:true' })
+    return
+  }
+
+  // genere cote serveur (jamais le client) -> pas d'injection dans resync_clock
+  const nowUtc = new Date().toISOString().replace('T', ' ').slice(0, 19)
+  const command = repairCommand(action, nowUtc)
+  const startedAt = Date.now()
+
+  try {
+    const result = await runOnce(robotId, command, action === 'reboot' ? 5_000 : 20_000)
+    const durationMs = Date.now() - startedAt
+    await prisma.sshAuditLog
+      .create({ data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: result.code, durationMs } })
+      .catch((err) => console.error('[repair] audit echec :', err.message))
+    res.json({ ok: result.code === 0, action, command, stdout: result.stdout, stderr: result.stderr, code: result.code })
+  } catch (err) {
+    const durationMs = Date.now() - startedAt
+    await prisma.sshAuditLog
+      .create({ data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: -1, durationMs } })
+      .catch(() => {})
+    // le reboot coupe la connexion SSH : c'est attendu, on considere l'action lancee
+    if (action === 'reboot') {
+      res.json({ ok: true, action, command, note: 'reboot lancé (connexion coupée)' })
+      return
+    }
+    res.status(502).json({ error: 'ssh failure', action, message: err instanceof Error ? err.message : 'ssh error' })
+  }
+}

--- a/web/backend/src/lib/repairActions.ts
+++ b/web/backend/src/lib/repairActions.ts
@@ -1,0 +1,39 @@
+// Actions de reparation robot exposees au front. L'idee : le front envoie un
+// NOM d'action (pas une commande shell), le backend mappe vers une commande SSH
+// fixe. Surface fermee -> pas d'injection possible.
+
+export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot'
+
+export const REPAIR_ACTIONS: readonly RepairAction[] = [
+  'reconnect_stm32',
+  'restart_ros',
+  'resync_clock',
+  'reboot',
+]
+
+export const REPAIR_LABELS: Record<RepairAction, string> = {
+  reconnect_stm32: 'Reconnexion STM32',
+  restart_ros: 'Redémarrage stack ROS',
+  resync_clock: 'Resync horloge',
+  reboot: 'Redémarrage Jetson',
+}
+
+export function isRepairAction(x: unknown): x is RepairAction {
+  return typeof x === 'string' && (REPAIR_ACTIONS as readonly string[]).includes(x)
+}
+
+// Commande SSH fixe pour une action. `nowUtc` (genere cote serveur, jamais le
+// client) sert uniquement a resync_clock.
+export function repairCommand(action: RepairAction, nowUtc?: string): string {
+  switch (action) {
+    case 'reconnect_stm32':
+      // restart du service -> son ExecStartPre relie /dev/myserial au CP2104 tout seul
+      return 'sudo systemctl restart micro-ros-agent.service'
+    case 'restart_ros':
+      return 'docker restart m3pro'
+    case 'resync_clock':
+      return `sudo date -u -s "${nowUtc ?? ''}"`
+    case 'reboot':
+      return 'sudo reboot'
+  }
+}

--- a/web/backend/src/routes/robotOps.ts
+++ b/web/backend/src/routes/robotOps.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { adminGuard } from '../middleware/auth'
+import { getHealth, runRepair } from '../controllers/repairController'
+
+// Routes ops robot (admin) : sante + reparation. Montees sous /api/admin.
+
+const router = Router()
+router.use(adminGuard)
+router.get('/robots/:id/health', getHealth)
+router.post('/robots/:id/repair', runRepair)
+
+export default router

--- a/web/backend/src/test/repair.test.ts
+++ b/web/backend/src/test/repair.test.ts
@@ -1,0 +1,131 @@
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+
+vi.mock('../services/sshConnection', () => ({ runOnce: vi.fn() }))
+
+import request from 'supertest'
+import { app } from '../app'
+import { runOnce } from '../services/sshConnection'
+import { PrismaClient, Role } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import { signToken } from '../middleware/auth'
+import { repairCommand } from '../lib/repairActions'
+
+const mockRunOnce = vi.mocked(runOnce)
+const prisma = new PrismaClient()
+let adminToken: string
+let userToken: string
+let adminId: number
+let userId: number
+let robotId: number
+
+beforeAll(async () => {
+  const a = await prisma.user.create({
+    data: { email: `adm-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'adm', role: Role.ADMIN },
+  })
+  adminId = a.id
+  adminToken = signToken({ userId: a.id, email: a.email, role: a.role })
+  const u = await prisma.user.create({
+    data: { email: `usr-${Date.now()}@x.com`, password: bcrypt.hashSync('x', 4), name: 'usr', role: Role.USER },
+  })
+  userId = u.id
+  userToken = signToken({ userId: u.id, email: u.email, role: u.role })
+  const r = await prisma.robot.create({ data: { name: `rep-${Date.now()}`, battery: 77 } })
+  robotId = r.id
+})
+
+afterAll(async () => {
+  await prisma.sshAuditLog.deleteMany({ where: { robotId } })
+  await prisma.robot.delete({ where: { id: robotId } })
+  await prisma.user.deleteMany({ where: { id: { in: [adminId, userId] } } })
+  await prisma.$disconnect()
+})
+
+beforeEach(() => {
+  mockRunOnce.mockReset()
+})
+
+describe('repairActions (pur)', () => {
+  it('mappe chaque action vers sa commande fixe', () => {
+    expect(repairCommand('reconnect_stm32')).toBe('sudo systemctl restart micro-ros-agent.service')
+    expect(repairCommand('restart_ros')).toBe('docker restart m3pro')
+    expect(repairCommand('reboot')).toBe('sudo reboot')
+    expect(repairCommand('resync_clock', '2026-06-17 10:00:00')).toBe('sudo date -u -s "2026-06-17 10:00:00"')
+  })
+})
+
+describe('GET /api/admin/robots/:id/health', () => {
+  it('consolide la sonde + la batterie', async () => {
+    mockRunOnce.mockResolvedValue({
+      stdout: '{"myserial_ok":true,"agent":"active","m3pro":"up","yb_node":true}',
+      stderr: '',
+      code: 0,
+    })
+    const res = await request(app).get(`/api/admin/robots/${robotId}/health`).set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ reachable: true, stm32: 'ok', ybNode: 'ok', agent: 'active', m3pro: 'up', battery: 77 })
+  })
+
+  it('robot injoignable -> reachable false, etats unknown', async () => {
+    mockRunOnce.mockRejectedValue(new Error('ssh timeout'))
+    const res = await request(app).get(`/api/admin/robots/${robotId}/health`).set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    expect(res.body.reachable).toBe(false)
+    expect(res.body.stm32).toBe('unknown')
+  })
+
+  it('refuse un non-admin (403)', async () => {
+    const res = await request(app).get(`/api/admin/robots/${robotId}/health`).set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('POST /api/admin/robots/:id/repair', () => {
+  it('reconnect_stm32 lance la bonne commande + audit', async () => {
+    mockRunOnce.mockResolvedValue({ stdout: '', stderr: '', code: 0 })
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'reconnect_stm32' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(mockRunOnce).toHaveBeenCalledWith(robotId, 'sudo systemctl restart micro-ros-agent.service', expect.any(Number))
+    const audit = await prisma.sshAuditLog.findFirst({ where: { robotId }, orderBy: { id: 'desc' } })
+    expect(audit?.command).toBe('sudo systemctl restart micro-ros-agent.service')
+  })
+
+  it('action inconnue -> 400', async () => {
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'rm -rf /' })
+    expect(res.status).toBe(400)
+    expect(mockRunOnce).not.toHaveBeenCalled()
+  })
+
+  it('reboot sans confirm -> 400', async () => {
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'reboot' })
+    expect(res.status).toBe(400)
+    expect(mockRunOnce).not.toHaveBeenCalled()
+  })
+
+  it('reboot avec confirm -> ok meme si la connexion tombe', async () => {
+    mockRunOnce.mockRejectedValue(new Error('ssh timeout'))
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'reboot', confirm: true })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('refuse un non-admin (403)', async () => {
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ action: 'reconnect_stm32' })
+    expect(res.status).toBe(403)
+  })
+})

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AdminObjectsPage } from './pages/AdminObjectsPage'
 import { ProfilePage } from './pages/ProfilePage'
 import { MappingPage } from './pages/MappingPage'
 import { AdminSshPage } from './pages/AdminSshPage'
+import { RobotRepairPage } from './pages/RobotRepairPage'
 import { LoginPage } from './pages/LoginPage'
 import { DegradedModeBanner } from './components/DegradedModeBanner'
 import { RequireAuth } from './components/RequireAuth'
@@ -52,6 +53,10 @@ export default function App() {
             <Route
               path="/admin/ssh"
               element={role === 'ADMIN' ? <AdminSshPage /> : <Navigate to="/" replace />}
+            />
+            <Route
+              path="/admin/repair"
+              element={role === 'ADMIN' ? <RobotRepairPage /> : <Navigate to="/" replace />}
             />
           </Route>
         </Route>

--- a/web/frontend/src/components/Sidebar.tsx
+++ b/web/frontend/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Terminal,
   Sparkles,
   Package,
+  Wrench,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
@@ -24,7 +25,8 @@ const NAV_ITEMS = [
   { to: '/admin', label: 'Admin', code: '05', Icon: Settings2, adminOnly: true },
   { to: '/admin/objects', label: 'Objets', code: '06', Icon: Package, adminOnly: true },
   { to: '/admin/ssh', label: 'SSH admin', code: '07', Icon: Terminal, adminOnly: true },
-  { to: '/profile', label: 'Profil', code: '07', Icon: User, adminOnly: false },
+  { to: '/admin/repair', label: 'Réparation', code: '08', Icon: Wrench, adminOnly: true },
+  { to: '/profile', label: 'Profil', code: '09', Icon: User, adminOnly: false },
 ]
 
 export function Sidebar() {

--- a/web/frontend/src/lib/repairApi.ts
+++ b/web/frontend/src/lib/repairApi.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from './api'
+
+// API page Reparation (admin). Cote back : /api/admin/robots/:id/{health,repair}.
+// On envoie un NOM d'action, jamais une commande shell.
+
+export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot'
+export type HealthState = 'ok' | 'down' | 'active' | 'dead' | 'up' | 'unknown'
+
+export interface RobotHealth {
+  reachable: boolean
+  stm32: HealthState
+  ybNode: HealthState
+  agent: HealthState
+  m3pro: HealthState
+  battery: number | null
+  ts: string
+}
+
+export interface RepairResult {
+  ok: boolean
+  action: RepairAction
+  command?: string
+  stdout?: string
+  stderr?: string
+  code?: number
+  note?: string
+}
+
+export const REPAIR_LABELS: Record<RepairAction, string> = {
+  reconnect_stm32: 'Reconnecter le STM32',
+  restart_ros: 'Redémarrer la stack ROS',
+  resync_clock: 'Resync horloge',
+  reboot: 'Redémarrer le Jetson',
+}
+
+export async function getRobotHealth(robotId: number): Promise<RobotHealth> {
+  const res = await apiFetch(`/admin/robots/${robotId}/health`)
+  if (!res.ok) throw new Error(`getRobotHealth ${res.status}`)
+  return res.json()
+}
+
+export async function runRepair(
+  robotId: number,
+  action: RepairAction,
+  confirm = false,
+): Promise<RepairResult> {
+  const res = await apiFetch(`/admin/robots/${robotId}/repair`, {
+    method: 'POST',
+    body: JSON.stringify({ action, confirm }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? `runRepair ${res.status}`)
+  }
+  return res.json()
+}

--- a/web/frontend/src/pages/RobotRepairPage.tsx
+++ b/web/frontend/src/pages/RobotRepairPage.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowLeft, Wrench, RefreshCw, ChevronDown, ChevronRight, Activity } from 'lucide-react'
+import { toast } from 'sonner'
+import { useRobotStore } from '../stores/robotStore'
+import { getRobotHealth, runRepair, REPAIR_LABELS, type RobotHealth, type RepairAction } from '../lib/repairApi'
+import { fetchRobotLogs } from '../lib/sshApi'
+
+// Page admin /admin/repair : sante du robot en clair + reparations 1-clic.
+// Poll la sante toutes les 4s, genere un fil d'evenements lisible, et permet
+// de declencher des actions de reparation (enum ferme cote back).
+
+type Level = 'ok' | 'warn' | 'bad' | 'info'
+interface FeedItem { id: number; t: string; level: Level; msg: string }
+
+interface Subsystem {
+  key: 'stm32' | 'ybNode' | 'agent' | 'm3pro'
+  label: string
+  isGood: (h: RobotHealth) => boolean
+  isBad: (h: RobotHealth) => boolean
+  repair: RepairAction
+}
+
+const SUBSYSTEMS: Subsystem[] = [
+  { key: 'stm32', label: 'STM32 (base/moteurs/bras)', isGood: (h) => h.stm32 === 'ok', isBad: (h) => h.stm32 === 'down', repair: 'reconnect_stm32' },
+  { key: 'ybNode', label: 'YB_Node (driver)', isGood: (h) => h.ybNode === 'ok', isBad: (h) => h.ybNode === 'down', repair: 'reconnect_stm32' },
+  { key: 'agent', label: 'Agent micro-ROS', isGood: (h) => h.agent === 'active', isBad: (h) => h.agent === 'dead', repair: 'reconnect_stm32' },
+  { key: 'm3pro', label: 'Stack ROS (m3pro)', isGood: (h) => h.m3pro === 'up', isBad: (h) => h.m3pro === 'down', repair: 'restart_ros' },
+]
+
+const LOG_UNITS = [
+  { value: 'micro-ros-agent.service', label: 'Agent micro-ROS' },
+  { value: 'roblaude-stm32-healthcheck.service', label: 'Healthcheck' },
+]
+
+function dotClass(level: Level): string {
+  return level === 'ok' ? 'bg-emerald-400'
+    : level === 'warn' ? 'bg-amber-400'
+    : level === 'bad' ? 'bg-destructive'
+    : 'bg-muted-foreground'
+}
+
+function cardClass(level: Level): string {
+  return level === 'ok' ? 'border-emerald-500/30 bg-emerald-500/5'
+    : level === 'warn' ? 'border-amber-500/30 bg-amber-500/5'
+    : level === 'bad' ? 'border-destructive/40 bg-destructive/5'
+    : 'border-muted-foreground/20 bg-muted-foreground/5'
+}
+
+function hhmmss(): string {
+  return new Date().toLocaleTimeString('fr-FR')
+}
+
+export function RobotRepairPage() {
+  const robotId = useRobotStore((s) => s.id)
+  const [health, setHealth] = useState<RobotHealth | null>(null)
+  const [feed, setFeed] = useState<FeedItem[]>([])
+  const [busy, setBusy] = useState<RepairAction | null>(null)
+  const [showLogs, setShowLogs] = useState(false)
+  const [logUnit, setLogUnit] = useState(LOG_UNITS[0].value)
+  const [logs, setLogs] = useState('')
+  const [loadingLogs, setLoadingLogs] = useState(false)
+
+  const prev = useRef<RobotHealth | null>(null)
+  const feedId = useRef(0)
+
+  const push = (level: Level, msg: string): void => {
+    feedId.current += 1
+    const item: FeedItem = { id: feedId.current, t: hhmmss(), level, msg }
+    setFeed((f) => [item, ...f].slice(0, 60))
+  }
+
+  // compare l'ancien et le nouvel etat -> messages en clair
+  const diff = (h: RobotHealth): void => {
+    const p = prev.current
+    if (!p) {
+      push(h.reachable ? 'info' : 'bad', h.reachable ? 'Connecté au robot' : 'Robot injoignable')
+    } else {
+      if (p.reachable && !h.reachable) push('bad', 'Perte de contact avec le robot')
+      if (!p.reachable && h.reachable) push('ok', 'Contact rétabli')
+      for (const s of SUBSYSTEMS) {
+        const was = s.isGood(p), now = s.isGood(h)
+        if (was && !now) push('bad', `${s.label} : tombé`)
+        if (!was && now) push('ok', `${s.label} : rétabli`)
+      }
+    }
+    prev.current = h
+  }
+
+  useEffect(() => {
+    let alive = true
+    const tick = async (): Promise<void> => {
+      try {
+        const h = await getRobotHealth(robotId)
+        if (!alive) return
+        diff(h)
+        setHealth(h)
+      } catch {
+        if (!alive) return
+        if (prev.current?.reachable !== false) push('bad', 'Santé indisponible (backend ou robot KO)')
+        prev.current = null
+        setHealth(null)
+      }
+    }
+    void tick()
+    const id = setInterval(tick, 4000)
+    return () => { alive = false; clearInterval(id) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [robotId])
+
+  const repair = async (action: RepairAction): Promise<void> => {
+    if (action === 'reboot' && !window.confirm('Redémarrer complètement le Jetson ? (~90s d\'indisponibilité)')) return
+    setBusy(action)
+    push('info', `🔧 ${REPAIR_LABELS[action]} lancé...`)
+    try {
+      const r = await runRepair(robotId, action, action === 'reboot')
+      if (r.ok) { push('ok', `${REPAIR_LABELS[action]} : OK${r.note ? ` (${r.note})` : ''}`); toast.success(REPAIR_LABELS[action]) }
+      else { push('warn', `${REPAIR_LABELS[action]} : code ${r.code}`); toast.warning(`${REPAIR_LABELS[action]} (code ${r.code})`) }
+    } catch (e) {
+      push('bad', `${REPAIR_LABELS[action]} : échec — ${e instanceof Error ? e.message : 'erreur'}`)
+      toast.error(e instanceof Error ? e.message : 'échec réparation')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const loadLogs = async (): Promise<void> => {
+    setLoadingLogs(true)
+    try {
+      const r = await fetchRobotLogs(robotId, { unit: logUnit, lines: 150 })
+      setLogs(r.stdout || '(aucune ligne)')
+    } catch (e) {
+      setLogs(`erreur: ${e instanceof Error ? e.message : 'unknown'}`)
+    } finally {
+      setLoadingLogs(false)
+    }
+  }
+
+  // statut "humain" par carte
+  const cardLevel = (s: Subsystem): Level => {
+    if (!health) return 'info'
+    if (s.isGood(health)) return 'ok'
+    if (s.isBad(health)) return 'bad'
+    return 'info'
+  }
+  const batteryLevel: Level = health?.battery == null ? 'info' : health.battery < 15 ? 'bad' : health.battery < 30 ? 'warn' : 'ok'
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link to="/admin" className="text-muted-foreground hover:text-foreground"><ArrowLeft className="size-5" /></Link>
+        <Wrench className="size-5 text-primary" />
+        <h1 className="text-lg font-semibold">Réparation robot</h1>
+        <span className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className={`size-2 rounded-full ${health?.reachable ? 'bg-emerald-400' : 'bg-destructive'}`} />
+          {health?.reachable ? 'en ligne' : 'hors ligne'}
+        </span>
+      </div>
+
+      {/* cartes sante */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        {SUBSYSTEMS.map((s) => {
+          const lvl = cardLevel(s)
+          const showFix = lvl === 'bad' && health?.reachable
+          return (
+            <div key={s.key} className={`rounded-lg border p-3 ${cardClass(lvl)}`}>
+              <div className="flex items-center gap-2">
+                <span className={`size-2 rounded-full ${dotClass(lvl)}`} />
+                <span className="text-sm font-medium">{s.label}</span>
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {lvl === 'ok' ? 'OK' : lvl === 'bad' ? 'à réparer' : 'inconnu'}
+              </div>
+              {showFix && (
+                <button
+                  onClick={() => repair(s.repair)}
+                  disabled={busy !== null}
+                  className="mt-2 w-full rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  {busy === s.repair ? '…' : 'Réparer'}
+                </button>
+              )}
+            </div>
+          )
+        })}
+
+        {/* batterie */}
+        <div className={`rounded-lg border p-3 ${cardClass(batteryLevel)}`}>
+          <div className="flex items-center gap-2">
+            <span className={`size-2 rounded-full ${dotClass(batteryLevel)}`} />
+            <span className="text-sm font-medium">Batterie</span>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {health?.battery == null ? 'inconnue' : `${health.battery}%`}
+          </div>
+        </div>
+
+        {/* connexion */}
+        <div className={`rounded-lg border p-3 ${cardClass(health?.reachable ? 'ok' : 'bad')}`}>
+          <div className="flex items-center gap-2">
+            <span className={`size-2 rounded-full ${dotClass(health?.reachable ? 'ok' : 'bad')}`} />
+            <span className="text-sm font-medium">Connexion</span>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">{health?.reachable ? 'OK' : 'injoignable'}</div>
+        </div>
+      </div>
+
+      {/* actions globales */}
+      <div className="flex flex-wrap gap-2">
+        {(['reconnect_stm32', 'restart_ros', 'resync_clock', 'reboot'] as RepairAction[]).map((a) => (
+          <button
+            key={a}
+            onClick={() => repair(a)}
+            disabled={busy !== null}
+            className={`rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 ${a === 'reboot' ? 'border-destructive/40 text-destructive' : 'border-border'}`}
+          >
+            {busy === a ? '…' : REPAIR_LABELS[a]}
+          </button>
+        ))}
+      </div>
+
+      {/* fil en clair */}
+      <div>
+        <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+          <Activity className="size-4 text-primary" /> Journal en clair
+        </div>
+        <div className="rounded-lg border bg-card max-h-72 overflow-y-auto divide-y divide-border/50">
+          {feed.length === 0 && <div className="p-3 text-xs text-muted-foreground">en attente…</div>}
+          {feed.map((f) => (
+            <div key={f.id} className="flex items-start gap-2 px-3 py-1.5 text-xs">
+              <span className={`mt-1 size-2 shrink-0 rounded-full ${dotClass(f.level)}`} />
+              <span className="font-mono text-muted-foreground">{f.t}</span>
+              <span className="text-foreground">{f.msg}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* logs bruts repliables */}
+      <div>
+        <button onClick={() => setShowLogs((v) => !v)} className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          {showLogs ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />} Logs bruts (debug)
+        </button>
+        {showLogs && (
+          <div className="mt-2 space-y-2">
+            <div className="flex items-center gap-2">
+              <select value={logUnit} onChange={(e) => setLogUnit(e.target.value)} className="rounded-md border bg-background px-2 py-1 text-xs">
+                {LOG_UNITS.map((u) => <option key={u.value} value={u.value}>{u.label}</option>)}
+              </select>
+              <button onClick={loadLogs} disabled={loadingLogs} className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50">
+                <RefreshCw className={`size-3 ${loadingLogs ? 'animate-spin' : ''}`} /> charger
+              </button>
+            </div>
+            <pre className="max-h-80 overflow-auto rounded-lg border bg-black/40 p-3 text-[11px] leading-snug text-muted-foreground whitespace-pre-wrap">{logs || '(clique sur charger)'}</pre>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/test/repairApi.test.ts
+++ b/web/frontend/src/test/repairApi.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../lib/api', () => ({ apiFetch: vi.fn() }))
+
+import { apiFetch } from '../lib/api'
+import { runRepair, getRobotHealth, REPAIR_LABELS } from '../lib/repairApi'
+
+const mockFetch = vi.mocked(apiFetch)
+
+beforeEach(() => mockFetch.mockReset())
+
+describe('repairApi', () => {
+  it('REPAIR_LABELS couvre les 4 actions', () => {
+    expect(Object.keys(REPAIR_LABELS).sort()).toEqual(['reboot', 'reconnect_stm32', 'restart_ros', 'resync_clock'])
+  })
+
+  it('runRepair POST la bonne route + body', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true, action: 'reconnect_stm32' }) } as Response)
+    const r = await runRepair(1, 'reconnect_stm32')
+    expect(mockFetch).toHaveBeenCalledWith('/admin/robots/1/repair', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'reconnect_stm32', confirm: false }),
+    })
+    expect(r.ok).toBe(true)
+  })
+
+  it('reboot passe confirm:true', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true, action: 'reboot' }) } as Response)
+    await runRepair(1, 'reboot', true)
+    expect(mockFetch).toHaveBeenCalledWith('/admin/robots/1/repair', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'reboot', confirm: true }),
+    })
+  })
+
+  it('getRobotHealth GET la bonne route', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ reachable: true }) } as Response)
+    await getRobotHealth(2)
+    expect(mockFetch).toHaveBeenCalledWith('/admin/robots/2/health')
+  })
+
+  it('runRepair leve si la reponse est !ok', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: 'boom' }) } as Response)
+    await expect(runRepair(1, 'restart_ros')).rejects.toThrow('boom')
+  })
+})


### PR DESCRIPTION
## Quoi

Page admin `/admin/repair` : voir l'état du robot en clair et le réparer en 1 clic. Filet de sécurité pour la soutenance.

## Contenu

- **Cartes santé** (vert/orange/rouge) : STM32, YB_Node, agent micro-ROS, stack ROS (m3pro), batterie, connexion. Poll toutes les 4 s.
- **Réparations 1-clic** (bouton sur carte rouge + barre d'actions) :
  - `reconnect_stm32` → `sudo systemctl restart micro-ros-agent.service` (relink CP2104 auto)
  - `restart_ros` → `docker restart m3pro`
  - `resync_clock` → `sudo date -u -s …`
  - `reboot` → `sudo reboot` (confirmation obligatoire)
- **Journal en clair** (transitions d'état + résultats d'actions) + **logs bruts repliables** (journalctl agent/healthcheck).

## Archi / sécurité

- API **par action** (enum fermé), jamais de commande shell depuis le front → pas d'injection.
- `GET/POST /api/admin/robots/:id/{health,repair}`, **adminGuard**, validation **Zod**, **audit** dans `SshAuditLog`.
- Santé = 1 appel SSH du script robot read-only `roblaude-robot-status.sh` (JSON) + `Robot.battery` (MQTT).

## Tests

- Back : 9 tests (mapping action→commande, refus action inconnue, reboot exige confirm, non-admin 403, audit écrit). 168/168 au total.
- Front : contrat repairApi (route + body) 5 tests. Lint + typecheck clean des deux côtés.
- Script status vérifié en live sur le robot : `{"myserial_ok":true,"agent":"active","m3pro":"up","yb_node":true}`.

À faire avant la soutenance : un clic-test end-to-end avec le backend lancé (SSH robot configuré).