### PR TITLE
wizard cartographie/localisation + bouton éteindre + carte zoomable + ssh par MAC

### DIFF
--- a/robot/roblaude_nav/launch/localization.launch.py
+++ b/robot/roblaude_nav/launch/localization.launch.py
@@ -1,0 +1,104 @@
+"""localization.launch.py — localisation sur carte FIGEE (AMCL), pas de SLAM.
+
+A lancer APRES avoir mappe + sauve une carte (map_saver_cli). Le robot se
+localise sur la carte sauvee SANS la modifier : on peut le bouger / l'eteindre,
+au demarrage il se re-repere via le LiDAR (probleme du "kidnapped robot").
+=> c'est le mode normal d'usage. Le mapping (slam.launch.py) ne sert qu'a
+   (re)construire la carte, ponctuellement.
+
+Chaine : /scan_multi -> scan_restamper -> /scan_fixed -> amcl
+         map_server charge roblaude_map.yaml -> /map (latche)
+         amcl publie la correction map->odom (comme slam, mais sans toucher la carte)
+
+Pre-requis : base_bringup (odom->base_footprint via EKF) + LiDAR (/scan_multi).
+
+Usage :
+    ros2 launch roblaude_nav localization.launch.py
+    ros2 launch roblaude_nav localization.launch.py map:=/home/jetson/maps/roblaude_map.yaml
+"""
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    map_arg = DeclareLaunchArgument(
+        'map',
+        default_value='/home/jetson/maps/roblaude_map.yaml',
+        description='Carte sauvee (.yaml) sur laquelle se localiser',
+    )
+    map_yaml = LaunchConfiguration('map')
+
+    lifecycle_nodes = ['map_server', 'amcl']
+
+    return LaunchDescription([
+        map_arg,
+
+        # restampe les scans (drift +futur du LiDAR Yahboom) -> /scan_fixed,
+        # sinon amcl droppe tout comme slam (message filter / queue full).
+        Node(
+            package='roblaude_nav',
+            executable='scan_restamper',
+            name='scan_restamper',
+            output='screen',
+        ),
+
+        # charge la carte figee -> topic /map (latche transient_local)
+        Node(
+            package='nav2_map_server',
+            executable='map_server',
+            name='map_server',
+            output='screen',
+            parameters=[{
+                'use_sim_time': False,
+                'yaml_filename': map_yaml,
+                'topic_name': 'map',
+                'frame_id': 'map',
+            }],
+        ),
+
+        # AMCL : se localise sur la carte via le LiDAR, publie map->odom.
+        # Ne modifie JAMAIS la carte (contrairement a slam_toolbox).
+        Node(
+            package='nav2_amcl',
+            executable='amcl',
+            name='amcl',
+            output='screen',
+            parameters=[{
+                'use_sim_time': False,
+                'base_frame_id': 'base_footprint',   # comme slam (cf slam.launch.py)
+                'odom_frame_id': 'odom',
+                'global_frame_id': 'map',
+                'scan_topic': '/scan_fixed',
+                'robot_model_type': 'nav2_amcl::DifferentialMotionModel',
+                'laser_model_type': 'likelihood_field',
+                'min_particles': 500,
+                'max_particles': 2000,
+                'laser_min_range': 0.3,
+                'laser_max_range': 4.0,
+                'max_beams': 60,
+                'update_min_d': 0.15,                # rafraichit des qu'on bouge un peu
+                'update_min_a': 0.15,
+                'transform_tolerance': 1.0,
+                'tf_broadcast': True,
+                # pose initiale = origine par defaut ; si on a deplace le robot,
+                # appeler /reinitialize_global_localization (ou donner une pose).
+                'set_initial_pose': True,
+                'initial_pose': {'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0},
+            }],
+        ),
+
+        # active map_server + amcl (lifecycle)
+        Node(
+            package='nav2_lifecycle_manager',
+            executable='lifecycle_manager',
+            name='lifecycle_manager_localization',
+            output='screen',
+            parameters=[{
+                'use_sim_time': False,
+                'autostart': True,
+                'node_names': lifecycle_nodes,
+            }],
+        ),
+    ])

--- a/robot/roblaude_nav/roblaude_nav/mapping_supervisor.py
+++ b/robot/roblaude_nav/roblaude_nav/mapping_supervisor.py
@@ -29,6 +29,7 @@ class MappingSupervisor(Node):
         self.proc = None
         self.session_id = None
         self.state = 'IDLE'
+        self.mode = 'mapping'   # 'mapping' (slam+explore) ou 'localization' (amcl)
         self.started_at = None
         self.lock = threading.Lock()
 
@@ -52,6 +53,8 @@ class MappingSupervisor(Node):
             self.stop(data.get('messageId'))
         elif action == 'save':
             self.save(data.get('sessionId'), data.get('name'), data.get('messageId'))
+        elif action == 'localize':
+            self.localize(data.get('map'), data.get('messageId'))
         else:
             self.get_logger().warn(f'action inconnue: {action}')
 
@@ -61,6 +64,7 @@ class MappingSupervisor(Node):
                 self.get_logger().warn('mapping deja en cours, ignore start')
                 return
             self.session_id = session_id
+            self.mode = 'mapping'
             self.state = 'STARTING'
             self.started_at = time.time()
             self.publish_state()
@@ -137,9 +141,40 @@ class MappingSupervisor(Node):
                 'reason': 'timeout 30s map_saver_cli',
             })))
 
+    def localize(self, map_yaml, message_id):
+        # bascule en mode localisation : coupe le mapping en cours s'il y en a,
+        # puis lance amcl sur la carte figee (ne modifie pas la carte).
+        with self.lock:
+            if self.proc is not None:
+                try:
+                    os.killpg(os.getpgid(self.proc.pid), signal.SIGINT)
+                except ProcessLookupError:
+                    pass
+                self.proc = None
+            self.mode = 'localization'
+            self.state = 'STARTING'
+            self.started_at = time.time()
+            self.publish_state()
+            cmd = ['ros2', 'launch', 'roblaude_nav', 'localization.launch.py']
+            if map_yaml:
+                cmd.append(f'map:={map_yaml}')
+            try:
+                self.proc = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    preexec_fn=os.setsid,
+                )
+                threading.Thread(target=self._watch, daemon=True).start()
+            except Exception as e:
+                self.state = 'FAILED'
+                self.publish_state(failure_reason=str(e))
+                self.proc = None
+
     def publish_state(self, failure_reason=None):
         payload = {
             'state': self.state,
+            'mode': self.mode,
             'sessionId': self.session_id,
             'startedAt': self.started_at,
         }

--- a/web/backend/src/controllers/mappingController.ts
+++ b/web/backend/src/controllers/mappingController.ts
@@ -13,6 +13,7 @@ import { saveSnapshotFiles, getSnapshotPath } from '../lib/mapStorage'
 const startSchema = z.object({ robotId: z.number().int().positive() })
 const stopSchema = z.object({ sessionId: z.number().int().positive() })
 const saveSchema = z.object({ sessionId: z.number().int().positive(), name: z.string().optional() })
+const localizeSchema = z.object({ robotId: z.number().int().positive(), map: z.string().optional() })
 
 const SAVE_TIMEOUT_MS = 30_000
 
@@ -39,6 +40,17 @@ export async function stopMapping(req: Request, res: Response): Promise<void> {
   if (!session) { res.status(404).json({ error: 'session not found' }); return }
   robotMqtt.publishCommand(session.robotId, 'mapping/stop', { sessionId: session.id })
   res.status(200).json({ ok: true })
+}
+
+// Bascule le robot en mode LOCALISATION (amcl sur carte figee, ne modifie pas
+// la carte). Le mapping_supervisor lance localization.launch.py.
+export async function localizeMapping(req: Request, res: Response): Promise<void> {
+  const parsed = localizeSchema.safeParse(req.body)
+  if (!parsed.success) { res.status(400).json({ error: 'invalid body' }); return }
+  const userId = req.user?.userId
+  if (!userId) { res.status(401).json({ error: 'auth required' }); return }
+  robotMqtt.publishCommand(parsed.data.robotId, 'mapping/localize', { map: parsed.data.map })
+  res.status(200).json({ ok: true, mode: 'localization' })
 }
 
 export async function saveMapping(req: Request, res: Response): Promise<void> {

--- a/web/backend/src/controllers/repairController.ts
+++ b/web/backend/src/controllers/repairController.ts
@@ -36,7 +36,9 @@ export async function getHealth(req: Request, res: Response): Promise<void> {
   let probe: RobotStatusJson | null = null
   let reachable = true
   try {
-    const r = await runOnce(robotId, STATUS_CMD, 12_000)
+    // 20s : le 1er appel a froid declenche la decouverte DDS (ros2 node list)
+    // qui peut prendre ~15s ; les suivants sont chauds et rapides.
+    const r = await runOnce(robotId, STATUS_CMD, 20_000)
     probe = JSON.parse(r.stdout.trim()) as RobotStatusJson
   } catch {
     reachable = false
@@ -72,9 +74,9 @@ export async function runRepair(req: Request, res: Response): Promise<void> {
     return
   }
   const action = parsed.data.action as RepairAction
-  // le reboot coupe tout -> on exige une confirmation explicite
-  if (action === 'reboot' && parsed.data.confirm !== true) {
-    res.status(400).json({ error: 'reboot requires confirm:true' })
+  // reboot et shutdown coupent tout -> confirmation explicite obligatoire
+  if ((action === 'reboot' || action === 'shutdown') && parsed.data.confirm !== true) {
+    res.status(400).json({ error: `${action} requires confirm:true` })
     return
   }
 
@@ -84,7 +86,9 @@ export async function runRepair(req: Request, res: Response): Promise<void> {
   const startedAt = Date.now()
 
   try {
-    const result = await runOnce(robotId, command, action === 'reboot' ? 5_000 : 20_000)
+    // shutdown laisse le temps au docker stop (range le bras) avant la coupure
+    const timeout = action === 'reboot' ? 5_000 : action === 'shutdown' ? 12_000 : 20_000
+    const result = await runOnce(robotId, command, timeout)
     const durationMs = Date.now() - startedAt
     await prisma.sshAuditLog
       .create({ data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: result.code, durationMs } })
@@ -95,9 +99,9 @@ export async function runRepair(req: Request, res: Response): Promise<void> {
     await prisma.sshAuditLog
       .create({ data: { robotId, userId, mode: 'ALLOWLIST', command, exitCode: -1, durationMs } })
       .catch(() => {})
-    // le reboot coupe la connexion SSH : c'est attendu, on considere l'action lancee
-    if (action === 'reboot') {
-      res.json({ ok: true, action, command, note: 'reboot lancé (connexion coupée)' })
+    // reboot/shutdown coupent la connexion SSH : attendu, on considere l'action lancee
+    if (action === 'reboot' || action === 'shutdown') {
+      res.json({ ok: true, action, command, note: `${action} lancé (connexion coupée)` })
       return
     }
     res.status(502).json({ error: 'ssh failure', action, message: err instanceof Error ? err.message : 'ssh error' })

--- a/web/backend/src/lib/repairActions.ts
+++ b/web/backend/src/lib/repairActions.ts
@@ -2,13 +2,14 @@
 // NOM d'action (pas une commande shell), le backend mappe vers une commande SSH
 // fixe. Surface fermee -> pas d'injection possible.
 
-export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot'
+export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot' | 'shutdown'
 
 export const REPAIR_ACTIONS: readonly RepairAction[] = [
   'reconnect_stm32',
   'restart_ros',
   'resync_clock',
   'reboot',
+  'shutdown',
 ]
 
 export const REPAIR_LABELS: Record<RepairAction, string> = {
@@ -16,6 +17,7 @@ export const REPAIR_LABELS: Record<RepairAction, string> = {
   restart_ros: 'Redémarrage stack ROS',
   resync_clock: 'Resync horloge',
   reboot: 'Redémarrage Jetson',
+  shutdown: 'Extinction propre',
 }
 
 export function isRepairAction(x: unknown): x is RepairAction {
@@ -35,5 +37,8 @@ export function repairCommand(action: RepairAction, nowUtc?: string): string {
       return `sudo date -u -s "${nowUtc ?? ''}"`
     case 'reboot':
       return 'sudo reboot'
+    case 'shutdown':
+      // docker stop -> le trap de container_autostart range le bras avant la coupure, puis extinction
+      return 'docker stop -t 6 m3pro; sudo shutdown -h now'
   }
 }

--- a/web/backend/src/routes/mapping.ts
+++ b/web/backend/src/routes/mapping.ts
@@ -3,6 +3,7 @@ import {
   startMapping,
   stopMapping,
   saveMapping,
+  localizeMapping,
   listSessions,
   getSession,
   downloadSnapshot,
@@ -18,6 +19,7 @@ const router = Router()
 router.post('/start', startMapping)
 router.post('/stop', stopMapping)
 router.post('/save', saveMapping)
+router.post('/localize', localizeMapping)
 router.get('/sessions', listSessions)
 router.get('/sessions/:id', getSession)
 router.get('/snapshots/:id/download.:ext', downloadSnapshot)

--- a/web/backend/src/services/mqtt.ts
+++ b/web/backend/src/services/mqtt.ts
@@ -93,6 +93,7 @@ export type CmdAction =
   | 'mapping/start'
   | 'mapping/stop'
   | 'mapping/save'
+  | 'mapping/localize'
   | 'teleop'
   | 'arm'
 

--- a/web/backend/src/services/sshConnection.ts
+++ b/web/backend/src/services/sshConnection.ts
@@ -1,7 +1,10 @@
 import { NodeSSH } from 'node-ssh'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 
-// Connexion SSH persistante par robotId. Reutilisee par wsTopics, et plus
-// tard par wsLogs/wsSsh (T3.5.12). NodeSSH wrappe ssh2, API Promise-based.
+const execFileP = promisify(execFile)
+
+// Connexion SSH persistante par robotId. NodeSSH wrappe ssh2, API Promise-based.
 
 type RobotSshConfig = {
   host: string
@@ -11,9 +14,33 @@ type RobotSshConfig = {
   password?: string
 }
 
-function getConfig(robotId: number): RobotSshConfig {
+// L'IP du robot change au gre du DHCP. Si ROBOT_{id}_SSH_MAC est fourni, on
+// resout l'IP COURANTE par la MAC via la table ARP du systeme (comme
+// find_robot.sh). Le robot parle en permanence au broker MQTT (sur cette
+// machine) -> sa MAC est toujours dans l'ARP. Fallback sur ROBOT_{id}_SSH_HOST.
+async function resolveIpByMac(mac: string): Promise<string | null> {
+  const norm = mac.toLowerCase()
+  try {
+    const { stdout } = await execFileP('arp', ['-an'])
+    for (const line of stdout.split('\n')) {
+      if (line.toLowerCase().includes(norm)) {
+        const m = line.match(/\((\d+\.\d+\.\d+\.\d+)\)/)
+        if (m) return m[1]
+      }
+    }
+  } catch { /* arp indispo (autre OS) -> fallback host */ }
+  return null
+}
+
+async function getConfig(robotId: number): Promise<RobotSshConfig> {
+  let host = process.env[`ROBOT_${robotId}_SSH_HOST`] ?? '192.168.1.100'
+  const mac = process.env[`ROBOT_${robotId}_SSH_MAC`]
+  if (mac) {
+    const ip = await resolveIpByMac(mac)
+    if (ip) host = ip   // IP courante resolue par MAC, peu importe le DHCP
+  }
   return {
-    host: process.env[`ROBOT_${robotId}_SSH_HOST`] ?? '192.168.1.100',
+    host,
     port: Number(process.env[`ROBOT_${robotId}_SSH_PORT`] ?? 22),
     username: process.env[`ROBOT_${robotId}_SSH_USER`] ?? 'jetson',
     password: process.env[`ROBOT_${robotId}_SSH_PASSWORD`],
@@ -30,7 +57,7 @@ export function getSshClient(robotId: number): Promise<NodeSSH> {
     // cast as any — RobotSshConfig.privateKey est Buffer mais NodeSSH veut string ;
     // node-ssh accepte les deux a l'execution.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await ssh.connect(getConfig(robotId) as any)
+    await ssh.connect((await getConfig(robotId)) as any)
     return ssh
   })()
   // si fail, on vire du cache pour permettre un retry au prochain appel.
@@ -44,15 +71,39 @@ export function _resetSshCache(): void {
   cache.clear()
 }
 
+// evince ET FERME la connexion (dispose). Sinon les connexions mortes restent
+// ouvertes -> les sshd s'accumulent sur le robot -> SSH lent -> timeouts.
+function evict(robotId: number): void {
+  const p = cache.get(robotId)
+  cache.delete(robotId)
+  void p?.then((ssh) => { try { ssh.dispose() } catch { /* deja mort */ } }).catch(() => {})
+}
+
 export async function runOnce(
   robotId: number,
   command: string,
   timeoutMs = 5000,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  const ssh = await getSshClient(robotId)
-  const timeoutPromise = new Promise<never>((_, rej) =>
-    setTimeout(() => rej(new Error('ssh timeout')), timeoutMs),
-  )
-  const result = await Promise.race([ssh.execCommand(command), timeoutPromise])
-  return { stdout: result.stdout, stderr: result.stderr, code: result.code ?? 0 }
+  // 2 tentatives : une connexion en cache peut etre MORTE (sshd ferme les
+  // sessions inactives). On detecte (isConnected) ou on attrape l'echec, on
+  // evince du cache et on reconnecte. Sinon un robot joignable apparait KO.
+  let lastErr: unknown
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      let ssh = await getSshClient(robotId)
+      if (!ssh.isConnected()) {
+        evict(robotId)
+        ssh = await getSshClient(robotId)
+      }
+      const timeoutPromise = new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error('ssh timeout')), timeoutMs),
+      )
+      const result = await Promise.race([ssh.execCommand(command), timeoutPromise])
+      return { stdout: result.stdout, stderr: result.stderr, code: result.code ?? 0 }
+    } catch (e) {
+      lastErr = e
+      evict(robotId)   // ferme la connexion morte -> pas d'accumulation de sshd
+    }
+  }
+  throw lastErr ?? new Error('ssh unreachable')
 }

--- a/web/backend/src/test/repair.test.ts
+++ b/web/backend/src/test/repair.test.ts
@@ -49,6 +49,7 @@ describe('repairActions (pur)', () => {
     expect(repairCommand('reconnect_stm32')).toBe('sudo systemctl restart micro-ros-agent.service')
     expect(repairCommand('restart_ros')).toBe('docker restart m3pro')
     expect(repairCommand('reboot')).toBe('sudo reboot')
+    expect(repairCommand('shutdown')).toBe('docker stop -t 6 m3pro; sudo shutdown -h now')
     expect(repairCommand('resync_clock', '2026-06-17 10:00:00')).toBe('sudo date -u -s "2026-06-17 10:00:00"')
   })
 })
@@ -117,6 +118,25 @@ describe('POST /api/admin/robots/:id/repair', () => {
       .post(`/api/admin/robots/${robotId}/repair`)
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ action: 'reboot', confirm: true })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('shutdown sans confirm -> 400', async () => {
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'shutdown' })
+    expect(res.status).toBe(400)
+    expect(mockRunOnce).not.toHaveBeenCalled()
+  })
+
+  it('shutdown avec confirm -> ok meme si la connexion tombe', async () => {
+    mockRunOnce.mockRejectedValue(new Error('ssh timeout'))
+    const res = await request(app)
+      .post(`/api/admin/robots/${robotId}/repair`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ action: 'shutdown', confirm: true })
     expect(res.status).toBe(200)
     expect(res.body.ok).toBe(true)
   })

--- a/web/frontend/src/components/CameraView.tsx
+++ b/web/frontend/src/components/CameraView.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
-import { Camera, Maximize2, Minimize2, X } from 'lucide-react'
+import { Camera, Maximize2, Minimize2, X, Minus } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
+import { useDraggable } from '@/hooks/useDraggable'
 
 // Vue camera POV du robot. Recoit des frames PNG/JPEG via WS telemetry sur
 // un byte de type 0x02 (similaire au map). Le robot publie sur
 // roblaude/{id}/telemetry/camera (binary retained, throttle 5-10 Hz).
-// Composant flotant en haut-droite par defaut — toggle plein ecran via
-// Fullscreen API.
+// Panneau flottant DEPLACABLE (drag par l'entete) + reductible + fermable.
 
 const TYPE_CAMERA_FRAME = 0x02
 
@@ -14,16 +14,21 @@ interface Props {
   robotId: number
   // si false, on cache completement (pas de WS ouvert).
   enabled?: boolean
+  // si fourni, le bouton fermer remonte au parent (barre d'outils) au lieu
+  // de juste se cacher en interne.
+  onClose?: () => void
 }
 
-export function CameraView({ robotId, enabled = true }: Props) {
+export function CameraView({ robotId, enabled = true, onClose }: Props) {
   const token = useAuthStore((s) => s.token)
   const [frameUrl, setFrameUrl] = useState<string | null>(null)
   const [fullscreen, setFullscreen] = useState(false)
   const [hidden, setHidden] = useState(false)
+  const [minimized, setMinimized] = useState(false)
   const [connected, setConnected] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const prevUrlRef = useRef<string | null>(null)
+  const { pos, onDragStart } = useDraggable({ x: window.innerWidth - 288, y: 84 })
 
   useEffect(() => {
     if (!enabled || !token) return
@@ -86,44 +91,46 @@ export function CameraView({ robotId, enabled = true }: Props) {
     <div
       ref={containerRef}
       className={`bg-black border border-gray-700 rounded shadow-lg overflow-hidden z-30 ${
-        fullscreen ? '' : 'fixed top-20 right-4 w-64'
+        fullscreen ? '' : 'fixed w-64'
       }`}
+      style={fullscreen ? undefined : { left: pos.x, top: pos.y }}
     >
-      <div className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800">
+      <div
+        onPointerDown={onDragStart}
+        className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800 cursor-move select-none"
+      >
         <div className="flex items-center gap-1.5 text-xs text-gray-300">
           <Camera className="w-3 h-3" /> POV
           <span className={`size-1.5 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-600'}`} />
         </div>
         <div className="flex items-center gap-1">
-          <button
-            onClick={toggleFs}
-            className="text-gray-400 hover:text-white p-0.5"
-            aria-label={fullscreen ? 'Quitter plein ecran' : 'Plein ecran'}
-          >
+          <button onClick={() => setMinimized((m) => !m)} className="text-gray-400 hover:text-white p-0.5" aria-label="Reduire">
+            <Minus className="w-3 h-3" />
+          </button>
+          <button onClick={toggleFs} className="text-gray-400 hover:text-white p-0.5"
+            aria-label={fullscreen ? 'Quitter plein ecran' : 'Plein ecran'}>
             {fullscreen ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
           </button>
-          <button
-            onClick={() => setHidden(true)}
-            className="text-gray-400 hover:text-white p-0.5"
-            aria-label="Cacher"
-          >
+          <button onClick={() => (onClose ? onClose() : setHidden(true))} className="text-gray-400 hover:text-white p-0.5" aria-label="Fermer">
             <X className="w-3 h-3" />
           </button>
         </div>
       </div>
-      <div className={`flex items-center justify-center bg-black ${fullscreen ? 'h-screen' : 'aspect-video'}`}>
-        {frameUrl ? (
-          <img
-            src={frameUrl}
-            alt="Camera POV"
-            className={fullscreen ? 'max-h-screen max-w-screen' : 'w-full h-full object-cover'}
-          />
-        ) : (
-          <div className="text-gray-600 text-xs p-4 text-center">
-            {connected ? 'En attente du premier frame…' : 'WS deconnecte'}
-          </div>
-        )}
-      </div>
+      {!minimized && (
+        <div className={`flex items-center justify-center bg-black ${fullscreen ? 'h-screen' : 'aspect-video'}`}>
+          {frameUrl ? (
+            <img
+              src={frameUrl}
+              alt="Camera POV"
+              className={fullscreen ? 'max-h-screen max-w-screen' : 'w-full h-full object-cover'}
+            />
+          ) : (
+            <div className="text-gray-600 text-xs p-4 text-center">
+              {connected ? 'En attente du premier frame…' : 'WS deconnecte'}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/components/MapLive.tsx
+++ b/web/frontend/src/components/MapLive.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { Maximize2, Minimize2, Layers, MapPin as MapPinIcon } from 'lucide-react'
+import { Maximize2, Minimize2, Layers, MapPin as MapPinIcon, ZoomIn, ZoomOut, Crosshair } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMappingStore } from '@/stores/mappingStore'
 import { worldToPixel, pixelToWorld } from '@/lib/mapProjection'
@@ -9,7 +9,10 @@ import { GhostLayer } from './GhostLayer'
 import { useRobotStore } from '@/stores/robotStore'
 
 // Carte SLAM live avec overlay canvas (scan, plan, frontiers, trail, heatmap)
-// + annotations cliquables + mode plein ecran.
+// + annotations cliquables + plein ecran + zoom/pan facon Foxglove.
+//
+// "Trop petite" reglé : la carte est upscalee pour remplir la vue (la petite
+// image PGM du debut d'explo n'est plus minuscule). Molette = zoom, drag = pan.
 
 interface LayerToggles {
   scan: boolean
@@ -35,6 +38,9 @@ interface Props {
   onAnnotationCreated?: (a: Annotation) => void
 }
 
+const ZOOM_MIN = 0.3
+const ZOOM_MAX = 16
+
 export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotationCreated }: Props) {
   const { mapPngUrl, mapMeta, scan, plan, frontiers, trail, robotPose } = useMappingStore()
   const robotId = useRobotStore((s) => s.id)
@@ -54,11 +60,44 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
   const [pending, setPending] = useState<PendingAnnotation | null>(null)
   const [pendingLabel, setPendingLabel] = useState('')
 
+  // --- zoom / pan ---
+  const [zoom, setZoom] = useState(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+  // drag en cours : on garde l'origine + on note si on a bouge (pour distinguer
+  // un pan d'un clic d'annotation).
+  const drag = useRef<{ x: number; y: number; panX: number; panY: number; moved: boolean } | null>(null)
+
+  const resetView = useCallback((): void => {
+    setZoom(1)
+    setPan({ x: 0, y: 0 })
+  }, [])
+  const zoomBy = useCallback((factor: number): void => {
+    setZoom((z) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z * factor)))
+  }, [])
+
+  // pas de zoom a la molette (UX : ca interferait avec le scroll de la page) —
+  // le zoom se fait UNIQUEMENT avec les boutons +/-.
+  const onPointerDown = useCallback((e: React.PointerEvent): void => {
+    drag.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y, moved: false }
+  }, [pan.x, pan.y])
+  const onPointerMove = useCallback((e: React.PointerEvent): void => {
+    const d = drag.current
+    if (!d) return
+    const dx = e.clientX - d.x
+    const dy = e.clientY - d.y
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) d.moved = true
+    setPan({ x: d.panX + dx, y: d.panY + dy })
+  }, [])
+  const onPointerUp = useCallback((): void => {
+    drag.current = null
+  }, [])
+
   // CSS fullscreen (au lieu de Fullscreen API) — comme ca les siblings
   // fixed (CameraView, ArmViewer, MiniMapPip) restent visibles dans le DOM.
   const toggleFullscreen = useCallback((): void => {
     setFullscreen((f) => !f)
-  }, [])
+    resetView()
+  }, [resetView])
 
   // Echap pour sortir du plein ecran (cohherent avec Fullscreen API natif)
   useEffect(() => {
@@ -194,15 +233,16 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
     }
   }, [mapMeta, scan, plan, frontiers, trail, robotPose, layers, annotations])
 
-  // clic sur la carte pour creer une annotation (si snapshot disponible)
-  const onCanvasClick = useCallback((e: React.MouseEvent<HTMLDivElement>): void => {
+  // clic sur la carte pour creer une annotation (si snapshot dispo ET qu'on n'a
+  // pas drague = pan). getBoundingClientRect tient compte du transform zoom/pan.
+  const onMapClick = useCallback((e: React.MouseEvent<HTMLDivElement>): void => {
+    if (drag.current?.moved) return
     if (!currentSnapshotId || !mapMeta) return
     const img = (e.currentTarget.querySelector('img') as HTMLImageElement | null)
     if (!img) return
     const rect = img.getBoundingClientRect()
     const xRatio = (e.clientX - rect.left) / rect.width
     const yRatio = (e.clientY - rect.top) / rect.height
-    // l'img est rendue redimensionnee — on remappe sur les coords natives
     const pxX = xRatio * mapMeta.width
     const pxY = yRatio * mapMeta.height
     const world = pixelToWorld(mapMeta, pxX, pxY)
@@ -228,17 +268,20 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
     }
   }, [pending, pendingLabel, currentSnapshotId, onAnnotationCreated])
 
+  // hauteur de la zone carte : grande par defaut, plein ecran sinon.
+  const viewportClass = fullscreen ? 'h-screen w-screen' : 'h-[68vh] w-full'
+  // l'image upscale pour remplir la hauteur (petite carte PGM -> grande), nets.
+  const imgSizeClass = fullscreen ? 'h-[92vh] w-auto' : 'h-[64vh] w-auto'
+
   return (
     <div
       ref={containerRef}
       className={`bg-black border border-gray-900 rounded ${
-        fullscreen
-          ? 'fixed inset-0 z-40 flex items-center justify-center'
-          : 'relative'
+        fullscreen ? 'fixed inset-0 z-40' : 'relative'
       }`}
     >
       {/* boutons en haut a droite */}
-      <div className="absolute top-2 right-2 z-10 flex gap-2">
+      <div className="absolute top-2 right-2 z-20 flex gap-2">
         <div className="relative">
           <button
             onClick={() => setShowLayerMenu((v) => !v)}
@@ -271,74 +314,111 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
         </button>
       </div>
 
-      <div
-        className={`relative inline-block ${currentSnapshotId ? 'cursor-crosshair' : ''}`}
-        onClick={onCanvasClick}
-      >
-        {mapPngUrl ? (
-          <>
-            <img
-              src={mapPngUrl}
-              alt="Carte SLAM"
-              className={fullscreen ? 'max-h-screen max-w-screen' : 'max-w-full max-h-[600px]'}
-              style={{ imageRendering: 'pixelated', display: 'block' }}
-            />
-            <GhostLayer
-              robotId={robotId}
-              enabled={layers.ghost}
-              width={mapMeta?.width ?? 0}
-              height={mapMeta?.height ?? 0}
-            />
-            <canvas
-              ref={canvasRef}
-              className="absolute inset-0 w-full h-full pointer-events-none"
-              style={{ imageRendering: 'pixelated' }}
-            />
-            {pending && (
-              <div
-                className="absolute z-20 bg-gray-900 border border-gray-700 rounded p-2 shadow-xl"
-                style={{
-                  left: `${(pending.pxX / (mapMeta?.width ?? 1)) * 100}%`,
-                  top: `${(pending.pxY / (mapMeta?.height ?? 1)) * 100}%`,
-                  transform: 'translate(8px, 8px)',
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="flex items-center gap-2">
-                  <MapPinIcon className="w-3 h-3 text-blue-400" />
-                  <input
-                    autoFocus
-                    value={pendingLabel}
-                    onChange={(e) => setPendingLabel(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') void submitAnnotation()
-                      if (e.key === 'Escape') setPending(null)
-                    }}
-                    placeholder="label"
-                    className="bg-black border border-gray-700 rounded px-2 py-0.5 text-xs text-white w-32"
-                  />
-                  <button
-                    onClick={() => void submitAnnotation()}
-                    className="text-xs bg-blue-600 hover:bg-blue-500 text-white px-2 py-0.5 rounded"
-                  >
-                    OK
-                  </button>
-                  <button
-                    onClick={() => setPending(null)}
-                    className="text-xs text-gray-400 hover:text-white px-1"
-                  >
-                    ✕
-                  </button>
-                </div>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="text-gray-600 text-sm py-24 px-12">
-            Aucune carte disponible — demarre une session
-          </div>
-        )}
+      {/* controles zoom en bas a droite */}
+      <div className="absolute bottom-2 right-2 z-20 flex flex-col gap-1.5">
+        <button onClick={() => zoomBy(1.3)} aria-label="Zoom avant"
+          className="bg-gray-900/80 hover:bg-gray-800 text-gray-200 p-2 rounded border border-gray-700">
+          <ZoomIn className="w-4 h-4" />
+        </button>
+        <button onClick={() => zoomBy(1 / 1.3)} aria-label="Zoom arriere"
+          className="bg-gray-900/80 hover:bg-gray-800 text-gray-200 p-2 rounded border border-gray-700">
+          <ZoomOut className="w-4 h-4" />
+        </button>
+        <button onClick={resetView} aria-label="Recadrer"
+          className="bg-gray-900/80 hover:bg-gray-800 text-gray-200 p-2 rounded border border-gray-700">
+          <Crosshair className="w-4 h-4" />
+        </button>
+        <span className="text-[10px] text-center text-gray-400 select-none">{Math.round(zoom * 100)}%</span>
       </div>
+
+      {mapPngUrl ? (
+        // viewport : capture molette + drag pour zoom/pan. overflow-hidden pour
+        // que la carte agrandie ne deborde pas hors du cadre.
+        <div
+          className={`overflow-hidden flex items-center justify-center ${viewportClass} ${
+            drag.current ? 'cursor-grabbing' : 'cursor-grab'
+          }`}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerLeave={onPointerUp}
+        >
+          {/* wrapper transforme (zoom + pan) ; le groupe img+canvas garde son
+              alignement interne (canvas en inset-0 sur l'img). */}
+          <div
+            style={{
+              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+              transformOrigin: 'center center',
+            }}
+          >
+            <div
+              className={`relative inline-block ${currentSnapshotId ? 'cursor-crosshair' : ''}`}
+              onClick={onMapClick}
+            >
+              <img
+                src={mapPngUrl}
+                alt="Carte SLAM"
+                draggable={false}
+                className={imgSizeClass}
+                style={{ imageRendering: 'pixelated', display: 'block' }}
+              />
+              <GhostLayer
+                robotId={robotId}
+                enabled={layers.ghost}
+                width={mapMeta?.width ?? 0}
+                height={mapMeta?.height ?? 0}
+              />
+              <canvas
+                ref={canvasRef}
+                className="absolute inset-0 w-full h-full pointer-events-none"
+                style={{ imageRendering: 'pixelated' }}
+              />
+              {pending && (
+                <div
+                  className="absolute z-20 bg-gray-900 border border-gray-700 rounded p-2 shadow-xl"
+                  style={{
+                    left: `${(pending.pxX / (mapMeta?.width ?? 1)) * 100}%`,
+                    top: `${(pending.pxY / (mapMeta?.height ?? 1)) * 100}%`,
+                    transform: 'translate(8px, 8px)',
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex items-center gap-2">
+                    <MapPinIcon className="w-3 h-3 text-blue-400" />
+                    <input
+                      autoFocus
+                      value={pendingLabel}
+                      onChange={(e) => setPendingLabel(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void submitAnnotation()
+                        if (e.key === 'Escape') setPending(null)
+                      }}
+                      placeholder="label"
+                      className="bg-black border border-gray-700 rounded px-2 py-0.5 text-xs text-white w-32"
+                    />
+                    <button
+                      onClick={() => void submitAnnotation()}
+                      className="text-xs bg-blue-600 hover:bg-blue-500 text-white px-2 py-0.5 rounded"
+                    >
+                      OK
+                    </button>
+                    <button
+                      onClick={() => setPending(null)}
+                      className="text-xs text-gray-400 hover:text-white px-1"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="text-gray-600 text-sm py-24 px-12 text-center">
+          Aucune carte disponible — demarre une session
+        </div>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/components/MapLive.tsx
+++ b/web/frontend/src/components/MapLive.tsx
@@ -63,6 +63,7 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
   // --- zoom / pan ---
   const [zoom, setZoom] = useState(1)
   const [pan, setPan] = useState({ x: 0, y: 0 })
+  const [isDragging, setIsDragging] = useState(false)
   // drag en cours : on garde l'origine + on note si on a bouge (pour distinguer
   // un pan d'un clic d'annotation).
   const drag = useRef<{ x: number; y: number; panX: number; panY: number; moved: boolean } | null>(null)
@@ -79,6 +80,7 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
   // le zoom se fait UNIQUEMENT avec les boutons +/-.
   const onPointerDown = useCallback((e: React.PointerEvent): void => {
     drag.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y, moved: false }
+    setIsDragging(true)
   }, [pan.x, pan.y])
   const onPointerMove = useCallback((e: React.PointerEvent): void => {
     const d = drag.current
@@ -90,6 +92,7 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
   }, [])
   const onPointerUp = useCallback((): void => {
     drag.current = null
+    setIsDragging(false)
   }, [])
 
   // CSS fullscreen (au lieu de Fullscreen API) — comme ca les siblings
@@ -334,9 +337,9 @@ export function MapLive({ currentSnapshotId = null, annotations = [], onAnnotati
       {mapPngUrl ? (
         // viewport : capture molette + drag pour zoom/pan. overflow-hidden pour
         // que la carte agrandie ne deborde pas hors du cadre.
-        <div
-          className={`overflow-hidden flex items-center justify-center ${viewportClass} ${
-            drag.current ? 'cursor-grabbing' : 'cursor-grab'
+          <div
+            className={`overflow-hidden flex items-center justify-center ${viewportClass} ${
+            isDragging ? 'cursor-grabbing' : 'cursor-grab'
           }`}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}

--- a/web/frontend/src/components/MappingWizard.tsx
+++ b/web/frontend/src/components/MappingWizard.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import {
+  CheckCircle2, Circle, Loader2, Play, Square, Save, Navigation,
+  ShieldCheck, Activity, AlertTriangle, RefreshCw,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useMappingStore } from '@/stores/mappingStore'
+import { startMapping, stopMapping, saveMapping, startLocalization } from '@/lib/mappingApi'
+import { getRobotHealth, type RobotHealth } from '@/lib/repairApi'
+
+// Wizard cartographie & localisation — pour la soutenance : 4 etapes claires,
+// chaque bouton envoie une commande au robot, un feed montre ce qui se passe.
+//   1. Preparation  -> verifie que le robot est pret
+//   2. Cartographie -> demarre l'exploration (SLAM), la carte grandit
+//   3. Sauvegarde   -> fige la carte
+//   4. Localisation -> le robot se repere sur la carte figee (sans la polluer)
+
+type Level = 'info' | 'ok' | 'warn' | 'bad'
+interface FeedItem { t: string; level: Level; text: string }
+
+const STEPS = [
+  { n: 1, label: 'Préparation', icon: ShieldCheck },
+  { n: 2, label: 'Cartographie', icon: Play },
+  { n: 3, label: 'Sauvegarde', icon: Save },
+  { n: 4, label: 'Localisation', icon: Navigation },
+] as const
+
+const levelColor: Record<Level, string> = {
+  info: 'text-gray-400', ok: 'text-emerald-400', warn: 'text-amber-400', bad: 'text-red-400',
+}
+
+export function MappingWizard({ robotId }: { robotId: number }) {
+  const { state, sessionId, mapMeta, wsConnected, failureReason, coveragePercent } = useMappingStore()
+  const [step, setStep] = useState(1)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [health, setHealth] = useState<RobotHealth | null>(null)
+  const [feed, setFeed] = useState<FeedItem[]>([])
+  const prevState = useRef<string>(state)
+
+  const log = useCallback((level: Level, text: string): void => {
+    const t = new Date().toLocaleTimeString()
+    setFeed((f) => [{ t, level, text }, ...f].slice(0, 40))
+  }, [])
+
+  // feed automatique sur les transitions d'etat du robot (le "retour live")
+  useEffect(() => {
+    if (state === prevState.current) return
+    prevState.current = state
+    const map: Record<string, [Level, string]> = {
+      STARTING: ['info', 'Robot : démarrage de la stack…'],
+      RUNNING: ['ok', 'Robot : cartographie EN COURS — la carte se construit'],
+      STOPPING: ['info', 'Robot : arrêt en cours…'],
+      STOPPED: ['ok', 'Robot : arrêté'],
+      FAILED: ['bad', `Robot : ÉCHEC${failureReason ? ` — ${failureReason}` : ''}`],
+    }
+    const entry = map[state]
+    if (entry) log(entry[0], entry[1])
+    if (state === 'RUNNING' && step < 2) setStep(2)
+  }, [state, failureReason, log, step])
+
+  // santé en continu mais LÉGER : toutes les 15s, et PAS pendant le mapping.
+  // La sonde lance des ros2 CLI dans le container -> sur le Nano (CPU faible)
+  // on ne veut surtout pas la lancer pendant que SLAM/Nav2 tournent.
+  useEffect(() => {
+    let alive = true
+    const tick = async (): Promise<void> => {
+      const st = useMappingStore.getState().state
+      if (st === 'STARTING' || st === 'RUNNING') return  // robot occupe -> on ne sonde pas
+      try { const h = await getRobotHealth(robotId); if (alive) setHealth(h) }
+      catch { if (alive) setHealth(null) }
+    }
+    void tick()
+    const id = setInterval(() => void tick(), 15000)
+    return () => { alive = false; clearInterval(id) }
+  }, [robotId])
+
+  const run = useCallback(async (key: string, fn: () => Promise<void>): Promise<void> => {
+    setBusy(key)
+    try { await fn() } finally { setBusy(null) }
+  }, [])
+
+  const doPrep = (): Promise<void> => run('prep', async () => {
+    log('info', 'Vérification du robot…')
+    try {
+      const h = await getRobotHealth(robotId)
+      setHealth(h)
+      // detail : chaque sous-systeme. On dit precisement ce qui n'est pas pret.
+      const checks: [string, boolean][] = [
+        ['connexion', h.reachable],
+        ['container ROS', h.m3pro === 'up'],
+        ['STM32', h.stm32 === 'ok'],
+        ['agent micro-ROS', h.agent === 'active'],
+        ['driver YB_Node', h.ybNode === 'ok'],
+        ['batterie ≥30%', (h.battery ?? 0) >= 30],
+      ]
+      const notReady = checks.filter(([, ok]) => !ok).map(([n]) => n)
+      if (notReady.length === 0) { log('ok', 'Tout est prêt ✓ — on peut cartographier'); setStep(2) }
+      else log('warn', `Pas prêt : ${notReady.join(' · ')}`)
+    } catch (e) {
+      log('bad', `Robot injoignable — ${e instanceof Error ? e.message : 'erreur'}`)
+    }
+  })
+
+  // re-verif manuelle (sonde ponctuelle) — dispo meme pendant le mapping, pour
+  // checker a la demande si ca bloque/sature. Ne change pas d'etape.
+  const refreshHealth = (): Promise<void> => run('health', async () => {
+    try { const h = await getRobotHealth(robotId); setHealth(h); log('ok', 'État rafraîchi') }
+    catch { setHealth(null); log('bad', 'Robot injoignable') }
+  })
+
+  const doStart = (): Promise<void> => run('start', async () => {
+    log('info', 'Commande envoyée : démarrer la cartographie')
+    try { const r = await startMapping(robotId); log('ok', `Session #${r.sessionId} créée`); setStep(2) }
+    catch (e) { log('bad', `Échec start — ${e instanceof Error ? e.message : 'erreur'}`) }
+  })
+
+  const doStop = (): Promise<void> => run('stop', async () => {
+    if (!sessionId) return
+    log('info', 'Commande envoyée : arrêter la cartographie')
+    try { await stopMapping(sessionId); log('ok', 'Arrêt demandé'); setStep(3) }
+    catch (e) { log('bad', `Échec stop — ${e instanceof Error ? e.message : 'erreur'}`) }
+  })
+
+  const doSave = (): Promise<void> => run('save', async () => {
+    if (!sessionId) { log('warn', 'Pas de session à sauvegarder'); return }
+    log('info', 'Commande envoyée : sauvegarder la carte…')
+    try { const r = await saveMapping(sessionId); log('ok', `Carte sauvegardée (snapshot #${r.snapshotId})`); toast.success('Carte sauvegardée'); setStep(4) }
+    catch (e) { log('bad', `Échec save — ${e instanceof Error ? e.message : 'erreur'}`) }
+  })
+
+  const doLocalize = (): Promise<void> => run('localize', async () => {
+    log('info', 'Commande envoyée : passer en localisation (AMCL sur carte figée)')
+    try { await startLocalization(robotId); log('ok', 'Localisation lancée — le robot se repère sur la carte (sans la modifier)'); toast.success('Mode localisation') }
+    catch (e) { log('bad', `Échec localisation — ${e instanceof Error ? e.message : 'erreur'}`) }
+  })
+
+  const mapping = state === 'STARTING' || state === 'RUNNING'
+
+  return (
+    <div className="space-y-4">
+      {/* etat robot LIVE — toujours visible (on voit que tout est bon, auto-refresh 5s) */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-3">
+        <div className="flex items-center gap-2 text-xs font-medium text-gray-400 mb-2">
+          <Activity className="w-3.5 h-3.5 text-emerald-400" /> État du robot
+          <span className="ml-auto flex items-center gap-1.5 text-[10px] text-gray-500">
+            <span className={`size-1.5 rounded-full ${mapping ? 'bg-amber-400' : health ? 'bg-emerald-400' : 'bg-gray-600'}`} />
+            {mapping ? 'figé (mapping)' : health ? 'live · 15s' : 'en attente…'}
+            <button onClick={refreshHealth} disabled={busy === 'health'}
+              className="ml-1 text-gray-400 hover:text-white disabled:opacity-50" aria-label="Re-vérifier maintenant" title="Re-vérifier maintenant">
+              {busy === 'health' ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+            </button>
+          </span>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+          {([
+            ['Connexion', health?.reachable ? 'ok' : 'bad', health ? (health.reachable ? 'en ligne' : 'injoignable') : '…'],
+            ['Container ROS', health?.m3pro === 'up' ? 'ok' : 'bad', health?.m3pro ?? '…'],
+            ['STM32', health?.stm32 === 'ok' ? 'ok' : 'bad', health?.stm32 ?? '…'],
+            ['Agent micro-ROS', health?.agent === 'active' ? 'ok' : 'bad', health?.agent ?? '…'],
+            ['Driver YB_Node', health?.ybNode === 'ok' ? 'ok' : 'bad', health?.ybNode ?? '…'],
+            ['Batterie', (health?.battery ?? 0) >= 30 ? 'ok' : 'warn', health?.battery == null ? '…' : `${health.battery}%`],
+          ] as [string, Level, string][]).map(([label, lvl, val]) => (
+            <div key={label} className="rounded border border-gray-800 bg-gray-950 p-2">
+              <div className="text-gray-500">{label}</div>
+              <div className={`font-medium ${levelColor[lvl]}`}>{val}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* stepper vertical — tout visible dans la colonne, pas de debordement */}
+      <div className="flex flex-col gap-1.5">
+        {STEPS.map((s) => {
+          const done = step > s.n
+          const active = step === s.n
+          const Icon = done ? CheckCircle2 : active ? s.icon : Circle
+          return (
+            <button
+              key={s.n}
+              onClick={() => setStep(s.n)}
+              className={`flex items-center gap-2.5 px-3 py-2 rounded-lg border w-full text-left transition ${
+                active ? 'border-cyan-500 bg-cyan-950/40 text-white'
+                : done ? 'border-emerald-700 bg-emerald-950/20 text-emerald-300'
+                : 'border-gray-800 bg-gray-900 text-gray-500'
+              }`}
+            >
+              <Icon className={`w-4 h-4 shrink-0 ${active ? 'text-cyan-400' : done ? 'text-emerald-400' : ''}`} />
+              <span className="text-sm font-medium">{s.n}. {s.label}</span>
+              {done && <span className="ml-auto text-[10px] text-emerald-400">fait</span>}
+              {active && <span className="ml-auto text-[10px] text-cyan-400">en cours</span>}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* carte de l'etape courante */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+        {step === 1 && (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-300">On vérifie que le robot est prêt avant de cartographier. Les indicateurs « État du robot » se rafraîchissent toutes les 15 s (en pause pendant le mapping pour ne pas charger le robot) — bouton ⟳ pour forcer.</p>
+            <button onClick={doPrep} disabled={busy !== null}
+              className="flex items-center gap-2 px-4 py-2 bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white rounded font-medium">
+              {busy === 'prep' ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShieldCheck className="w-4 h-4" />}
+              Vérifier le robot
+            </button>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-300">
+              Le robot explore tout seul et construit la carte. Tu peux le piloter au clavier si besoin.
+              {coveragePercent != null && <span className="text-cyan-400"> · couverture ~{Math.round(coveragePercent)}%</span>}
+            </p>
+            <div className="flex gap-2">
+              <button onClick={doStart} disabled={busy !== null || mapping}
+                className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded font-medium">
+                {busy === 'start' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                Démarrer la cartographie
+              </button>
+              <button onClick={doStop} disabled={busy !== null || !mapping}
+                className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white rounded font-medium">
+                {busy === 'stop' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Square className="w-4 h-4" />}
+                Arrêter
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-300">Quand la pièce est bien couverte, on fige la carte.</p>
+            <button onClick={doSave} disabled={busy !== null}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded font-medium">
+              {busy === 'save' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+              Sauvegarder la carte
+            </button>
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-300">
+              Mode usage : le robot se repère sur la carte figée. On peut le déplacer / l'éteindre,
+              il retrouve sa position — <span className="text-emerald-400">sans jamais polluer la carte</span>.
+            </p>
+            <button onClick={doLocalize} disabled={busy !== null}
+              className="flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white rounded font-medium">
+              {busy === 'localize' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Navigation className="w-4 h-4" />}
+              Passer en localisation
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* feed live : ce qui se passe */}
+      <div>
+        <div className="flex items-center gap-2 text-xs font-medium text-gray-400 mb-1.5">
+          <Activity className="w-3.5 h-3.5 text-cyan-400" /> Ce qui se passe
+          <span className={`ml-auto flex items-center gap-1 ${wsConnected ? 'text-emerald-400' : 'text-gray-500'}`}>
+            <span className={`size-1.5 rounded-full ${wsConnected ? 'bg-emerald-400' : 'bg-gray-600'}`} />
+            {wsConnected ? 'live' : 'hors ligne'}
+          </span>
+        </div>
+        <div className="bg-gray-950 border border-gray-800 rounded-lg h-40 overflow-y-auto divide-y divide-gray-900 text-xs font-mono">
+          {feed.length === 0 ? (
+            <div className="p-3 text-gray-600">En attente d'une action…</div>
+          ) : feed.map((f, i) => (
+            <div key={i} className="px-3 py-1.5 flex gap-2">
+              <span className="text-gray-600 shrink-0">{f.t}</span>
+              <span className={levelColor[f.level]}>{f.text}</span>
+            </div>
+          ))}
+        </div>
+        {failureReason && (
+          <div className="mt-2 flex items-start gap-2 text-xs text-red-400 bg-red-950/30 border border-red-900 rounded p-2">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" /> {failureReason}
+          </div>
+        )}
+      </div>
+
+      {mapMeta && (
+        <div className="text-[10px] text-gray-600 text-center">
+          carte {mapMeta.width}×{mapMeta.height}px · {mapMeta.resolution.toFixed(3)} m/px
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/components/MiniMapPip.tsx
+++ b/web/frontend/src/components/MiniMapPip.tsx
@@ -1,20 +1,24 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Map as MapIcon, Minus, X } from 'lucide-react'
 import { useMappingStore } from '@/stores/mappingStore'
+import { useDraggable } from '@/hooks/useDraggable'
 
-// Mini-map picture-in-picture (PIP) en bas a droite : version reduite de la
-// carte SLAM + position robot. Visible quand on est en plein ecran ou quand
-// la carte principale est masquee.
+// Mini-map picture-in-picture (PIP) : version reduite de la carte SLAM +
+// position robot. Panneau flottant DEPLACABLE (drag entete) + reductible + fermable.
 
 const PIP_W = 180
 const PIP_H = 120
 
-export function MiniMapPip() {
+export function MiniMapPip({ onClose }: { onClose?: () => void } = {}) {
   const { mapPngUrl, mapMeta, robotPose } = useMappingStore()
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [hidden, setHidden] = useState(false)
+  const [minimized, setMinimized] = useState(false)
+  const { pos, onDragStart } = useDraggable({ x: 16, y: window.innerHeight - 200 })
 
   useEffect(() => {
     const canvas = canvasRef.current
-    if (!canvas || !mapPngUrl || !mapMeta) return
+    if (!canvas || !mapPngUrl || !mapMeta || minimized) return
     canvas.width = PIP_W
     canvas.height = PIP_H
     const ctx = canvas.getContext('2d')
@@ -40,13 +44,48 @@ export function MiniMapPip() {
       }
     }
     img.src = mapPngUrl
-  }, [mapPngUrl, mapMeta, robotPose])
+  }, [mapPngUrl, mapMeta, robotPose, minimized])
 
   if (!mapPngUrl) return null
+
+  if (hidden) {
+    return (
+      <button
+        onClick={() => setHidden(false)}
+        className="fixed bottom-4 left-4 z-30 bg-gray-900 border border-gray-700 rounded p-2 text-gray-300 hover:text-white"
+        aria-label="Re-afficher la mini-carte"
+      >
+        <MapIcon className="w-4 h-4" />
+      </button>
+    )
+  }
+
   return (
-    <div className="fixed bottom-4 right-4 z-30 bg-gray-950 border border-gray-700 rounded shadow-lg p-1">
-      <canvas ref={canvasRef} style={{ imageRendering: 'pixelated' }} />
-      <div className="text-[9px] text-gray-500 text-center mt-0.5 font-mono">PIP</div>
+    <div
+      className="fixed z-30 bg-gray-950 border border-gray-700 rounded shadow-lg overflow-hidden"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div
+        onPointerDown={onDragStart}
+        className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800 cursor-move select-none"
+      >
+        <span className="flex items-center gap-1.5 text-[10px] text-gray-300 font-mono">
+          <MapIcon className="w-3 h-3" /> Mini-carte
+        </span>
+        <div className="flex items-center gap-1">
+          <button onClick={() => setMinimized((m) => !m)} className="text-gray-400 hover:text-white p-0.5" aria-label="Reduire">
+            <Minus className="w-3 h-3" />
+          </button>
+          <button onClick={() => (onClose ? onClose() : setHidden(true))} className="text-gray-400 hover:text-white p-0.5" aria-label="Fermer">
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+      {!minimized && (
+        <div className="p-1">
+          <canvas ref={canvasRef} style={{ imageRendering: 'pixelated' }} />
+        </div>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/components/URDFViewer.tsx
+++ b/web/frontend/src/components/URDFViewer.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
 import URDFLoader from 'urdf-loader'
-import { Bot, Maximize2, Minimize2, X, AlertTriangle } from 'lucide-react'
+import { Bot, Maximize2, Minimize2, X, Minus, AlertTriangle } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { useMappingStore } from '@/stores/mappingStore'
 import { armPoseToUrdfJoints } from '@/lib/armUrdf'
+import { useDraggable } from '@/hooks/useDraggable'
 
 // Viewer 3D fidele du bras Yahboom M3 Pro via urdf-loader.
 // Charge l'URDF reel servi par le backend (/robot_assets/m3pro.urdf.xml)
 // et applique les /joint_states recus via WS pour animer.
+// Panneau flottant DEPLACABLE (drag entete) + reductible + fermable.
 //
 // Si l'URDF n'est pas dispo (pas encore fetch via fetch_urdf_from_robot.sh),
 // affiche un message explicite — surtout pas un faux bras anime.
@@ -16,13 +18,14 @@ import { armPoseToUrdfJoints } from '@/lib/armUrdf'
 interface Props {
   robotId: number
   enabled?: boolean
+  onClose?: () => void
 }
 
 interface JointMap {
   [name: string]: { setJointValue: (v: number) => void }
 }
 
-export function URDFViewer({ robotId, enabled = true }: Props) {
+export function URDFViewer({ robotId, enabled = true, onClose }: Props) {
   const token = useAuthStore((s) => s.token)
   const armPose = useMappingStore((s) => s.armPose)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -36,7 +39,9 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
   const [status, setStatus] = useState<'loading' | 'ready' | 'missing' | 'error'>('loading')
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [hidden, setHidden] = useState(false)
+  const [minimized, setMinimized] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
+  const { pos, onDragStart } = useDraggable({ x: window.innerWidth - 288, y: window.innerHeight - 290 })
 
   useEffect(() => {
     const container = containerRef.current
@@ -101,6 +106,7 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
       if (!container) return
       const w = container.clientWidth
       const h = container.clientHeight
+      if (w === 0 || h === 0) return
       camera.aspect = w / h
       camera.updateProjectionMatrix()
       renderer.setSize(w, h)
@@ -189,10 +195,14 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
   return (
     <div
       className={`bg-black border border-gray-700 rounded shadow-lg overflow-hidden z-30 ${
-        fullscreen ? 'fixed inset-0' : 'fixed bottom-32 right-4 w-64'
+        fullscreen ? 'fixed inset-0' : 'fixed w-64'
       }`}
+      style={fullscreen ? undefined : { left: pos.x, top: pos.y }}
     >
-      <div className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800">
+      <div
+        onPointerDown={onDragStart}
+        className="flex items-center justify-between bg-gray-900 px-2 py-1 border-b border-gray-800 cursor-move select-none"
+      >
         <div className="flex items-center gap-1.5 text-xs text-gray-300">
           <Bot className="w-3 h-3" /> Bras 3D (URDF)
           <span className={`text-[10px] ${
@@ -204,32 +214,42 @@ export function URDFViewer({ robotId, enabled = true }: Props) {
           </span>
         </div>
         <div className="flex items-center gap-1">
+          <button onClick={() => setMinimized((m) => !m)} className="text-gray-400 hover:text-white p-0.5" aria-label="Reduire">
+            <Minus className="w-3 h-3" />
+          </button>
           <button onClick={toggleFs} className="text-gray-400 hover:text-white p-0.5" aria-label="plein ecran">
             {fullscreen ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
           </button>
-          <button onClick={() => setHidden(true)} className="text-gray-400 hover:text-white p-0.5" aria-label="cacher">
+          <button onClick={() => (onClose ? onClose() : setHidden(true))} className="text-gray-400 hover:text-white p-0.5" aria-label="fermer">
             <X className="w-3 h-3" />
           </button>
         </div>
       </div>
-      <div ref={containerRef} className={fullscreen ? 'h-screen w-screen' : 'aspect-video w-full'} />
-      {status === 'missing' && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-center p-3">
-          <div className="text-xs text-gray-300">
-            <AlertTriangle className="w-5 h-5 text-yellow-500 mx-auto mb-1.5" />
-            URDF non récupéré.<br />
-            Lance <code className="text-cyan-400">./robot/scripts/fetch_urdf_from_robot.sh</code>
+      {/* le canvas THREE reste monte (cache en CSS quand reduit) pour ne pas
+          recreer la scene a chaque toggle. */}
+      <div className="relative">
+        <div
+          ref={containerRef}
+          className={`${minimized ? 'hidden' : ''} ${fullscreen ? 'h-screen w-screen' : 'aspect-video w-full'}`}
+        />
+        {!minimized && status === 'missing' && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-center p-3">
+            <div className="text-xs text-gray-300">
+              <AlertTriangle className="w-5 h-5 text-yellow-500 mx-auto mb-1.5" />
+              URDF non récupéré.<br />
+              Lance <code className="text-cyan-400">./robot/scripts/fetch_urdf_from_robot.sh</code>
+            </div>
           </div>
-        </div>
-      )}
-      {status === 'error' && errorMsg && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-center p-3">
-          <div className="text-xs text-red-400">
-            <AlertTriangle className="w-5 h-5 mx-auto mb-1.5" />
-            Erreur URDF :<br />{errorMsg}
+        )}
+        {!minimized && status === 'error' && errorMsg && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-center p-3">
+            <div className="text-xs text-red-400">
+              <AlertTriangle className="w-5 h-5 mx-auto mb-1.5" />
+              Erreur URDF :<br />{errorMsg}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/web/frontend/src/hooks/useDraggable.ts
+++ b/web/frontend/src/hooks/useDraggable.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef, useState } from 'react'
+
+// Petit hook pour rendre un panneau flottant deplacable : on attache
+// `onDragStart` a l'entete (poignee), et on positionne le panneau avec `pos`
+// (left/top, en position: fixed). Le drag suit le pointeur jusqu'au relachement.
+export function useDraggable(initial: { x: number; y: number }) {
+  const [pos, setPos] = useState(initial)
+  const start = useRef<{ sx: number; sy: number; px: number; py: number } | null>(null)
+
+  const onDragStart = useCallback((e: React.PointerEvent): void => {
+    // on ne demarre pas un drag depuis un bouton (fermer/reduire/plein ecran)
+    if ((e.target as HTMLElement).closest('button')) return
+    start.current = { sx: e.clientX, sy: e.clientY, px: pos.x, py: pos.y }
+
+    const onMove = (ev: PointerEvent): void => {
+      const s = start.current
+      if (!s) return
+      // on clamp grossierement dans la fenetre pour ne pas perdre le panneau
+      const x = Math.max(0, Math.min(window.innerWidth - 60, s.px + (ev.clientX - s.sx)))
+      const y = Math.max(0, Math.min(window.innerHeight - 30, s.py + (ev.clientY - s.sy)))
+      setPos({ x, y })
+    }
+    const onUp = (): void => {
+      start.current = null
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }, [pos.x, pos.y])
+
+  return { pos, onDragStart }
+}

--- a/web/frontend/src/lib/mappingApi.ts
+++ b/web/frontend/src/lib/mappingApi.ts
@@ -43,6 +43,17 @@ export async function saveMapping(sessionId: number, name?: string): Promise<{ s
   return res.json()
 }
 
+// Bascule le robot en mode localisation (amcl sur carte figee). Le robot se
+// repere sur la carte sauvee sans la modifier.
+export async function startLocalization(robotId: number, map?: string): Promise<{ ok: boolean }> {
+  const res = await apiFetch('/mapping/localize', {
+    method: 'POST',
+    body: JSON.stringify({ robotId, ...(map ? { map } : {}) }),
+  })
+  if (!res.ok) throw new Error(`startLocalization ${res.status}`)
+  return res.json()
+}
+
 export async function listSessions(robotId: number): Promise<MappingSessionLite[]> {
   const res = await apiFetch(`/mapping/sessions?robotId=${robotId}`)
   if (!res.ok) throw new Error(`listSessions ${res.status}`)

--- a/web/frontend/src/lib/repairApi.ts
+++ b/web/frontend/src/lib/repairApi.ts
@@ -3,7 +3,7 @@ import { apiFetch } from './api'
 // API page Reparation (admin). Cote back : /api/admin/robots/:id/{health,repair}.
 // On envoie un NOM d'action, jamais une commande shell.
 
-export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot'
+export type RepairAction = 'reconnect_stm32' | 'restart_ros' | 'resync_clock' | 'reboot' | 'shutdown'
 export type HealthState = 'ok' | 'down' | 'active' | 'dead' | 'up' | 'unknown'
 
 export interface RobotHealth {
@@ -31,6 +31,7 @@ export const REPAIR_LABELS: Record<RepairAction, string> = {
   restart_ros: 'Redémarrer la stack ROS',
   resync_clock: 'Resync horloge',
   reboot: 'Redémarrer le Jetson',
+  shutdown: 'Éteindre le robot',
 }
 
 export async function getRobotHealth(robotId: number): Promise<RobotHealth> {

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -59,8 +59,20 @@ export function MappingPage() {
   }, [robotId, refreshKey])
 
   useEffect(() => {
-    if (!currentSnapshotId) { setAnnotations([]); return }
-    void listAnnotations(currentSnapshotId).then(setAnnotations).catch(() => setAnnotations([]))
+    let cancelled = false
+    void (async () => {
+      if (!currentSnapshotId) {
+        if (!cancelled) setAnnotations([])
+        return
+      }
+      try {
+        const items = await listAnnotations(currentSnapshotId)
+        if (!cancelled) setAnnotations(items)
+      } catch {
+        if (!cancelled) setAnnotations([])
+      }
+    })()
+    return () => { cancelled = true }
   }, [currentSnapshotId])
 
   return (

--- a/web/frontend/src/pages/MappingPage.tsx
+++ b/web/frontend/src/pages/MappingPage.tsx
@@ -1,17 +1,15 @@
 import { useState, useEffect } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { toast } from 'sonner'
-import { ArrowLeft, Play, Square, Save, Wifi, WifiOff, MapPin } from 'lucide-react'
+import { ArrowLeft, Wifi, WifiOff, MapPin, Camera, Bot, Map as MapIcon } from 'lucide-react'
 import { useRobotStore } from '../stores/robotStore'
 import { useMappingStore } from '../stores/mappingStore'
 import { useMappingTelemetry } from '../hooks/useMappingTelemetry'
 import { useMappingStaleness } from '../hooks/useStaleness'
 import { useTfStream, useTopicsStream } from '../hooks/useRobotInfraWs'
-import { startMapping, stopMapping, saveMapping } from '../lib/mappingApi'
 import { MappingSessionsList } from '../components/MappingSessionsList'
 import { TeleopPanel } from '../components/TeleopPanel'
 import { MapLive } from '../components/MapLive'
-import { DockBottom } from '../components/DockBottom'
+import { MappingWizard } from '../components/MappingWizard'
 import { MiniMapPip } from '../components/MiniMapPip'
 import { CameraView } from '../components/CameraView'
 import { URDFViewer } from '../components/URDFViewer'
@@ -19,25 +17,14 @@ import { ArmController } from '../components/ArmController'
 import { listAnnotations, type Annotation } from '../lib/annotationsApi'
 import { listSessions } from '../lib/mappingApi'
 
-const STATE_LABEL: Record<string, { label: string; color: string }> = {
-  IDLE: { label: 'En veille', color: 'bg-gray-700 text-gray-200' },
-  STARTING: { label: 'Demarrage…', color: 'bg-yellow-600 text-white' },
-  RUNNING: { label: 'Cartographie en cours', color: 'bg-green-600 text-white' },
-  STOPPING: { label: 'Arret…', color: 'bg-yellow-600 text-white' },
-  STOPPED: { label: 'Arrete', color: 'bg-gray-700 text-gray-200' },
-  FAILED: { label: 'Echec', color: 'bg-red-600 text-white' },
-}
-
 export function MappingPage() {
   const params = useParams<{ robotId?: string }>()
   const storeRobotId = useRobotStore((s) => s.id)
-  // /mapping/:robotId override le robot courant du store, sinon fallback
-  // au robot par defaut (single-robot MVP).
+  // /mapping/:robotId override le robot courant, sinon robot par defaut.
   const parsed = params.robotId ? Number(params.robotId) : NaN
   const robotId = Number.isInteger(parsed) && parsed > 0 ? parsed : storeRobotId
-  const robotConnected = useRobotStore((s) => s.connected)
   const robotPos = useRobotStore((s) => s.position)
-  const { state, sessionId, mapMeta, wsConnected, failureReason, setMapping, setRobotPose, pushTrail } = useMappingStore()
+  const { state, wsConnected, setRobotPose, pushTrail } = useMappingStore()
 
   // WS telemetry (carte live + scan + plan + frontiers) + TF + Topics infra
   useMappingTelemetry(robotId, true)
@@ -46,203 +33,74 @@ export function MappingPage() {
   const stale = useMappingStaleness()
 
   // Synchronise robotStore.position -> mappingStore.robotPose + trail
-  // (la position vient du WS legacy /ws via position_update -> robotStore).
   useEffect(() => {
     setRobotPose({ x: robotPos.x, y: robotPos.y, theta: robotPos.heading })
     if (state === 'RUNNING') pushTrail({ x: robotPos.x, y: robotPos.y })
   }, [robotPos.x, robotPos.y, robotPos.heading, state, setRobotPose, pushTrail])
 
-  const [busy, setBusy] = useState(false)
-  const [refreshKey, setRefreshKey] = useState(0)
-  // snapshot courant = dernier snapshot du robot (pour rattacher les annotations)
+  const [refreshKey] = useState(0)
   const [currentSnapshotId, setCurrentSnapshotId] = useState<number | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  // vues flottantes fermees par defaut (camera POV, bras 3D, mini-carte)
+  const [tools, setTools] = useState({ camera: false, arm: false, minimap: false })
 
-  // resolve currentSnapshotId : on prend le dernier snapshot de la session
-  // active si elle a un snapshot, sinon on tente le dernier snapshot du robot.
+  // dernier snapshot de la session active (pour rattacher les annotations)
   useEffect(() => {
     let cancelled = false
     void (async () => {
       try {
         const sessions = await listSessions(robotId)
-        for (const s of sessions) {
-          const c = s._count?.snapshots ?? 0
-          if (c > 0) {
-            // on n'a pas l'id direct ici — il faut un fetch supplementaire.
-            // Pour MVP : on garde currentSnapshotId null si pas dispo, l'utilisateur
-            // doit sauvegarder une carte pour creer des annotations.
-            // todo: endpoint snapshots/latest?robotId=...
-            return
-          }
+        if (!cancelled && !sessions.some((s) => (s._count?.snapshots ?? 0) > 0)) {
+          setCurrentSnapshotId(null)
         }
-        if (!cancelled) setCurrentSnapshotId(null)
-      } catch {
-        /* ignore */
-      }
+      } catch { /* ignore */ }
     })()
     return () => { cancelled = true }
   }, [robotId, refreshKey])
 
   useEffect(() => {
-    if (!currentSnapshotId) {
-      setAnnotations([])
-      return
-    }
+    if (!currentSnapshotId) { setAnnotations([]); return }
     void listAnnotations(currentSnapshotId).then(setAnnotations).catch(() => setAnnotations([]))
   }, [currentSnapshotId])
 
-  const onStart = async (): Promise<void> => {
-    setBusy(true)
-    try {
-      const r = await startMapping(robotId)
-      setMapping('STARTING', r.sessionId)
-      toast.success(`Session ${r.sessionId} demarree`)
-      setRefreshKey((k) => k + 1)
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'erreur start')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const onStop = async (): Promise<void> => {
-    if (!sessionId) return
-    setBusy(true)
-    try {
-      await stopMapping(sessionId)
-      setMapping('STOPPING', sessionId)
-      toast.success('Arret demande')
-      setRefreshKey((k) => k + 1)
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'erreur stop')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const onSave = async (): Promise<void> => {
-    if (!sessionId) return
-    setBusy(true)
-    try {
-      const r = await saveMapping(sessionId)
-      toast.success(`Carte sauvegardee (snapshot #${r.snapshotId})`)
-      setRefreshKey((k) => k + 1)
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'erreur save')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const canStart = state === 'IDLE' || state === 'STOPPED' || state === 'FAILED'
-  const canStop = state === 'STARTING' || state === 'RUNNING'
-  const canSave = state === 'RUNNING' || state === 'STOPPED'
-
-  const badge = STATE_LABEL[state] ?? STATE_LABEL.IDLE
-
   return (
-    <div className="p-6 max-w-6xl mx-auto">
+    <div className="p-6 max-w-7xl mx-auto">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-5">
         <div className="flex items-center gap-3">
-          <Link to="/" className="text-gray-400 hover:text-white">
-            <ArrowLeft className="w-5 h-5" />
-          </Link>
+          <Link to="/" className="text-gray-400 hover:text-white"><ArrowLeft className="w-5 h-5" /></Link>
           <div>
-            <h1 className="text-2xl font-semibold text-white">Mode mapping</h1>
-            <p className="text-sm text-gray-500 mt-0.5">Cartographie SLAM live</p>
+            <h1 className="text-2xl font-semibold text-white">Cartographie & Localisation</h1>
+            <p className="text-sm text-gray-500 mt-0.5">Suis les étapes : prépare → cartographie → sauvegarde → localise</p>
           </div>
         </div>
         <div className="flex items-center gap-3 text-sm">
-          {stale && (
-            <span className="px-2 py-0.5 rounded bg-yellow-600 text-white text-xs font-medium">
-              Perte signal robot
-            </span>
-          )}
-          {wsConnected ? (
-            <span className="flex items-center gap-1.5 text-green-400">
-              <Wifi className="w-4 h-4" /> WS connecte
-            </span>
-          ) : (
-            <span className="flex items-center gap-1.5 text-gray-500">
-              <WifiOff className="w-4 h-4" /> WS deconnecte
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Etat + boutons */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-          <div className="text-xs text-gray-500 uppercase mb-1">Etat</div>
-          <span className={`inline-block px-3 py-1 rounded text-sm font-medium ${badge.color}`}>
-            {badge.label}
+          {stale && <span className="px-2 py-0.5 rounded bg-amber-600 text-white text-xs font-medium">Perte signal robot</span>}
+          <span className={`flex items-center gap-1.5 ${wsConnected ? 'text-emerald-400' : 'text-gray-500'}`}>
+            {wsConnected ? <Wifi className="w-4 h-4" /> : <WifiOff className="w-4 h-4" />}
+            {wsConnected ? 'connecté' : 'déconnecté'}
           </span>
-          {sessionId && <div className="text-xs text-gray-500 mt-2">Session #{sessionId}</div>}
-          {failureReason && <div className="text-xs text-red-400 mt-2">{failureReason}</div>}
-        </div>
-
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-          <div className="text-xs text-gray-500 uppercase mb-1">Robot</div>
-          <div className="text-white font-medium">{useRobotStore.getState().name}</div>
-          <div className={`text-xs mt-1 ${robotConnected ? 'text-green-400' : 'text-gray-500'}`}>
-            {robotConnected ? 'En ligne' : 'Hors ligne'}
-          </div>
-        </div>
-
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-          <div className="text-xs text-gray-500 uppercase mb-1">Carte</div>
-          {mapMeta ? (
-            <>
-              <div className="text-white text-sm">
-                {mapMeta.width} × {mapMeta.height} px
-              </div>
-              <div className="text-xs text-gray-500 mt-1">
-                resolution {mapMeta.resolution.toFixed(3)} m/px
-              </div>
-            </>
-          ) : (
-            <div className="text-gray-500 text-sm">en attente…</div>
-          )}
         </div>
       </div>
 
-      {/* Boutons */}
-      <div className="flex gap-3 mb-6">
-        <button
-          onClick={onStart}
-          disabled={!canStart || busy || !robotConnected}
-          className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
-        >
-          <Play className="w-4 h-4" /> Demarrer
-        </button>
-        <button
-          onClick={onStop}
-          disabled={!canStop || busy}
-          className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
-        >
-          <Square className="w-4 h-4" /> Arreter
-        </button>
-        <button
-          onClick={onSave}
-          disabled={!canSave || busy}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded font-medium"
-        >
-          <Save className="w-4 h-4" /> Sauvegarder
-        </button>
+      {/* barre d'outils : vues flottantes (fermees par defaut) */}
+      <div className="flex items-center gap-2 mb-4 text-xs">
+        <span className="text-gray-500">Vues :</span>
+        {([['camera', 'Caméra POV', Camera], ['arm', 'Bras 3D', Bot], ['minimap', 'Mini-carte', MapIcon]] as const).map(([k, label, Icon]) => (
+          <button key={k} onClick={() => setTools((t) => ({ ...t, [k]: !t[k] }))}
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded border ${tools[k] ? 'border-cyan-600 bg-cyan-950/40 text-cyan-300' : 'border-gray-800 bg-gray-900 text-gray-400 hover:text-white'}`}>
+            <Icon className="w-3.5 h-3.5" /> {label}
+          </button>
+        ))}
       </div>
 
-      {/* Carte live + panneaux cote a cote */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
-        <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-lg p-4">
+      {/* Carte (grande) + wizard cote a cote */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4">
+        <div className="lg:col-span-3 bg-gray-900 border border-gray-800 rounded-lg p-4">
           <div className="flex items-center gap-2 mb-3">
             <MapPin className="w-4 h-4 text-gray-400" />
             <h2 className="text-sm font-medium text-gray-300">Carte SLAM live</h2>
-            {mapMeta && (
-              <span className="text-[10px] text-gray-500 ml-auto">
-                {mapMeta.width}×{mapMeta.height}px · {mapMeta.resolution.toFixed(3)}m/px
-              </span>
-            )}
+            <span className="text-[10px] text-gray-500 ml-auto">molette désactivée · boutons +/− pour zoomer · glisser pour déplacer · ⛶ plein écran</span>
           </div>
           <MapLive
             currentSnapshotId={currentSnapshotId}
@@ -251,17 +109,23 @@ export function MappingPage() {
           />
         </div>
 
-        <div className="space-y-4">
-          <TeleopPanel enabled={state === 'RUNNING' && wsConnected} />
-          <ArmController robotId={robotId} />
-          <MappingSessionsList robotId={robotId} refreshKey={refreshKey} />
+        {/* le wizard = le guide de la soutenance */}
+        <div className="lg:col-span-2">
+          <MappingWizard robotId={robotId} />
         </div>
       </div>
 
-      <DockBottom />
-      <MiniMapPip />
-      <CameraView robotId={robotId} />
-      <URDFViewer robotId={robotId} />
+      {/* Outils (sous la carte) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
+        <TeleopPanel enabled={state === 'RUNNING' && wsConnected} />
+        <ArmController robotId={robotId} />
+        <MappingSessionsList robotId={robotId} refreshKey={refreshKey} />
+      </div>
+
+      {/* vues flottantes : fermees par defaut, ouvertes via la barre d'outils */}
+      {tools.minimap && <MiniMapPip onClose={() => setTools((t) => ({ ...t, minimap: false }))} />}
+      {tools.camera && <CameraView robotId={robotId} onClose={() => setTools((t) => ({ ...t, camera: false }))} />}
+      {tools.arm && <URDFViewer robotId={robotId} onClose={() => setTools((t) => ({ ...t, arm: false }))} />}
     </div>
   )
 }

--- a/web/frontend/src/pages/RobotRepairPage.tsx
+++ b/web/frontend/src/pages/RobotRepairPage.tsx
@@ -110,10 +110,11 @@ export function RobotRepairPage() {
 
   const repair = async (action: RepairAction): Promise<void> => {
     if (action === 'reboot' && !window.confirm('Redémarrer complètement le Jetson ? (~90s d\'indisponibilité)')) return
+    if (action === 'shutdown' && !window.confirm('Éteindre le robot proprement ? (range le bras puis coupe — il faudra le rallumer physiquement)')) return
     setBusy(action)
     push('info', `🔧 ${REPAIR_LABELS[action]} lancé...`)
     try {
-      const r = await runRepair(robotId, action, action === 'reboot')
+      const r = await runRepair(robotId, action, action === 'reboot' || action === 'shutdown')
       if (r.ok) { push('ok', `${REPAIR_LABELS[action]} : OK${r.note ? ` (${r.note})` : ''}`); toast.success(REPAIR_LABELS[action]) }
       else { push('warn', `${REPAIR_LABELS[action]} : code ${r.code}`); toast.warning(`${REPAIR_LABELS[action]} (code ${r.code})`) }
     } catch (e) {
@@ -207,12 +208,12 @@ export function RobotRepairPage() {
 
       {/* actions globales */}
       <div className="flex flex-wrap gap-2">
-        {(['reconnect_stm32', 'restart_ros', 'resync_clock', 'reboot'] as RepairAction[]).map((a) => (
+        {(['reconnect_stm32', 'restart_ros', 'resync_clock', 'reboot', 'shutdown'] as RepairAction[]).map((a) => (
           <button
             key={a}
             onClick={() => repair(a)}
             disabled={busy !== null}
-            className={`rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 ${a === 'reboot' ? 'border-destructive/40 text-destructive' : 'border-border'}`}
+            className={`rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 ${a === 'reboot' || a === 'shutdown' ? 'border-destructive/40 text-destructive' : 'border-border'}`}
           >
             {busy === a ? '…' : REPAIR_LABELS[a]}
           </button>

--- a/web/frontend/src/test/repairApi.test.ts
+++ b/web/frontend/src/test/repairApi.test.ts
@@ -10,8 +10,14 @@ const mockFetch = vi.mocked(apiFetch)
 beforeEach(() => mockFetch.mockReset())
 
 describe('repairApi', () => {
-  it('REPAIR_LABELS couvre les 4 actions', () => {
-    expect(Object.keys(REPAIR_LABELS).sort()).toEqual(['reboot', 'reconnect_stm32', 'restart_ros', 'resync_clock'])
+  it('REPAIR_LABELS couvre les actions exposees', () => {
+    expect(Object.keys(REPAIR_LABELS).sort()).toEqual([
+      'reboot',
+      'reconnect_stm32',
+      'restart_ros',
+      'resync_clock',
+      'shutdown',
+    ])
   })
 
   it('runRepair POST la bonne route + body', async () => {


### PR DESCRIPTION
## Ce qui a été fait
**Wizard mapping** (page Cartographie & Localisation refaite) : 4 étapes (prépa → carto → save → localisation), chaque bouton pilote le robot via MQTT, feed live de ce qui se passe, état robot détaillé (6 sous-systèmes) auto-rafraîchi mais en pause pendant le mapping (CPU Nano).

**Mode localisation** : `localization.launch.py` (AMCL sur carte figée — le robot se repère sans polluer la carte) + action `localize` dans `mapping_supervisor` + endpoint backend.

**Bouton Éteindre** robot (page Réparation) : range le bras puis shutdown propre.

**Carte web** : zoom (boutons), pan, plein écran, upscale des petites cartes. Panneaux flottants (caméra/bras 3D/mini-carte) fermés par défaut, déplaçables + réductibles + fermables.

**SSH backend** : résolution IP par MAC (DHCP-proof), reconnexion auto + fermeture des connexions mortes (fini l'accumulation de sshd qui ralentissait le robot).

## Tests
- typecheck back + front : 0 erreur
- santé robot validée en direct (reachable:true)
- Docs (.md) gardées locales, .env non commité.