### PR TITLE
feat(robot): qr, boot stable et wifi demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# RobLaude — Mémoire agents
+
+> **Ce fichier a été fusionné dans la source canonique unique : [`docs/architecture.md`](docs/architecture.md).**
+> Lis-la **en entier avant d'agir** — elle contient tout (matériel, réseau, contrôle robot, MQTT,
+> archi web + robot, pièges appris à la dure, causes racines connues avec niveau de preuve).
+
+## Rappels top-priorité (le détail est dans `docs/architecture.md`)
+
+- **Langue** : toujours répondre **en français**.
+- **Git** : jamais `git commit` / `gh pr create` direct → toujours le skill `/commit`. 1 ticket = 1 branche = 1 PR, partir de `dev`, jamais merge direct (hook `git-guard`).
+- **Commits/commentaires** : 1 ligne, style humain. Mots IA bannis (implement, enhance, ensure, robust, comprehensive, « This commit… »…).
+- **Rigueur** (cf. CLAUDE.md global) : standard « 1+1=2 » — vérifier avant d'affirmer, étiqueter PROUVÉ/DÉDUIT/SUPPOSÉ, isoler la variable avant d'agir, anti-tunnel.
+- **Robot** : `ROS_DOMAIN_ID=30` + `FASTDDS_BUILTIN_TRANSPORTS=UDPv4` obligatoires ; CPU Jetson Nano = la contrainte n°1 ; `YB_Node` crashe sous pub en boucle (→ reboot) ; ne rien bouger sans accord.
+
+→ **Tout le reste : [`docs/architecture.md`](docs/architecture.md).**

--- a/CODEX_BRIEFING.md
+++ b/CODEX_BRIEFING.md
@@ -1,0 +1,7 @@
+# RobLaude — Briefing technique
+
+> **Fusionné dans la source canonique unique : [`docs/architecture.md`](docs/architecture.md).**
+>
+> Tout le contenu de ce briefing (matériel, réseau, SSH, contrôle robot, MQTT, archi web + robot,
+> pièges, causes racines) vit désormais là, à jour et sans doublon. Ne plus éditer ce fichier —
+> mettre à jour `docs/architecture.md`.

--- a/docs/AUTONAV_PROCEDURE.md
+++ b/docs/AUTONAV_PROCEDURE.md
@@ -1,0 +1,75 @@
+# Procédure de test autonav (Nav2) — RobLaude M3 Pro
+
+> Préparée à froid le 2026-06-18. À dérouler demain, robot chargé (**batterie ≥ 12 V**).
+> Objectif : valider le correctif `nav2_slam_roblaude.launch.py` qui avait fait
+> `ABORTED` / `GridBased failed to create plan` la dernière fois.
+
+## Ce qui a été corrigé (et pourquoi ça plantait)
+
+1. **Bug bloquant trouvé en prep** : le launch lisait `controller['goal_checker']`,
+   mais sous Humble le bloc s'appelle **`general_goal_checker`** → `KeyError` au
+   lancement (vérifié sur le vrai fichier du robot, dans le container). Corrigé :
+   on suit `goal_checker_plugins` / `progress_checker_plugin`, robuste cross-version.
+2. **global_costmap** sans obstacle live → fin des drops `MessageFilter` globaux
+   (on planifie sur la `static_layer` du SLAM).
+3. **local_costmap** sur `/scan_fixed` (scan restampé par `scan_restamper`).
+4. **planner** `GridBased.tolerance` 0.5 → **1.0** (évite "failed to create plan").
+5. **controller** lent et tolérant : `max_vel_x 0.12`, `xy_goal_tolerance 0.35`.
+
+La logique est testée (`test_nav2_overrides.py`, 6 tests) et validée sur le
+fichier réel du robot (aucun KeyError, valeurs correctes).
+
+## Pré-requis (dans l'ordre)
+
+1. **Batterie ≥ 12 V** (sinon moteurs capricieux). Vérifier sur la page Réparation
+   ou `ros2 topic echo /battery --once`.
+2. Lien STM32 OK : `YB_Node` présent (page Réparation = tout vert).
+3. Dans le container `m3pro` :
+   - `base_bringup` lancé (odom + EKF + TF `odom->base_link`).
+   - `slam.launch.py` lancé → `scan_restamper` (/scan_multi→/scan_fixed) + slam_toolbox.
+   - Vérifier que **TF `map->odom`** existe et que **`/map`** publie :
+     `ros2 topic hz /scan_fixed` (~7 Hz) · `ros2 topic echo /map --once`.
+
+## Lancement Nav2
+
+```bash
+# dans le container m3pro, env ROS_DOMAIN_ID=30 + FASTDDS_BUILTIN_TRANSPORTS=UDPv4
+ros2 launch roblaude_nav nav2_slam_roblaude.launch.py
+```
+
+Vérifier que les nodes montent et passent **active** :
+```bash
+ros2 node list | grep -E "controller_server|planner_server|bt_navigator|behavior_server"
+ros2 lifecycle get /planner_server   # -> active
+```
+
+## Test progressif (NE PAS sauter d'étape)
+
+**Étape 1 — goal très court, zone blanche connue (~0,5 m devant).**
+Envoyer un goal proche, dans une zone déjà cartographiée et libre :
+```bash
+ros2 topic pub --once /goal_pose geometry_msgs/PoseStamped \
+  "{header: {frame_id: 'map'}, pose: {position: {x: 0.5, y: 0.0, z: 0.0}, orientation: {w: 1.0}}}"
+```
+- Surveiller : `ros2 topic echo /cmd_vel` (le robot doit avancer doucement),
+  les logs `bt_navigator` (pas de `ABORTED`), pas de `failed to create plan`.
+- **Garder la main sur l'arrêt d'urgence** (bouton page mission / `cmd/emergency-stop`).
+
+**Étape 2 — goal moyen (1–2 m) dans la même zone.** Même surveillance.
+
+**Étape 3 — point nommé court** (ex. un point proche défini en base), puis
+seulement après succès : **Accueil / Bureau**.
+
+## Si ça re-`ABORTED`
+
+- `ros2 topic echo /plan --once` : un plan est-il produit ? (sinon = planner)
+- Drops `Message Filter` dans les logs costmap → vérifier `/scan_fixed` à ~7 Hz et
+  la TF `odom->base_link` (EKF) bien présente.
+- `GridBased failed to create plan` malgré tolérance 1.0 → goal probablement dans
+  l'inconnu/obstacle : viser plus court, en zone blanche.
+- Augmenter au besoin `stamp_offset` du restamper (`-p stamp_offset:=0.3`).
+
+## Rollback
+
+Le launch ne modifie rien de façon permanente (il génère un YAML temporaire à
+chaque run). Pour revenir au comportement par défaut : ne pas lancer ce launch.

--- a/docs/DETTE.md
+++ b/docs/DETTE.md
@@ -1,0 +1,97 @@
+# Dette technique RobLaude — à ne pas oublier
+
+> Fichier mémo local (non commité, jamais sur `dev` ni `main`).
+> Mis à jour le 2026-06-17 **après consolidation des branches** (#265/#266/#267 mergées sur `dev`).
+> Règle : ne tracer ici que ce qui reste VRAIMENT ouvert. Chaque item = une action claire.
+
+---
+
+## 0. RÉSOLU le 2026-06-17 (ne plus en parler)
+
+- ✅ `fix/explore-tf-drops` (fix `scan_restamper`) — **mergée #265**, plus aucun commit local-only.
+- ✅ `feat/uc02-robot` (détecteur, IK, **pince `/arm_joint` id=6**, caméra DaBai, autostart) — **mergée #266**. `dev` peut maintenant être déployé sur le robot **sans régresser UC-02**.
+- ✅ `feat/uc02-graspobject-color` (migration `GraspObject.color`) — **mergée #267**. La colonne a enfin sa migration Prisma (≠ `Annotation.color`).
+- ✅ Branches mortes supprimées : `feat/arm-control-camera-live` (absorbée #255), `fix/web-bugs-257-258` (vide), worktrees retirés, `stash@{0}` (paho-mqtt, déjà sur `dev`) droppé.
+
+---
+
+## 0bis. SESSION 2026-06-19 (investigations + doc)
+
+- ✅ **Doc consolidée** : `docs/architecture.md` créé = **source canonique unique**. `AGENTS.md` + `CODEX_BRIEFING.md` fusionnés dedans (réduits à des pointeurs). Fin de la divergence « 4 docs mémoire ».
+- ✅ **Capteurs sains [PROUVÉ]** : sous mouvement réel, chaîne LiDAR (`/scan0,1`/`/scan_multi`/`/scan_fixed` ~7 Hz) + `/odom` tiennent, 0 trou, 0 « queue full ». Le « gel SLAM / scan silent » des sessions passées = **contact USB LiDAR intermittent, réglé par recâblage**. Plus un bug logiciel.
+- ✅ **Bras** : bus servo recâblé → le bras bouge (HOME + mono-servo). STM32 exécute bien (buzzer/LEDs répondent). « Ne tient pas la pose » = batterie/couple ou contact marginal **[DÉDUIT, à reconfirmer batterie chargée]**.
+- ✅ **Règle rigueur** ajoutée au `CLAUDE.md` global (standard 1+1=2, étiqueter PROUVÉ/DÉDUIT/SUPPOSÉ, isoler la variable avant d'agir, anti-tunnel).
+
+### Objectif produit visé : SCAN auto → repérer objet (QR) → grasp → retour base
+- **80 % existe déjà** (rapport d'exploration 2026-06-19) : détection 3D, IK bras, séquence saisie/dépôt, navigation pickup→destination, points en DB (`Point`/`GraspObject`), contrat MQTT. Le « retour base » = un `toPoint` fixe.
+- **Manque** : (a) **détecteur QR** dans `object_detector.py` (aucun code QR/ArUco aujourd'hui), (b) vérif identité `objectId` vs ID lu du QR, (c) état **SCAN/recherche** (le robot ne sait pas encore *chercher* un objet de position inconnue), (d) point **base** dédié. Conception en cours.
+
+### ⏳ PAS FAIT au 2026-06-19 (à faire — ordre = spec UC03 §7)
+- [ ] **Fix `mqtt_bridge` CPU** : seulement diagnostiqué, **pas appliqué** (slam /tf 50→20 Hz + lookup TF 5 Hz). Prérequis dur pour l'automap+caméra.
+- [ ] **Vérif `/tf`** (injection 50/20 Hz → mesure CPU) : **interrompue**, à reprendre pour prouver la magnitude.
+- [ ] **UC-03 (QR → fetch → base)** : **spec écrite** (`docs/UC03_SCAN_FETCH_QR.md`), **0 ligne de code**. Étape 1 = détecteur QR (hors-ligne).
+- [ ] **Bras « ne tient pas la pose »** : à reconfirmer **batterie chargée** (couple/contact).
+- [ ] **Automap bout-en-bout** : pas validé (Nav2 timeout sous charge tant que le cœur n'est pas libéré).
+
+---
+
+## 1. Dette working tree `dev` (local, hors PR)
+
+- **Suppressions non commitées** : `robot/scripts/start_all.sh`, `robot/scripts/start_robot.sh` (« redondants », `CODEX_BRIEFING.md` §10).
+  → Trancher dans une branche `chore/scripts-cleanup` : committer la suppression ou `git checkout --` pour annuler.
+- **Nouveaux docs à committer** : `docs/architecture.md` (**NOUVEAU**, source canonique), `AGENTS.md` + `CODEX_BRIEFING.md` (réduits à des pointeurs), `.codex/`, `AUDIT_REPORT.md`, `docs/CHECKPOINT.md`, `docs/DETTE.md`, `docs/ROBOT.md`.
+  → Décider : committer (doc projet) ou `.gitignore`. **Ne pas mettre sur `main`.**
+- **Branches distantes hors périmètre à auditer** (non touchées) : `origin/docs/technique`, `origin/fix/position-ws-broadcast`, `origin/test/frontend-coverage`, `origin/test/wcag-audit`.
+
+---
+
+## 2. Dette hardware / robot
+
+### ✅ RÉSOLU — bras : `/arm6_joints` fonctionne (testé 2026-06-17, câble STM32 neuf)
+Les deux canaux actionnent le bras. **Canal retenu = `/arm6_joints` (batch, méthode A)** — il fait exactement la pose voulue, c'est celui qu'utilise déjà `mission_executor._send_arm` (`mission_executor.py:413`) + le bridge → **rien à corriger pour UC-02**. (`/arm_joint` single-servo marche aussi, mais on standardise sur `/arm6_joints`.)
+- **Faux négatif du matin expliqué** : le test `/arm6_joints` sans mouvement venait du **câble USB STM32 en train de lâcher** (coupure totale ensuite). Quand le STM32 est sain, `/arm6_joints` marche.
+- **Leçon** : bras/batterie/moteurs muets → vérifier D'ABORD le lien STM32 (`lsusb 10c4:ea60`, `/dev/myserial`, `/battery`). Cf `docs/ROBOT.md` §6bis.
+
+### Reste
+- **Batterie / chargeur** : ✅ **12.2 V au 2026-06-17** (a enfin chargé) → mouvement débloqué. Garder l'œil (règle « ≥12 V » = convention `AGENTS.md:122`, pas de garde-fou code).
+- **`/cmd_vel`** : ✅ **sain** (vérifié 2026-06-17 : 0 message au repos ; `mqtt_bridge` = téléop/deadman, `mission_executor` = emergency only). Pas de fix nécessaire.
+- **Pince `/arm_joint` id=6** : ✅ **validée en réel** (open/close) → anomalie #1 levée.
+- **Calibration bras 3D (mirror #264)** : conversion `rad=(deg-90)·π/180` uniforme (`web/frontend/src/lib/armUrdf.ts`), à recaler par joint contre le bras physique. Pince non mappée dans le 3D (URDF 2 doigts rlink/llink).
+- **Mode mapping léger** : ✅ validé en session 2026-06-17. Carte `roblaude_map` sauvée sur robot + Mac (`312 x 261`, `0.05 m/px`, origine `[-8.21, -8.72]`, soit ~15.6 x 13 m). À industrialiser (mode `mapping` vs `full` dans l'autostart).
+- **Nav2 sans `explore_lite`** : ✅ lancé en mode SLAM live, sans goal mouvement. Nodes `controller_server`, `planner_server`, `bt_navigator`, `behavior_server`, `smoother`, `velocity_smoother`, `lifecycle_manager` OK ; costmaps global/local OK ; `/navigate_to_pose` disponible. Le Nano tient ce mode sans `explore_lite`.
+- **Autonav réelle** : premier retour A a échoué en session 2026-06-17. Cause observée : drops TF/scan dans les costmaps + `GridBased failed to create plan with tolerance 0.50`. Fix préparé côté repo : `robot/roblaude_nav/launch/nav2_slam_roblaude.launch.py` génère des params Nav2 adaptés (`global_costmap` sans obstacle live, `local_costmap` sur `/scan_fixed`, vitesses basses, tolerance planner 1.0). À tester batterie rechargée.
+
+---
+
+## 3. Dette logicielle connue (à revérifier sur `dev` actuel)
+
+- **`mqtt_bridge` >100 % CPU — CAUSE TROUVÉE 2026-06-19 [PROUVÉ]** : ce n'est **PAS** le broker absent (broker connecté = TCP ESTABLISHED). Le CPU est **piloté par les messages** (0 % topics silencieux ↔ ~120 % topics actifs), brûlé dans l'exécuteur rclpy (`wait_for_ready_callbacks`), pas paho/DDS. ~17 souscriptions sur un `SingleThreadedExecutor` inondées en automap (slam publie `/tf` à 50 Hz). Détail complet + chaîne de preuves : `docs/architecture.md` §9.3.
+  - **VÉRIF préalable [EN COURS]** : injection `/tf` synthétique à 50/20 Hz → mesure CPU `mqtt_bridge`, pour passer la magnitude de DÉDUITE à PROUVÉE (test interrompu, à reprendre).
+  - **FIX à appliquer (après vérif)** : (1) slam `transform_publish_period` 0.02→0.05 (50→20 Hz). (2) `mqtt_bridge` : remplacer la souscription `/tf` brute par un **lookup TF périodique à 5 Hz** (préserve la pose web sans inonder l'exécuteur). Re-mesurer le CPU pendant l'automap pour valider. `robot_state_publisher` ~49 % = même famille, secondaire.
+- **`Infinity` dans le JSON du scan** (`telemetry/scan`) — sanitiser `inf`→`null` (probablement `ranges` LaserScan).
+- **#257 — `/mapping` écran noir sans WebGL** : error-boundary OK dans un vrai navigateur, à durcir pour la démo (machine sans GPU).
+
+---
+
+## 4. Docs & tickets
+
+- **Docs périmées** : `STATUS.md`/journaux décrivaient Sprint 3-4 alors que le code est à Sprint 7 (`AUDIT_REPORT.md` §6). `STATUS.md` mis à jour le 2026-06-17.
+- **Tickets GitHub** : 116 fermés / 72 ouverts. Ouverts surtout Sprint 8 (16, hardware), Sprint 9 (15, soutenance), Sprint 6 (14), Sprint 7 (13). Beaucoup non clôturables sans présentiel robot.
+
+---
+
+## 5. [MANQUANT] — à fournir par Wissem (cf `docs/ROBOT.md`)
+
+- **Hostname** robot dans le repo (observé `jetson-desktop`, non sourcé).
+- **Seuil batterie de blocage réel** voulu (aucun garde-fou code aujourd'hui).
+- **Carte seed de navigation** versionnée (`web/backend/maps/` = `.gitkeep` seul).
+- *(Résolu)* ~~Canal pince~~ → `/arm_joint` id=6, désormais sur `dev` (#266).
+
+---
+
+## Ordre de traitement suggéré
+
+1. **Jour robot (batterie OK)** : lancer `slam.launch.py`, puis `nav2_slam_roblaude.launch.py`, tester un goal très court en zone blanche, puis seulement ensuite un point `Accueil`/`Bureau`.
+2. **Branche `chore/git-cleanup`** : trancher untracked + scripts supprimés (§1). Jamais sur `main`.
+3. **Audit séparé** des 4 branches remote hors périmètre (§1).
+4. **Soutenance (Sprint 9)** : slides, script démo, secours vidéo.

--- a/docs/DIFFICULTES_ROBOT.md
+++ b/docs/DIFFICULTES_ROBOT.md
@@ -1,0 +1,249 @@
+# Les difficultés rencontrées avec le robot RobLaude — et comment on les a résolues
+
+> Robot : Yahboom ROSMASTER M3 PRO sur Jetson Nano (ROS 2 Humble).
+> Document pensé pour être lu à voix haute en soutenance : chaque problème =
+> **ce qu'on voyait → la vraie cause → ce qu'on a fait**.
+
+---
+
+## Vue d'ensemble : par où passe l'information
+
+```
+   [ Front React ]  --REST/WebSocket-->  [ Backend Node ]  --MQTT-->  [ Robot ]
+        PWA                                  Express/Prisma            Jetson Nano
+                                                  |                       |
+                                                  |  SSH (admin)          | micro-ROS (série)
+                                                  +---------------------> [ STM32 ]
+                                                                          base : moteurs,
+                                                                          batterie, bras
+```
+
+Trois canaux, trois familles de pannes :
+1. **Front ↔ Back** : REST + WebSocket (temps réel).
+2. **Back ↔ Robot** : MQTT (commandes + télémétrie) + SSH (admin/diag).
+3. **Jetson ↔ STM32** : micro-ROS sur un câble série USB. **C'est ici qu'on a eu
+   le plus de mal.**
+
+---
+
+## A — Liaison Jetson ↔ STM32 (le gros morceau)
+
+### A1. Le STM32 "ne répondait plus" — bras/batterie/moteurs muets
+
+**Ce qu'on voyait :** l'agent micro-ROS démarrait (`running... fd: 3`) puis plus
+rien. Pas de `YB_Node`, `/battery` muet, `/cmd_vel` sans abonné. Le bras ne
+bougeait pas, la batterie ne remontait pas.
+
+**Fausse piste :** "c'est le câble / le hub / l'alim". On a même remplacé le câble.
+Le problème revenait.
+
+**La vraie cause :** il y a **DEUX** adaptateurs USB-série sur le robot, et on
+pointait sur le mauvais.
+
+```
+            /dev/ttyUSB0   ──►  CP2104  (10c4:ea60)  = STM32  ✅ le bon
+   Jetson
+            /dev/ttyUSB1   ──►  CH340   (1a86)        = micro  ❌ pas le STM32
+
+   L'agent micro-ROS ouvrait le CH340 (le micro) au lieu du CP2104 (le STM32).
+   -> port valide, mais personne ne parle micro-ROS au bout -> aucune session.
+```
+
+En plus, l'ordre `ttyUSB0/ttyUSB1` **change à chaque démarrage**, donc viser un
+numéro fixe était condamné à échouer un jour sur deux.
+
+**Comment on a résolu :**
+- Un script qui lie `/dev/myserial` à la **puce** du STM32 (CP210x), jamais au
+  numéro `ttyUSB`, jamais au CH340.
+- L'agent micro-ROS lancé en **service systemd** (redémarre tout seul).
+- **Preuve** : en pointant sur le CP2104, session établie immédiatement +
+  `YB_Node` présent + `/battery` à 10,5 V. Le STM32 était sain depuis le début.
+
+### A2. On rediagnostiquait la même panne à chaque fois
+
+**Ce qu'on voyait :** à chaque incident, on repartait de zéro (SSH, dmesg, etc.).
+
+**La cause :** rien ne surveillait la *vraie* santé (juste "le process tourne"),
+et aucune trace n'était gardée.
+
+**Comment on a résolu :** un **healthcheck** (toutes les 2 min) qui vérifie
+`YB_Node` + `/battery`, **capture le diagnostic** dans `/var/log/roblaude/` à
+chaque incident, puis **répare tout seul** (relink + restart). Testé en cassant
+le lien volontairement : détecté → réparé en quelques secondes.
+
+### A3. Débit série à 2 Mbaud sur puce CH340 = fragile (note)
+
+Le débit micro-ROS est figé à **2 000 000 baud**. Sur une puce CH340 c'est la
+limite haute (peu de marge → trames corrompues). Sur le CP2104 (le vrai STM32)
+c'est fiable. Conclusion : **garder le STM32 sur le CP2104**, ne jamais essayer
+de faire parler micro-ROS au CH340.
+
+---
+
+## B — Démarrage & persistance du robot
+
+### B1. L'IP du robot change tout le temps (DHCP)
+
+**Problème :** le réseau de l'école donne une IP différente à chaque fois → on ne
+savait plus où joindre le robot.
+
+**Solution :** `find_robot.sh` scanne le réseau et retrouve le robot par son
+**adresse MAC** (fixe), pas par IP.
+
+### B2. Le Jetson perd l'heure à chaque extinction
+
+**Problème :** le Jetson Nano n'a **pas d'horloge interne (RTC)**. Au rallumage,
+date fausse → SLAM rejette les scans (timestamps incohérents), certificats/logs
+faux.
+
+**Solution :** `fake-hwclock` (mémorise la dernière heure) + `sync_time.sh` qui
+repousse l'heure depuis le Mac à chaque session. NTP est bloqué par le réseau
+école, d'où le palliatif.
+
+### B3. L'autostart d'origine était fragile
+
+**Problème :** au boot, un terminal graphique lançait un script qui supposait que
+`/dev/myserial` existait déjà — souvent faux → "Serial port not found".
+
+**Solution :** remplacé par un **service systemd** propre qui attend le bon
+device, crée le lien, lance l'agent et le relance s'il tombe.
+
+### B4. SSH qui coupe juste après le démarrage
+
+**Ce qu'on voyait :** `kex_exchange_identification: Connection reset` quelques
+minutes après le reboot.
+
+**La cause :** le Jetson **sature au boot** (Docker + containers ROS + agent qui
+démarrent tous en même temps sur 4 Go de RAM) → SSH refuse temporairement.
+
+**Solution / contournement :** attendre ~90 s que le boot se calme ; éviter de
+tout lancer en même temps. (Piste d'amélioration : étaler les démarrages.)
+
+---
+
+## C — Capteurs & navigation
+
+### C1. SLAM qui décroche : "queue full"
+
+**Ce qu'on voyait :** le SLAM laissait tomber des scans ("message filter
+drops"), pas de carte.
+
+**La cause :** les timestamps du LiDAR/odométrie venaient du STM32 (horloge non
+synchro) → SLAM les jugeait "trop vieux" et les jetait.
+
+**Solution :** un node `scan_restamper` re-tamponne `/scan` et `/odom` à
+`maintenant - 0,2 s` → les scans repassent le filtre temporel. Fin des drops.
+
+### C2. Navigation autonome qui s'annule (ABORTED)
+
+**Ce qu'on voyait :** premier objectif accepté puis `ABORTED`, avec
+`GridBased failed to create plan` et des drops de costmap.
+
+**La cause :** la config Nav2 par défaut était trop stricte pour notre carte/Nano
+(obstacles live bruités, tolérance planner trop faible).
+
+**Solution (préparée) :** un launch Nav2 sur-mesure
+(`nav2_slam_roblaude.launch.py`) : costmap allégée, scan fixe, vitesses réduites,
+tolérance planner augmentée. À valider sur un objectif court.
+
+### C3. `explore_lite` trop lourd pour le Nano
+
+**Constat :** le Jetson Nano tient `SLAM + Nav2`, mais l'exploration autonome
+(`explore_lite`) le met à genoux.
+
+**Solution :** cartographie en **mode léger** (base + SLAM + téléop clavier +
+sauvegarde de carte), exploration auto mise de côté.
+
+### C4. Le LiDAR sort 2 demi-scans
+
+**Détail matériel :** le M3 PRO publie `/scan0` + `/scan1` (deux moitiés) qu'il
+faut fusionner en `/scan`. Géré par le merger laser.
+
+---
+
+## D — Bras & pince
+
+### D1. Le bras n'a aucun retour de position (open-loop)
+
+**Problème :** `/joint_states` publie `0.0` partout — impossible de lire la vraie
+position du bras (pas de capteur de retour).
+
+**Conséquence + solution :** côté front, le bras 3D est en **"mode miroir"** : il
+rejoue la dernière commande envoyée (on affiche ce qu'on a demandé, pas une
+mesure réelle). Honnête et suffisant pour la démo.
+
+### D2. La convention de la pince était inversée
+
+**Problème :** la doc du prof disait l'inverse de la réalité → la pince
+s'ouvrait/fermait au mauvais moment.
+
+**Solution :** convention vérifiée physiquement et figée :
+`pince = servo id 6`, **0 = fermé, 180 = ouvert**. Espaces YAML obligatoires
+(`{id: 6, joint: 180}`), sinon la commande est ignorée en silence.
+
+### D3. `YB_Node` plante sous rafales de commandes
+
+**Problème :** envoyer beaucoup de `ros2 topic pub` d'affilée fait crasher le
+driver (`YB_Node`), qui pilote les servos ET publie la batterie → tout devient
+muet.
+
+**Solution / règle :** commandes en `--once`, jamais en boucle ; rebooter avant
+une session de test bras. (C'est ce crash qui faisait passer des commandes
+correctes pour des "échecs".)
+
+---
+
+## E — Énergie
+
+### E1. Batterie faible = comportements bizarres
+
+**Règle apprise :** sous ~12 V, les moteurs/servos deviennent capricieux. On vise
+**≥ 12 V avant tout mouvement**. (Ce n'est pas un blocage logiciel, c'est une
+règle humaine — la batterie était à 10,5 V en fin de session.)
+
+---
+
+## F — Web (front/back) côté robot
+
+### F1. Deux émetteurs sur `/cmd_vel`
+
+**Problème :** `mission_executor` ET `mqtt_bridge` publient tous les deux sur
+`/cmd_vel` → conflit possible au repos (téléop vs arrêt d'urgence).
+
+**État :** identifié, à nettoyer (un seul propriétaire de `/cmd_vel`).
+
+### F2. Écran `/mapping` noir sans WebGL
+
+**Problème :** la carte plantait dans un navigateur headless sans WebGL (vu en CI
+E2E).
+
+**Solution :** error-boundary qui affiche un message au lieu d'un écran noir ; OK
+dans un vrai navigateur.
+
+---
+
+## Les 3 leçons à retenir (pour la soutenance)
+
+1. **Ne jamais accuser le matériel sans preuve.** La plus grosse panne (le STM32)
+   n'était PAS un câble — c'était un mauvais port série. On l'a prouvé en
+   pointant sur le bon device : ça a marché immédiatement.
+2. **Identifier par la nature, pas par le numéro.** `ttyUSB0/1` change au boot →
+   on cible la *puce* (CP2104). Pareil pour l'IP → on cible la *MAC*.
+3. **Rendre le système auto-diagnostiquant.** Un healthcheck qui capture le diag
+   et répare tout seul = on ne perd plus une heure à rechercher la même panne.
+```
+
+---
+
+## Annexe — où c'est dans le code
+
+| Sujet | Fichier |
+|---|---|
+| Lien série STM32 | `robot/scripts/roblaude-link-stm32.sh` |
+| Service agent micro-ROS | `robot/scripts/systemd/micro-ros-agent.service` |
+| Healthcheck + capture diag | `robot/scripts/roblaude-stm32-healthcheck.sh` |
+| Recherche robot par MAC | `robot/scripts/find_robot.sh` |
+| Sync horloge | `robot/scripts/sync_time.sh` |
+| Re-stamp SLAM | `robot/roblaude_nav/roblaude_nav/scan_restamper.py` |
+| Nav2 sur-mesure | `robot/roblaude_nav/launch/nav2_slam_roblaude.launch.py` |
+| Bridge MQTT | `robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py` |

--- a/docs/ROBOT.md
+++ b/docs/ROBOT.md
@@ -1,0 +1,247 @@
+# ROBOT.md — Faits robot RobLaude (sourcés)
+
+> Généré le 2026-06-17. Doc **uniquement factuel** : chaque ligne porte sa source `fichier:ligne`
+> ou la commande git exacte. `[MANQUANT]` = non trouvé dans le repo. `[DÉDUIT]` = inféré, à confirmer.
+> État du repo : branche `dev`. Le travail UC-02 robot vit sur des branches non mergées (§8).
+
+---
+
+## 0. État des sources
+
+- **Avant ce fichier, pas de doc robot canonique unique** : le savoir etait eparpille entre
+  `robot/README.md`, `robot/docs/explore-stack.md`, `robot/CLAUDE.md`, `AGENTS.md`,
+  `CODEX_BRIEFING.md`, `docs/STATUS.md`, `docs/CHECKPOINT.md`, `docs/journal/*` et
+  `docs/DETTE.md`.
+- Docs robot existants :
+  - `robot/README.md` (87 lignes, **tracké**) — sections : stack, roblaude_nav, launch, nodes, scripts, notes matérielles.
+  - `robot/docs/explore-stack.md` (156 lignes, **tracké**).
+  - `robot/CLAUDE.md` (62 lignes, **non tracké**).
+  - `AGENTS.md` + `CODEX_BRIEFING.md` (racine, **non trackés**) — briefings robot détaillés mais hors git.
+- Verdict : doc robot **partiel et dispersé**, en partie hors git.
+
+---
+
+## 1. Accès robot
+
+- **User SSH** : `jetson` — `robot/scripts/connect.sh:9`, `robot/scripts/sync_time.sh:20`, `robot/scripts/deploy_to_robot.sh:23` (`ROBOT_USER="${ROBOT_USER:-jetson}"`).
+- **Password SSH** : `yahboom` — `robot/scripts/connect.sh:27`, `robot/scripts/sync_time.sh:21` (`ROBOT_PASS="${ROBOT_PASS:-yahboom}"`).
+- **IP** : **non fixe** — résolue dynamiquement par MAC. `robot/scripts/find_robot.sh:19` : `ROBOT_MAC="${ROBOT_MAC:-50:3d:d1:ff:f3:7d}"`. Un exemple d'IP figure en commentaire (`sync_time.sh:13` : `10.10.220.109`) — **exemple, pas l'IP réelle**.
+- **MAC Jetson** : `50:3d:d1:ff:f3:7d` — `robot/scripts/find_robot.sh:19`.
+- **noVNC** : port `6080` — `robot/scripts/connect.sh:24`.
+- **Hostname** : `[MANQUANT dans le repo]` — observé en session via `hostname` = `jetson-desktop`, mais non présent dans un fichier du repo.
+- **Registry Docker privé** : `192.168.2.51:5000` — `robot/scripts/Docker_M3Pro_Joy.sh:69`, `robot/scripts/start_agent.sh:8`.
+- **Image container ROS** : `192.168.2.51:5000/rosmaster-m3pro-nano:1.1.0` — `Docker_M3Pro_Joy.sh:69`.
+- **Image micro-ROS agent** : `192.168.2.51:5000/micro-ros-agent:humble` — `start_agent.sh:8`.
+- **Bind-mounts** (hôte → container) — `Docker_M3Pro_Joy.sh` :
+  - `/home/jetson/roblaude_ws` → `/root/roblaude_ws` (`:62`)
+  - `/home/jetson/robot_maps` → `/root/maps` (`:63`)
+  - `/home/jetson/.local` → `/root/.local` (`:64`)
+- **Fichier IP broker côté robot** : `/etc/roblaude/broker_ip`, écrit par `sync_time.sh:69`.
+
+---
+
+## 2. Stack ROS2
+
+- **Distro** : `humble` — `container_autostart.sh:43` (`source /opt/ros/humble/setup.bash`), `deploy_to_robot.sh:79`, `start_agent.sh:8`.
+- **Packages présents sur `dev`** (tous `ament_python`) :
+  - `roblaude_nav` v`0.1.0` — `robot/roblaude_nav/package.xml:4-5`, build_type `:36`.
+  - `roblaude_mqtt` v`0.1.0` — `robot/roblaude_mqtt/package.xml:4-5`, build_type `:29`.
+- **`roblaude_pickplace` : ABSENT de `dev`** — présent uniquement sur `feat/uc02-robot` (§8). Source : `git ls-tree -r dev` → 0 fichier ; `git ls-tree -r feat/uc02-robot` → 15 fichiers.
+- **Nodes (console_scripts)** :
+  - `roblaude_mqtt` : `mqtt_bridge` — `robot/roblaude_mqtt/setup.py:29`.
+  - `roblaude_nav` : `scan_restamper`, `odom_to_tf`, `mission_executor`, `initial_rotation`, `mapping_supervisor` — `robot/roblaude_nav/setup.py:29-33`.
+- **Launch (`roblaude_nav/launch/`)** : `camera`, `explore`, `foxglove`, `lidar`, `nav2`, `odom`, `slam`, `teleop`, `tf2_static`, `web_video` (`.launch.py`) — listés par `find`.
+- **Launch (`roblaude_mqtt/launch/`)** : `mqtt_bridge.launch.py`.
+- **Topics réels du bridge** (`roblaude_mqtt/mqtt_bridge.py`) :
+  - Sub : `/odom` (`:204`), `/battery` (`:207`), `/map` (`:223`), `/scan_multi` (`:224`), `/plan` (`:225`), `/explore/frontiers` (`:226`), `/tf` (`:227`), caméra compressée (`:235`), `JointState` (`:236`).
+  - Pub : `/arm6_joints` (`:191`), `/cmd_vel` Twist (`:242`), `/mqtt/cmd/mapping` (`:243`).
+
+---
+
+## 3. Réseau / env ROS
+
+- **`ROS_DOMAIN_ID=30`** : **PROUVÉ** —
+  - `robot/scripts/container_autostart.sh:24` : `export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-30}"`
+  - `robot/scripts/Docker_M3Pro_Joy.sh:57` : `-e ROS_DOMAIN_ID=30`
+  - `robot/roblaude_nav/roblaude_nav/odom_to_tf.py:16` (commentaire export).
+- **`FASTDDS_BUILTIN_TRANSPORTS=UDPv4`** : **PROUVÉ** —
+  - `container_autostart.sh:25` : `export FASTDDS_BUILTIN_TRANSPORTS="${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}"`
+  - `Docker_M3Pro_Joy.sh:58` : `-e FASTDDS_BUILTIN_TRANSPORTS=UDPv4`.
+- **Broker MQTT (defaults bridge)** : `broker_host: "localhost"`, `broker_port: 1883`, `robot_id: 1`, `mqtt_user: ""` — `robot/roblaude_mqtt/config/mqtt_bridge.yaml:5-8`.
+
+---
+
+## 4. Déploiement — `robot/scripts/deploy_to_robot.sh`
+
+Étapes prouvées (numéros de ligne du script) :
+1. Source `find_robot.sh` pour obtenir l'IP par MAC — `:21`.
+2. Flag `--no-build` = deploy sans build — `:29`.
+3. `rsync` des packages vers `/home/jetson/roblaude_ws` (`WS_HOST` `:25`), `--delete-after`, exclut `.git`/`build`/`install`/`log` — `:58-60`.
+4. `rsync` des scripts — `:68`.
+5. `colcon build --symlink-install` **dans le container**, après `source /opt/ros/humble/setup.bash` + `source /root/yahboomcar_ws/install/setup.bash` — `:79-82`.
+6. Le workspace est visible dans le container via bind-mount — `:89`.
+
+---
+
+## 5. Démarrage / arrêt — `robot/scripts/container_autostart.sh`
+
+- Pose `ROS_DOMAIN_ID=30` + `FASTDDS_BUILTIN_TRANSPORTS=UDPv4` — `:24-25`.
+- Source `/opt/ros/humble/setup.bash` — `:43`.
+- Lance (`spawn_once`) :
+  - `base_bringup` : `ros2 launch M3Pro_navigation base_bringup.launch.py` — `:85`.
+  - `mqtt_bridge` (si build présent) — `:99`.
+  - `mission_executor` (si build présent) — `:109`.
+- **`slam_toolbox` désactivé dans l'autostart** : commenté avec la note « slam_toolbox bloque "queue full" -> pas de mapping. On le coupe. » — `:93-94`.
+- Arrêt propre : `trap` SIGTERM/INT qui `pkill` les enfants — `:119`.
+- **[DÉDUIT — à confirmer]** : sur le robot en session, `object_detector` + caméra **tournaient** (snapshot process `…/roblaude_pickplace/lib/roblaude_pickplace/object_detector`), alors que cet autostart de `dev` ne les lance PAS. → Le robot exécute une version d'autostart issue de `feat/uc02-robot` (§8), pas celle de `dev`.
+
+---
+
+## 6. Sécurité (batterie, env, /cmd_vel)
+
+- **Bornes batterie (code)** : `BATTERY_EMPTY_V = 10.0`, `BATTERY_FULL_V = 12.6` — `robot/roblaude_mqtt/mqtt_bridge.py:94-95`. Ce sont les bornes d'**interpolation du pourcentage**, pas un seuil de blocage.
+- **Topic `/battery`** : `Float32` (YB_Node) — `mqtt_bridge.py:207`.
+- **Seuil « ≥12 V avant mouvement »** : **[DÉDUIT / convention documentée — PAS un seuil dans le code]**
+  - `AGENTS.md:122` : « ≥12 V = sain ».
+  - `CODEX_BRIEFING.md:193` : « Vérifier la batterie avant tout mouvement (`/battery`, viser ≥12 V) ».
+  - → Aucune ligne de code n'empêche le mouvement sous 12 V. C'est une **règle humaine**, pas un garde-fou logiciel. (Ces deux fichiers sont **non trackés**.)
+- **`/cmd_vel` à 2 publishers** : **PROUVÉ** — `mission_executor.py:53` ET `mqtt_bridge.py:242` créent chacun un publisher Twist sur `/cmd_vel`. Conflit possible au repos.
+- **`ROS_DOMAIN_ID=30` + `FASTDDS=UDPv4` obligatoires** : voir §3 (prouvé). Conséquence « sinon les commandes n'atteignent pas le STM32 » = documentée (`AGENTS.md`), pas dans le code.
+
+### 6bis. Bras — canaux d'actionnement (RÉSOLU — testé 2026-06-17, câble STM32 neuf)
+
+**Les DEUX canaux actionnent le bras** (observé en session, STM32 sain) :
+- `/arm6_joints` (`arm_msgs/ArmJoints`, batch — **canal Yahboom officiel**) : pose complète joints 1-5 → **bouge** ✅. C'est le canal utilisé par `mission_executor._send_arm` (`mission_executor.py:413`) + le bridge → **OK pour UC-02**.
+- `/arm_joint` (`arm_msgs/ArmJoint`, single-servo) : pince id=6 (0=ouvert / 180=fermé) **et** joints id=1..5 → **bougent** ✅.
+- `YB_Node` est abonné aux deux topics (quand le STM32 est connecté).
+
+→ **Canal standard retenu : `/arm6_joints` (méthode A)** — fait exactement la pose voulue, déjà câblé dans `mission_executor`/bridge. (`/arm_joint` = utile pour la pince et le debug single-servo.)
+
+**⚠️ LEÇON (important)** : un test `/arm6_joints` plus tôt le même jour n'avait **rien bougé** → c'était un **FAUX NÉGATIF**. En réalité le **câble USB du STM32 était en train de lâcher** (il a complètement coupé peu après : kernel « Cannot enable. Maybe the USB cable is bad? », `/dev/myserial` disparu, `YB_Node`/`/battery` morts). **Quand le lien STM32 est sain, `/arm6_joints` marche.**
+→ **Règle de diag** : si le bras (ou la batterie, ou les moteurs) ne répond pas, **vérifier D'ABORD le lien STM32** avant de soupçonner les topics :
+`lsusb | grep 10c4:ea60` · `/dev/myserial` présent · `micro_ros_agent` « session established » · `/battery` publie · `YB_Node` dans `ros2 node list`.
+
+---
+
+## 7. Diagnostic (outils présents dans le repo)
+
+- **`robot/scripts/find_robot.sh`** : retrouve l'IP par MAC (scan ARP) — `:60-62`.
+- **`robot/scripts/sync_time.sh`** : sync horloge Jetson + pousse l'IP broker dans `/etc/roblaude/broker_ip` — `:44-69`.
+- **`robot/roblaude_mqtt/tools/mqtt_smoke_test.py`** : test bout-en-bout MQTT (publie/écoute `roblaude/1/telemetry/battery`, etc.) — `:140-236`.
+- Commandes ROS de diagnostic live (`ros2 node list`, `ros2 topic echo /battery --once`) : **[observées en session, non présentes comme script dans le repo]**.
+
+---
+
+## 8. Travail sur les branches non mergées (committé + poussé sauf indication)
+
+Source : `git diff --name-status dev..<branche> -- robot/` et `git grep <branche>`.
+
+### `feat/uc02-robot` — UC-02 pick&place robot (poussée sur origin)
+- **Nouveau package `roblaude_pickplace`** (15 fichiers) :
+  - Node `object_detector` — `setup.py:29`.
+  - `arm_kin.py` (IK bras → publie `/arm6_joints`, `package.xml:10`), `color.py`, `detection.py`.
+  - Config `detection_params.yaml` : `target_color: "#ff0000"` par défaut — `:14`.
+  - Topics `object_detector.py` : sub images color/depth/info + `/roblaude/target_color` (`:88`) ; pub `/roblaude/detections` PoseArray (`:90`) + `/roblaude/detection_image` (`:92`).
+  - Launch `pickplace.launch.py` + tests (`test_arm_kin`, `test_color`, `test_detection`).
+- **Modifie** : `roblaude_nav/launch/camera.launch.py`, `roblaude_nav/package.xml`, `roblaude_nav/mission_executor.py`, `scripts/Docker_M3Pro_Joy.sh`, `scripts/container_autostart.sh`, `robot/README.md`.
+
+### `fix/explore-tf-drops` — fix SLAM (commit `2117dc1`, **NON poussée**)
+- **Modifie** `robot/roblaude_nav/roblaude_nav/scan_restamper.py` (restamp `now()-0.2s`).
+- ⚠️ Sur **aucun remote** → travail uniquement local (worktree `roblaude-mapping`).
+
+### `feat/arm-control-camera-live` — contrôle bras + caméra (poussée sur origin)
+- **Modifie** `roblaude_mqtt/mqtt_bridge.py`, `roblaude_mqtt/test/test_arm_command.py`, `scripts/fetch_urdf_from_robot.sh`.
+
+---
+
+## 9. Dette / Bugs / Risques
+
+### 9.1 Bugs confirmés (sourcés code ou session)
+- **`/cmd_vel` à 2 publishers au repos** — `mission_executor.py:53` + `mqtt_bridge.py:242`. Risque : conflit avec le téléop. (PROUVÉ)
+- **Bras open-loop** : `/joint_states` publie `0.0` sur tous les joints — **confirmé en session** (`ros2 topic echo /joint_states --once`). Impact : pose réelle illisible, d'où le « mirror mode » front (PR #264).
+- **Auth MQTT absente** : `mqtt_user: ""`, `mqtt_password: ""` — `robot/roblaude_mqtt/config/mqtt_bridge.yaml:8-9` (TODO explicite `:9` « injecter via secret »). Broker en anonyme.
+
+### 9.2 Bugs documentés — à revérifier contre le code
+- **Busy-loop 95 % CPU quand broker absent** — `CODEX_BRIEFING.md:127`, `AGENTS.md:190`. **[À CONFIRMER]** : le code `dev` a pourtant `reconnect_delay_set(min_delay=1, max_delay=30)` + `loop_start()` (`mqtt_bridge.py:275,278`) → peut-être déjà mitigé, à mesurer sur le robot.
+- **`Infinity` dans le JSON du scan** (`telemetry/scan`) — `CODEX_BRIEFING.md:128`, `AGENTS.md:191`. **[DÉDUIT]** : non localisé explicitement dans `mqtt_bridge.py` ; vient probablement des `ranges` LaserScan (valeurs `inf`) sérialisées. À sanitiser.
+- **Anomalie pince `joint6`** (open/close KO) — `docs/CHECKPOINT.md` §5 (doc). Voir aussi [MANQUANT] sur le canal pince.
+- **YB_Node crash sous rafales `ros2 topic pub`** → reboot — `AGENTS.md` (doc). Règle : `--once`, jamais de boucle.
+- **#257 — `/mapping` écran noir sans WebGL** (frontend) — observé en session (chromium headless) ; error-boundary OK dans un vrai navigateur.
+
+### 9.3 Risques / incohérences trouvés en session
+- **Autostart `dev` ≠ autostart robot** : `container_autostart.sh` de `dev` ne lance que `base_bringup` + `mqtt_bridge` + `mission_executor` (`container_autostart.sh:84-110`), tandis que la session robot du 2026-06-17 a montre camera + detector actifs et un autostart plus lourd (`docs/journal/2026-06-17_session.md:27-32`). **[DÉDUIT — à confirmer]** : le robot tourne probablement une variante issue de `feat/uc02-robot`.
+- **Travail robot hors `dev`** (§8) : `roblaude_pickplace` vit sur `feat/uc02-robot` (§8) et `scan_restamper` sur `fix/explore-tf-drops` (`git branch -vv`, `git worktree list`, `git log --branches --not --remotes`). Un déploiement naïf depuis `dev` perd ces deux briques.
+- **`fix/explore-tf-drops` (`2117dc1`) non poussé** → perte possible si disque perdu (`git log --branches --not --remotes --oneline --decorate`, `git stash list`).
+- **`GraspObject.color` est un memo obsolet** : le schema Prisma courant met `color` sur `Annotation` (`web/backend/prisma/schema.prisma:169-186`), pas sur `GraspObject` (`:51-59`). Les notes `AGENTS.md:92-93` et `docs/DETTE.md:28-30` sont donc stale sur ce point.
+- **`robot/README.md` est stale** sur la structure : il annonce `roblaude_arm`, `roblaude_vision`, `roblaude_sim` et `start_all.sh`/`start_robot.sh` (`robot/README.md:9-15`, `:71-79`), alors que le code reel suit `roblaude_nav` + `roblaude_mqtt` + `roblaude_pickplace` sur branche.
+
+### 9.4 Reste à faire (jour du robot, batterie ≥ 12 V)
+Source : `docs/DETTE.md` (synthèse de session). Items robot :
+- Recaler la **calibration bras** deg→rad par joint contre le vrai bras (HOME/Salut/Vertical) — `docs/DETTE.md` §2.
+- **Nettoyer `/cmd_vel`** : `mission_executor` publie un Twist zero sur emergency stop (`robot/roblaude_nav/roblaude_nav/mission_executor.py:53,183-188`) et `mqtt_bridge` publie aussi `/cmd_vel` pour `teleop` (`robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py:242,245-249,332-349`). Conflit reel au repos.
+- **Mode mapping léger** : validé en session 2026-06-17. Carte `roblaude_map` sauvée sur robot + Mac (`312 x 261`, `0.05 m/px`, origine `[-8.21, -8.72]`, ~15.6 x 13 m). Methode : base + `slam.launch.py` + teleop clavier → `map_saver`. Supporté par `AGENTS.md:114-115`, `robot/roblaude_nav/launch/explore.launch.py:1-14`, `robot/roblaude_nav/launch/slam.launch.py:29-33`.
+- **Nav2 sans `explore_lite`** : validé en session 2026-06-17, sans envoyer de goal. Nodes Nav2 actifs (`controller_server`, `planner_server`, `bt_navigator`, `behavior_server`, `smoother`, `velocity_smoother`, `lifecycle_manager`), costmaps global/local construites, `/navigate_to_pose` disponible. Le Nano tient `slam + nav2` ; le point lourd reste `explore_lite`.
+- **Autonav sur carte sauvée / SLAM live** : le premier goal retour A a été accepté puis `ABORTED` en session 2026-06-17. Logs observés : drops `Message Filter` côté costmaps + `GridBased failed to create plan with tolerance 0.50`. Correctif préparé : `robot/roblaude_nav/launch/nav2_slam_roblaude.launch.py` génère des params Nav2 depuis le YAML Humble installé, coupe l'obstacle live de la `global_costmap`, met la `local_costmap` sur `/scan_fixed`, ralentit les vitesses et monte la tolérance planner. Prochaine étape = tester un goal très court en zone blanche avant de retenter `Accueil`/`Bureau`.
+- **Carte figée AMCL** : toujours non câblée. `robot/roblaude_nav/launch/nav2.launch.py` reste un launch Nav2 sans `amcl` ni `map_server` (`robot/roblaude_nav/launch/nav2.launch.py:1-20`). À faire seulement après validation du replay SLAM live.
+- **Lever l'anomalie / conflit pince** : le code courant de l'API bras dit `joint6: 0 = ferme, 180 = ouvert max` (`web/backend/src/controllers/armController.ts:9-18, 40-63`), idem le frontend (`web/frontend/src/components/ArmController.tsx:7-10, 26-34`), mais `AGENTS.md:119` et `CODEX_BRIEFING.md:76` disent l'inverse. A trancher sur le robot avant toute demo bras.
+- **Nettoyer le travail local** : `robot/scripts/start_all.sh` et `robot/scripts/start_robot.sh` sont supprimes dans `dev`, avec plusieurs untracked locaux (`git status --short --branch`).
+- **Sauver le fix SLAM** : `fix/explore-tf-drops` porte `2117dc1` et n'est pas pousse (`git log --branches --not --remotes --oneline --decorate`, `git stash list`).
+
+### 9.5 Etat de fin de session
+- `dev` contient maintenant le merge PR `#264` (bras 3D miroir + proxy `/robot_assets`) : `git log` montre `2e6e9a1` sur `dev`, et `docs/journal/2026-06-17_session.md:103-114` dit la PR mergée.
+- `docs/STATUS.md:7-12` reste en mode "Sprint 3 navigation + Sprint 4 prepare" ; le journal du 2026-06-17 montre que le projet a depasse cet etat. Le status est donc partiellement stale.
+- `docs/journal/2026-06-17_session.md:21-33, 36-41, 45-64, 68-72` couvre le diagnostic read-only, la chaine MQTT Robot->Broker->Backend->Front, le fix `/robot_assets`, le mode miroir du bras, puis le fix du test #007.
+
+---
+
+## 10. Où on en est (état projet — 2026-06-17)
+
+> Source : `gh issue list`, `gh pr list`, `git log` exécutés le 2026-06-17.
+
+**Issues GitHub** : **116 fermées / 72 ouvertes** (188 total) → ~61,7 % fermées (`gh issue list --state open|closed`).
+
+Ouvertes par milestone (`gh issue list --state open --json milestone`) :
+- Sprint 8 — Tests & Hardware : **16**
+- Sprint 9 — Soutenance : **15**
+- Sprint 6 — MoveIt2 & Vision : **14**
+- Sprint 7 — UC-02 Pick & Place : **13**
+- Sprint 5 — UC-01 E2E : **7**
+- Sprint 3 — Navigation : **3** · (sans milestone) : **3** · Sprint 2 — Web MVP : **1**
+
+**PR** : **aucune ouverte**. 8 dernières mergées (`gh pr list --state merged`) :
+- `#264` 2026-06-16 — bras 3D miroir + fix proxy urdf
+- `#263` / `#262` 2026-06-15 — UC-02 front (page objets) + back (CRUD/watchdog)
+- `#261` 2026-06-15 — suite E2E mobile + UC-01 + arrêt d'urgence
+- `#260` 2026-06-15 — migrations Prisma manquantes (mapping/SSH)
+- `#256` 2026-06-15 — bras presets Yahboom · `#255`/`#254` 2026-05-22 — bras+caméra+publishers
+
+**Lecture côté robot :**
+- Mergé sur `dev` : web UC-02 (`#263`+`#262`), bras 3D + presets (`#255`/`#256`/`#264`), publishers caméra/joint_states (`#254`).
+- **Robot UC-02** (détection objet, IK bras) : **non mergé**, vit sur `feat/uc02-robot` (§8) → Sprint 7 robot pas sur `dev`.
+- ⚠️ **Désynchro issues/code** : Sprint 6 (14 open) et Sprint 7 (13 open) ont des issues ouvertes alors que du code existe (mergé ou sur branche) — cf `AUDIT_REPORT.md` §4. Beaucoup d'open Sprint 8/9 = hardware réel + soutenance, non clôturables sans présentiel robot.
+- **Dernière session** : `docs/journal/2026-06-17_session.md` (diag read-only + PR #264).
+
+---
+
+## 11. Git local utile pour le robot (2026-06-17)
+
+- **Branche courante** : `dev` = `2e6e9a1` (`origin/dev`) — PR `#264` mergée (`git branch -vv`).
+- **`feat/arm-mirror-urdf`** : branche supprimée apres merge ; ses commits sont dans `dev` (`4fb0a3c`, `82c8f54`, `3ffece3`) et la PR `#264` est fermee/mergee (`git log --oneline --decorate --graph --all -n 40`).
+- **Branches / worktrees actifs** (`git branch -vv`, `git worktree list`) :
+  - `feat/uc02-robot` (`d3c0615`, worktree `roblaude-uc02`, pousse sur `origin/feat/uc02-robot`)
+  - `feat/uc02-graspobject-color` (`32e5a73`, pousse sur `origin/feat/uc02-graspobject-color`)
+  - `fix/explore-tf-drops` (`2117dc1`, worktree `roblaude-mapping`, non pousse)
+  - `fix/web-bugs-257-258` (`507838b`, worktree `roblaude-web`, local)
+  - `feat/arm-control-camera-live` (`d1b0ed2`, pousse sur `origin/feat/arm-control-camera-live`)
+- **Commit local non pousse** : `2117dc1` (`git log --branches --not --remotes --oneline --decorate`).
+- **Stash** : `stash@{0}` = WIP persistance robot / paho-mqtt (`git stash list`).
+- **Working tree `dev`** : suppressions non commitees `robot/scripts/start_all.sh`, `robot/scripts/start_robot.sh` + untracked `.codex/`, `AGENTS.md`, `AUDIT_REPORT.md`, `CODEX_BRIEFING.md`, `docs/CHECKPOINT.md`, `docs/DETTE.md` (`git status --short --branch`).
+
+---
+
+## [MANQUANT] — à fournir par Wissem
+
+- **Hostname robot** dans le repo (observé `jetson-desktop`, non sourcé).
+- **Seuil batterie de blocage réel** : aucune valeur de garde-fou dans le code (seul « ≥12 V » documenté).
+- **Canal physique exact de la pince sur le robot** : le code API bras/front utilise `joint6` dans `/api/robots/:id/arm` et `mqtt_bridge` relaie vers `/arm6_joints`, mais la confirmation IRL du servo qui bouge reste a refaire sur robot.
+- **Carte seed de navigation** : `roblaude_map.{pgm,yaml}` existe localement apres la session 2026-06-17, mais reste a décider si elle doit être versionnée ou gardée comme artefact local.

--- a/docs/UC03_SCAN_FETCH_QR.md
+++ b/docs/UC03_SCAN_FETCH_QR.md
@@ -1,0 +1,127 @@
+# UC-03 — Explore → Découvrir (QR) → Fetch sur clic → Retour base
+
+> **Conception** (spec). Date : 2026-06-19. Source de vérité archi : `docs/architecture.md`.
+> Étiquettes : **[EXISTE]** déjà codé · **[NOUVEAU]** à créer · **[ÉTEND]** modifier l'existant.
+> Objectif produit (mots du codeur) : « le robot explore tout seul, repère les QR sur la
+> carte, me la ramène ; je clique sur un QR (ou un point) → il y va, attrape, revient base. »
+
+---
+
+## 1. Vue d'ensemble — 2 phases
+
+### Phase A — Exploration + cartographie des QR (autonome)
+Le robot explore une zone inconnue, construit la carte SLAM, et **pendant ce temps** détecte les
+QR codes : pour chaque QR vu, il lit son ID, calcule sa position **dans le repère `map`**, et
+mémorise `(qrId, x_map, y_map)`. La liste des objets découverts remonte au web → la carte affiche
+un marqueur par QR.
+
+### Phase B — Fetch sur clic (déclenché par l'utilisateur)
+Sur la carte web, l'utilisateur **clique un marqueur QR** (objet connu, coords + ID) **ou un point
+libre** (coords seules) → bouton **Fetch**. Le robot navigue vers la cible, **active la caméra à fond**,
+**reconnaît/confirme le QR** (vérifie l'ID), **attrape** l'objet, puis **revient au Point « base »**.
+
+> **Modèle caméra (refinement codeur 2026-06-19) — c'est le levier CPU :**
+> - **Pendant l'explore** : caméra à **bas débit** (2-3 Hz), juste repérer/marquer les objets sur la carte. Léger.
+> - **Au point de fetch (sur clic)** : caméra **activée à fond** pour reconnaître précisément + saisir.
+> → On **n'allume jamais** explore + SLAM + caméra-pleine-cadence + QR en même temps. Ça résout la tension §6.
+
+```
+PHASE A (auto):   explore_lite + SLAM ──┐
+                  caméra + QR detector ──┴─► (qrId, x_map, y_map) ──MQTT──► backend ──► carte web (marqueurs)
+
+PHASE B (clic):   clic marqueur/point ──► backend cmd/mission ──► robot:
+                  NAV(coords) ─► CONFIRM_QR ─► GRASP ─► NAV(base) ─► done
+```
+
+---
+
+## 2. Ce qui EXISTE déjà (rapport d'exploration 2026-06-19)
+
+- **[EXISTE]** Détection 3D objet (HSV+depth) : `object_detector.py` → `/roblaude/detections` (PoseArray), pipeline `sample_depth_median` + `backproject` (`detection.py`).
+- **[EXISTE]** IK bras `arm_kin.py` (`compute_ik`, `rad_to_servo`), séquence saisie + dépôt (`mission_executor.py`).
+- **[EXISTE]** Navigation Nav2 `/navigate_to_pose`, machine à états PICK_AND_PLACE.
+- **[EXISTE]** TF `camera → base_link → map` (donc on peut placer une détection dans `map`).
+- **[EXISTE]** DB : `Point{x,y,theta,slug}`, `GraspObject{color,locationId}`, `Mission{fromPoint,toPoint,objectId}`.
+- **[EXISTE]** Contrat MQTT mission complet (`docs/mqtt-spec.md`).
+- **[EXISTE]** Carte live web (`/map` via `mqtt_bridge` → wsTf/telemetry).
+- **[EXISTE]** Explore_lite + SLAM (la stack automap, en cours d'optimisation CPU).
+
+## 3. Ce qui MANQUE (à construire)
+
+| # | Pièce | Couche | Type |
+|---|-------|--------|------|
+| 1 | **Détecteur QR** (`cv2.QRCodeDetector`) : détecte + décode l'ID, calcule la pos 3D (réutilise le depth→3D existant), publie avec l'ID. HSV gardé en fallback. | robot | NOUVEAU |
+| 2 | **qr_mapper** : transforme chaque détection QR `camera → map` (TF), **déduplique** par ID, tient la liste `(qrId, x_map, y_map, seenAt)`, la publie en MQTT (retained). | robot | NOUVEAU |
+| 3 | **Mission FETCH** : NAV(coords) → **CONFIRM_QR** (revérifie l'ID sur place) → GRASP → NAV(**base**) → done. Réutilise PICK_AND_PLACE + ajoute confirm QR + retour base. | robot | ÉTEND |
+| 4 | **Point « base »** (slug `base`) en DB + un défaut si absent. | DB/config | NOUVEAU |
+| 5 | **Backend** : sub MQTT `telemetry/discovered_objects` → upsert DB ; modèle `DiscoveredObject{qrId,x,y,seenAt,...}` ; REST `GET /discovered` + `POST /missions/fetch`. | backend | NOUVEAU |
+| 6 | **Frontend** : marqueurs QR sur la carte + clic marqueur/point → bouton **Fetch** → POST. | frontend | NOUVEAU |
+
+---
+
+## 4. Détail technique des pièces robot
+
+### 4.1 Détecteur QR (`object_detector.py` [ÉTEND])
+- `cv2.QRCodeDetector().detectAndDecodeMulti(rgb)` → pour chaque QR : 4 coins + texte décodé (= l'ID objet, ex. `"obj-42"`).
+- Centre QR (moyenne des coins) → `sample_depth_median` + `backproject` (pipeline existant) → `(x,y,z)` repère caméra.
+- **Sortie** : nouveau topic `/roblaude/qr_detections` (String JSON) = `[{ "qr": "obj-42", "x":…, "y":…, "z":… }, …]` (PoseArray ne porte pas de texte → topic parallèle).
+- Pas de dépendance nouvelle : `cv2.QRCodeDetector` est dans `opencv-python` (déjà utilisé). **[À VÉRIFIER]** version OpenCV du container (multi-QR ≥ 4.5.1 ; sinon `detectAndDecode` simple).
+- HSV reste actif → fallback si QR illisible.
+
+### 4.2 qr_mapper (logique de cartographie [NOUVEAU])
+- Souscrit `/roblaude/qr_detections`, lookup TF `camera → map`, transforme chaque point en `map`.
+- **Dédup** par `qr` (même ID revu → met à jour la position moyenne, pas un doublon). Garde le meilleur (depth valide, proche).
+- Publie `roblaude/{id}/telemetry/discovered_objects` (retained) = `[{ "qr", "x_map", "y_map", "seenAt" }, …]`.
+- Peut vivre dans `mission_executor` ou un petit node dédié (décider à l'implémentation — un node dédié est plus propre et coupable indépendamment côté CPU).
+
+### 4.3 Mission FETCH (`mission_executor.py` [ÉTEND])
+États : `NAVIGATING_TO_OBJECT` → `CONFIRMING_QR` (revérifie l'ID lu == cible, sinon `failed:qr-mismatch`) → `GRASPING` (existant) → `RETURNING_TO_BASE` (nav vers Point `base`) → `completed`.
+- `fromPoint` = coords du QR cliqué (ou point libre). `toPoint` = Point `base`.
+- Reasons d'échec : `qr-not-found`, `qr-mismatch`, `grasp-failed`, `nav-status-*`.
+
+---
+
+## 5. Ajouts contrat MQTT
+
+- **`telemetry/discovered_objects`** (Robot→Back, retained) : `[{ qr, x_map, y_map, seenAt }]`.
+- **`cmd/mission`** : ajouter `type: "FETCH"`, `qrId` (optionnel, pour CONFIRM_QR).
+- **`mission/status`** : nouveaux états `NAVIGATING_TO_OBJECT`, `CONFIRMING_QR`, `RETURNING_TO_BASE`.
+- **`mission/result`** : reasons `qr-not-found`, `qr-mismatch`.
+
+(Détailler dans `docs/mqtt-spec.md` à l'implémentation.)
+
+---
+
+## 6. ⚠️ Contrainte CPU (prouvée 2026-06-19) — prérequis dur
+
+Phase A = explore_lite + SLAM + caméra + QR + mqtt **en même temps** = le cas le **plus lourd** pour le Nano (4 cœurs faibles). On a **prouvé** que :
+- l'automap seul met déjà le Nano sous tension ;
+- `mqtt_bridge` brûle ~1 cœur (cause `docs/architecture.md` §9.3).
+
+**Donc, prérequis avant la Phase A :**
+1. **Appliquer le fix `mqtt_bridge`** (slam /tf 50→20 Hz + lookup TF 5 Hz) → libère ~1 cœur. (cf. `DETTE.md` §3)
+2. **Throttler la détection QR** (ex. 2-3 Hz, pas la pleine cadence caméra).
+3. Tester **incrémentalement** : explore seul OK ? + caméra ? + QR ? — mesurer le load à chaque ajout, ne pas tout allumer d'un coup.
+
+Si le Nano ne tient pas explore+caméra ensemble malgré le fix → repli : **mapper d'abord (sans caméra), puis une passe de recherche** (caméra+QR) sur la carte figée. À décider par la mesure, pas par supposition.
+
+---
+
+## 7. Ordre de construction (incrémental, chaque étape testable)
+
+0. **[PRÉREQUIS]** Fix `mqtt_bridge` CPU + vérif `/tf` (cf. `DETTE.md`).
+1. **Détecteur QR** (robot) — testable hors-ligne avec une image de QR (unit test). Détecte+décode+3D, publie `/roblaude/qr_detections`. HSV gardé.
+2. **qr_mapper** — détection→`map`, dédup, publie `discovered_objects`. Test : poser un QR, vérifier la coord `map` stable.
+3. **Backend** — modèle `DiscoveredObject` + sub MQTT + REST (`GET /discovered`, `POST /missions/fetch`).
+4. **Frontend** — marqueurs QR sur la carte + clic → Fetch.
+5. **Mission FETCH** (robot) — NAV→CONFIRM_QR→GRASP→retour base.
+6. **Intégration E2E** — explore → découvre → clic fetch → grasp → retour base.
+
+---
+
+## 8. Décisions ouvertes (à trancher en avançant)
+
+- **Contenu du QR** : ID brut (`"obj-42"`) ou un payload structuré ? → MVP : ID brut = `GraspObject.id` ou un slug.
+- **qr_mapper** : node dédié vs dans `mission_executor` ? → penché node dédié (isolable CPU).
+- **Repli carte-figée** si CPU insuffisant (cf. §6) → décidé par mesure.
+- **Clic point libre** (sans QR) : on envoie le robot aux coords sans CONFIRM_QR (juste go-to / fetch best-effort) ? → à confirmer avec le codeur.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,347 @@
+# RobLaude — Architecture & mémoire projet (SOURCE CANONIQUE)
+
+> **C'est LE document de référence.** Source de vérité unique du projet (matériel, réseau,
+> contrôle robot, MQTT, archi web + robot, pièges, causes racines connues).
+> Tout le reste (AGENTS.md, CODEX_BRIEFING.md) a été fusionné ici pour ne plus diverger.
+>
+> Dernière mise à jour : **2026-06-19**. Robot : Yahboom ROSMASTER M3 Pro / Jetson Nano / ROS 2 Humble.
+> Projet académique HETIC — 18 semaines (fév → juin 2026). Équipe : **Wissem** (robot réel + web) + **Maxime** (web/simu + CI).
+>
+> **Convention de fiabilité** (règle absolue) : chaque fait sensible porte une étiquette —
+> **[PROUVÉ]** = observé/mesuré directement · **[DÉDUIT]** = inféré d'indices, à confirmer ·
+> **[SUPPOSÉ]** = hypothèse non testée. Si pas d'étiquette = fait stable établi.
+
+---
+
+## 0. Index — quoi lire, et le rôle de chaque doc
+
+| Doc | Rôle | Quand le lire |
+|-----|------|---------------|
+| **`docs/architecture.md`** (ce fichier) | **Source canonique** : tout le contexte stable | **Toujours, en premier** |
+| `docs/STATUS.md` | État des sprints, ce qui est en cours | Début de session |
+| `docs/DETTE.md` | Dette technique ouverte (actions claires) | Avant de planifier |
+| `docs/DIFFICULTES_ROBOT.md` | Récit problème→cause→fix (pour la soutenance) | Prépa soutenance |
+| `docs/ROBOT.md` | Faits robot sourcés `fichier:ligne` | Vérifier un détail précis |
+| `docs/mqtt-spec.md` | Contrat MQTT détaillé (le vrai schéma des payloads) | Toucher au bridge / backend MQTT |
+| `docs/AUTONAV_PROCEDURE.md` | Runbook test autonav Nav2 | Tester la nav sur le robot |
+| `docs/UC03_SCAN_FETCH_QR.md` | **Spec** : explore → découvrir QR → fetch sur clic → retour base | Travailler sur le pick&place autonome / QR |
+| `docs/CDC_Roblaude_v1.2.md` / `ROADMAP.md` | Cahier des charges + roadmap | Cadrage produit |
+| `docs/journal/` | Historique narratif des sessions | Retrouver « comment on en est arrivé là » |
+| `AGENTS.md` / `CODEX_BRIEFING.md` | **Obsolètes → pointent ici** | Ne plus utiliser |
+
+---
+
+## 1. Matériel
+
+- **Robot** : Yahboom **ROSMASTER M3 PRO**. Calculateur = **Jetson Nano** (B01, ARM64).
+  **CPU 4 cœurs faibles — c'est LA contrainte n°1 qui structure tout** (voir §7 et §8).
+- Sur le Jetson tourne **Docker**. Toute la robotique vit dans des **containers**, pas sur l'hôte.
+- **STM32** : pilote physiquement moteurs, servos (bras + pince), LEDs, buzzer, IMU, encodeurs.
+  Il parle à ROS via **micro-ROS** (série + agent).
+- 2 LiDAR (dual), 1 caméra RGB-D **Orbbec DaBai DCW2**, 1 bras 6 DOF + pince, batterie 3S Li-Ion (10.0 V vide → 12.6 V plein).
+
+**Les 2 containers Docker permanents :**
+
+| Container | Rôle |
+|-----------|------|
+| `m3pro` | ROS 2 Humble + drivers Yahboom + **notre** workspace `roblaude_ws` (bind-monté). On y lance toutes les commandes ROS. |
+| `micro_ros_agent` | Pont **STM32 ↔ ROS 2**. Sans lui, aucune commande n'atteint moteurs/servos. |
+
+**Branchements série STM32** (leçon dure) : le **STM32 = CP2104** (`10c4:ea60`), le micro-ROS agent = CH340 (`1a86`).
+« Agent up mais pas de session » = mauvaise cible série, **PAS** un souci hardware.
+
+---
+
+## 2. Réseau — pourquoi Mac et robot ont des IP différentes
+
+- **Mac** : `10.10.221.77`, netmask `/22` (`255.255.252.0`).
+- **Robot** : IP **DHCP** qui change (dernières vues : `10.10.220.208`, puis **`10.10.221.45` au 2026-06-19**). MAC fixe = `50:3d:d1:ff:f3:7d`.
+
+Un `/22` sur `10.10.220.0` couvre `10.10.220.0 → 10.10.223.255` → Mac et robot sont dans **le MÊME sous-réseau** (même LAN/Wi-Fi de l'école). Ils se parlent **directement**, sans routeur (ping ~8 ms).
+
+**Pourquoi ça compte** : le robot doit joindre le **broker MQTT qui tourne sur le Mac**. Il lit l'IP du Mac dans `/etc/roblaude/broker_ip` (mis à jour par `sync_time.sh`). Le DHCP change les IP → `find_robot.sh` retrouve le robot par sa MAC.
+
+---
+
+## 3. Se connecter & contrôler le robot — le pattern OBLIGATOIRE
+
+```bash
+# 1. Trouver l'IP courante (DHCP)
+./robot/scripts/find_robot.sh        # scanne le subnet, matche la MAC 50:3d:d1:ff:f3:7d
+
+# 2. SSH (auth par mot de passe → sshpass). User: jetson / Password: yahboom
+sshpass -p yahboom ssh -o StrictHostKeyChecking=accept-new jetson@<ip>
+```
+
+**Toute commande ROS passe DANS le container `m3pro`, avec 2 variables critiques :**
+
+```bash
+docker exec m3pro bash -lc '
+  source /opt/ros/humble/setup.bash
+  source /root/yahboomcar_ws/install/setup.bash     # drivers Yahboom (image)
+  source /root/roblaude_ws/install/setup.bash        # NOTRE code (bind-monté)
+  export ROS_DOMAIN_ID=30                             # OBLIGATOIRE
+  export FASTDDS_BUILTIN_TRANSPORTS=UDPv4             # OBLIGATOIRE
+  ros2 node list
+'
+```
+
+⚠️ **Sans `ROS_DOMAIN_ID=30` + `FASTDDS_BUILTIN_TRANSPORTS=UDPv4`, les commandes n'atteignent jamais le STM32.** Cause n°1 de « ça ne répond pas ».
+
+**Quoting SSH → docker (leçon dure)** : ne PAS empiler les guillemets. Utiliser le **heredoc littéral** :
+
+```bash
+ssh jetson@<ip> 'bash -s' <<'EOF'
+docker exec -i m3pro bash -l <<'INNER'
+source /opt/ros/humble/setup.bash; source /root/roblaude_ws/install/setup.bash 2>/dev/null
+ros2 node list
+INNER
+EOF
+```
+
+Lancer un node/launch en fond : **`docker exec -d`** (jamais attaché — sinon le SSH timeout à 2 min). Relire l'état via les **fichiers de log** (`/tmp/roslogs/*.log`), plus robuste qu'une requête `ros2` live.
+
+**Topics de contrôle :**
+
+| Action | Topic | Type | Notes |
+|--------|-------|------|-------|
+| Déplacer la base | `/cmd_vel` | `geometry_msgs/Twist` | moteurs |
+| Bras joints 1-5 | `/arm6_joints` | `arm_msgs/msg/ArmJoints` | servos bras |
+| **Pince** | `/arm_joint` | `arm_msgs/msg/ArmJoint {id,joint,time}` | **id=6, 0=OUVERT, 180=FERMÉ** |
+| Batterie (lecture) | `/battery` | `std_msgs/Float32` | tension brute (V) |
+| Buzzer / LEDs | `/beep` / `/rgb` | — | utiles pour tester que le STM32 exécute |
+
+**Déployer du code** : `./robot/scripts/deploy_to_robot.sh` (rsync `robot/roblaude_*` → `/home/jetson/roblaude_ws` puis `colcon build --symlink-install`). Les scripts (`*.sh`) n'ont pas besoin de build.
+
+**Santé OK** [DÉDUIT] = ~**16 nodes**, 2 containers up, STM32 connecté, autostart 0 erreur.
+
+---
+
+## 4. Architecture web (les 3 couches)
+
+```
+web/frontend/   React 19.2 + Vite 7 + TS + Zustand 5 + PWA + Three.js (visu bras) + xterm (SSH)   (dev :5173)
+web/backend/    Node 20 + Express 4 + Prisma 6.19 + MySQL + mqtt 5 + ws 8                          (:3001, PAS 3000)
+robot/          ROS 2 Humble (Python) sur le Jetson
+infra/          docker-compose : MySQL 8 + Mosquitto 2
+```
+
+- **Front ↔ Back** : REST (`web/frontend/src/lib/api.ts` ↔ `routes/*`) + **plusieurs WebSocket** (`wsRouter` → `wsTelemetry`, `wsTf`, `wsTopics`, `wsSsh`). Front a un terminal SSH (xterm) et une visu 3D du bras (Three.js + urdf-loader).
+- **Back ↔ Robot** : **MQTT uniquement** (pas de REST/WS robot↔back).
+
+**Lancer la web app en local** (testé) :
+```bash
+# MySQL sur 3307 (le .env backend vise localhost:3307, PAS 3306)
+docker run -d --name roblaude-mysql -p 3307:3306 -e MYSQL_ROOT_PASSWORD=rootpass \
+  -e MYSQL_DATABASE=roblaude -e MYSQL_USER=roblaude -e MYSQL_PASSWORD=roblaude mysql:8.0
+# Broker MQTT anonyme (dev)
+docker run -d --name roblaude-mosquitto -p 1883:1883 eclipse-mosquitto:2 \
+  sh -c "printf 'listener 1883\nallow_anonymous true\n' > /mosquitto/config/mosquitto.conf && exec mosquitto -c /mosquitto/config/mosquitto.conf"
+cd web/backend && npx prisma migrate deploy && npx tsx prisma/seed.ts && npm run dev   # Prisma 7 ne seed pas seul
+cd web/frontend && npm run dev
+```
+- **Login** : `admin@roblaude.fr` / `changeme` (ADMIN) · `marie@roblaude.fr` / `changeme` (USER).
+- Gotcha seed : plante sur `GraspObject.color` (branche non mergée) → `ALTER TABLE GraspObject ADD COLUMN color VARCHAR(191) NOT NULL DEFAULT '#ff0000';`.
+
+**Détail stack backend** : `zod` 4, `jsonwebtoken`, `bcryptjs`, `node-ssh` + `ssh2` (terminal SSH), `sharp`, `yaml`. Coverage min **70 %** sur les controllers.
+**CI** (`.github/workflows/ci.yml`) : 2 jobs — Frontend (eslint + build + test) et Backend (build + `prisma migrate deploy` + test). ⚠️ **Lire la conclusion par job**, pas l'exit global.
+
+### 4.1 Structure du repo (réelle)
+
+```
+web/frontend/src/   pages(~10) components(~25 + ui/) stores(5 Zustand) hooks(5) lib(15) e2e/(5 specs)
+web/backend/src/    routes/ controllers(11) services/ middleware/ prisma/ types/
+                    services clés : mqtt.ts, websocket.ts, wsRouter→{wsTelemetry,wsTf,wsTopics,wsSsh},
+                    sshConnection.ts, missionWatchdog.ts, mqttEvents.ts
+robot/roblaude_nav/        launch(slam, nav2_slam_roblaude, explore, camera, lidar, tf2_static) +
+                           mission_executor, mapping_supervisor, scan_restamper, odom_to_tf, initial_rotation
+robot/roblaude_mqtt/       mqtt_bridge.py (pont MQTT↔ROS) + config + launch
+robot/roblaude_pickplace/  détecteur HSV+depth + IK bras (arm_kin) + color.py + tests  (UC-02)
+robot/m-explore-ros2/       TIERS vendored (explore_lite + map_merge)
+robot/docs/                explore-stack.md, m3pro-reference.md (notre robot corrigé)
+infra/mosquitto/           mosquitto.conf + acl + passwd.example  (passwd réel jamais commit)
+```
+
+⚠️ `bridge/` (annoncé dans le README) est **vide** — le vrai bridge est `robot/roblaude_mqtt`.
+
+---
+
+## 5. MQTT — le seul canal Back ↔ Robot
+
+```
+[React] --REST+WS--> [Backend Express] --MQTT--> [Mosquitto (sur le Mac, :1883)] <--MQTT-- [mqtt_bridge.py] <--ROS--> [nodes / STM32]
+```
+
+- Broker **sur le Mac**, port **1883**. En dev : **anonyme** (creds vides). Le robot lit l'IP du broker dans `/etc/roblaude/broker_ip`.
+- `robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py` = le pont (un node ROS). Côté back : `web/backend/src/services/mqtt.ts`.
+- **Contrat détaillé = `docs/mqtt-spec.md`** (le vrai schéma des payloads).
+
+**Topics** (`{id}` = `Robot.id`, ici **1**) :
+
+| Topic | Sens | QoS | Retained |
+|-------|------|-----|----------|
+| `roblaude/{id}/cmd/{mission,cancel,resume,loading-confirmed,emergency-stop}` | Back→Robot | 2 | non |
+| `roblaude/{id}/telemetry/position` | Robot→Back | 0 | oui |
+| `roblaude/{id}/telemetry/battery` | Robot→Back | 1 | oui |
+| `roblaude/{id}/telemetry/scan` | Robot→Back | 0 | — |
+| `roblaude/{id}/status` | Robot→Back | 1 | oui |
+| `roblaude/{id}/mission/{ack,status,result}` | Robot→Back | 1/1/2 | non/oui/non |
+| `roblaude/{id}/connection` | Robot→Back | 1 | oui |
+
+Backend s'abonne en wildcard : `roblaude/+/telemetry/#`, `roblaude/+/status`, `roblaude/+/mission/#`, `roblaude/+/connection`.
+
+**Flux mission** : front → REST → backend publie `cmd/mission {type,objectId,targetColor}` (QoS 2) → `mqtt_bridge` traduit en ROS → `mission_executor` (ActionClient Nav2 `/navigate_to_pose`) → robot publie `mission/ack` → `mission/status` (NAVIGATING→DETECTING→GRASPING→…→DEPOSITING) → `mission/result {completed | reason}` → backend → WebSocket → front.
+
+---
+
+## 6. Architecture robot (interne)
+
+**Deux familles de workspaces sourcées ensemble :**
+- `/root/yahboomcar_ws` (+ `/root/M3Pro_ws`) : **drivers Yahboom**, DANS l'image (intouchables). Fournissent `base_bringup` (moteurs, EKF odométrie, IMU, fusion LiDAR), `robot_state_publisher` (URDF), nav2, slam_toolbox, driver bras (`YB_Node`), driver caméra.
+- `/root/roblaude_ws` : **NOTRE code**, bind-monté depuis `/home/jetson/roblaude_ws`. Packages :
+  - `roblaude_nav` : `slam.launch`, `nav2_slam_roblaude.launch`, `explore.launch`, `scan_restamper`, `mission_executor`, `mapping_supervisor`, `tf2_static`, `initial_rotation`, `camera.launch`.
+  - `roblaude_mqtt` : `mqtt_bridge.py`.
+  - `roblaude_pickplace` : détecteur objet HSV+depth + IK bras (`arm_kin`) — UC-02.
+
+**Arbre TF** : `map → odom → base_footprint → base_link → {laser, camera, arm_base, imu}`.
+L'EKF (`base_bringup`) publie `odom→base_footprint`. slam_toolbox publie `map→odom`.
+
+**Chaîne LiDAR / mapping (cartographiée et vérifiée 2026-06-18) [PROUVÉ] :**
+```
+/scan0 (laser0_frame) + /scan1 (laser1_frame)
+   → laserscan_multi_merger → /scan_multi (base_link, ~7 Hz)
+   → laser_filter_node      → /scan
+   → scan_restamper         → /scan_fixed
+   → slam_toolbox           → /map + TF map→odom
+```
+- slam_toolbox : `base_frame=base_footprint`, `scan_topic=/scan_fixed`, `transform_publish_period=0.02` (**= /tf à 50 Hz**, important pour §9), `minimum_time_interval=0.5`.
+- **Bug drift TF résolu** : le LiDAR Yahboom estampille les scans **dans le futur** (mesuré +3.46 s) → slam droppe tout (« Message Filter dropping… queue is full »). Fix `scan_restamper` : republie avec **`now() - 0.2s`** (offset, pas `now()` brut sinon la TF odom EKF n'est pas encore dispo). Résultat : **0 drop** avec slam seul.
+- **Visu** : `foxglove_bridge` sur le robot (port 8765) → depuis le Mac : `ws://<ip>:8765`.
+
+**Au boot** : `robot/scripts/container_autostart.sh` (PID 1 du container) lance la stack. Modes : **`minimal`** (base + mqtt + mission, sans caméra/détecteur) et **`full`** (tout). `start_perception.sh` lance caméra+détecteur à la demande. Le bras est mis en HOME une fois YB_Node prêt (jamais en rafale).
+
+### 6.1 Scripts robot (`robot/scripts/`) — rôle de chacun
+
+| Script | Rôle |
+|--------|------|
+| `Docker_M3Pro_Joy.sh` | lance le container `m3pro` (→ `container_autostart`) — **cœur** |
+| `container_autostart.sh` | PID 1 du container, lance la stack ROS au boot (modes minimal/full) — **cœur** |
+| `deploy_to_robot.sh` | rsync packages + `colcon build` — **cœur** |
+| `find_robot.sh` | trouve l'IP du robot par MAC — **cœur** |
+| `sync_time.sh` | sync horloge Jetson + pousse l'IP broker (Mac) — **cœur** |
+| `start_perception.sh` | lance caméra + détecteur à la demande (idempotent) |
+| `start_agent.sh` | lance le container `micro_ros_agent` |
+| `connect.sh` | SSH + noVNC rapide |
+| `fetch_urdf_from_robot.sh` | récupère l'URDF pour le front (`backend/app.ts`) |
+| `install_persistence.sh` | setup one-shot persistance |
+| `start_all.sh` / `start_robot.sh` | démarrage manuel debug — **redondants** (supprimés sur la branche courante) |
+
+### 6.2 UC-02 pick&place — détail
+
+- **Codé + partiellement validé réel** : détecteur couleur 3D (caméra DaBai), pince réparée (`/arm_joint id=6`), bras joints 1-5, `mission_executor` PICK_AND_PLACE, `roblaude_pickplace`.
+- **Détecteur** : `/roblaude/detections` à **10 Hz** (HSV + depth) ; couleur cible à chaud via `/roblaude/target_color` (testé objet bleu → x=0.025, y=0.025, z=0.174 m).
+- **IK bras** (`arm_kin`) : portée 2-link loi des cosinus, `rad_to_servo` (0 rad → servo 90), **rejette** hors portée / joint > ±1.57 rad.
+- **Contrat MQTT** : `cmd/mission {type:PICK_AND_PLACE, objectId, targetColor}` → `mission/ack` → `mission/status` (NAVIGATING→DETECTING→GRASPING→…→DEPOSITING) → `mission/result {completed | reason:grasp-failed}`. `targetColor` dérivé du hex `GraspObject.color`.
+- **Reste** : valider grasp réel (batterie), recaler reset bras boot/shutdown, retirer `--device=/dev/video0` (inutile) de `Docker_M3Pro_Joy.sh`, test E2E + non-régression UC-01, PR.
+
+---
+
+## 7. ⚠️ Savoir robot appris à la dure (lire avant de toucher au robot)
+
+- **CPU Jetson Nano très faible (4 cœurs).** `slam_toolbox` seul = load ~2, OK. **`nav2 + explore_lite` sature** → l'exploration autonome ne marche pas proprement sans optimisation (voir §9 pour la **vraie** cause racine, trouvée 2026-06-19).
+- **`YB_Node` crashe sous un `ros2 topic pub` continu** → bras/moteurs muets jusqu'à **REBOOT**. Règle : **`--once`**, une commande à la fois, jamais de boucle de pub.
+- **`pkill -f` se tue lui-même** si le motif apparaît en clair dans la commande → **bracket-trick** : `pkill -9 -f "[c]ontroller_server"`.
+- **Bras OPEN-LOOP total** : aucun retour servo, `/joint_states` ne reflète pas une pose mise à la main. On impose des poses par commande.
+- **Calibration bras (vérifiée réel)** : servo **90 = neutre/droit**. VERTICALE = `[90,90,90,90,90]`. HOME safe = `[90,120,10,20,90,0]` time=2000. joint2 (épaule) : 0=bas / 90=vertical / 180=arrière. joint3 (coude) : 90=droit / 0=plié.
+- **PINCE** : topic `/arm_joint`, **id=6, 0=OUVERT / 180=FERMÉ** (le `joint6` de `/arm6_joints` ne fait PAS un open/close propre).
+- **Caméra = Orbbec DaBai DCW2** (PAS astra_pro2). Launch `dabai_dcw2`. Au boot l'USB est frais → marche ; relance à chaud sur device occupé échoue (reboot résout).
+- **Batterie** : topic `/battery`. ≥12 V = sain. **La lecture est faussée (timeout) quand le CPU sature** → batterie illisible = le Nano rame.
+- **Horloge Jetson ~25 jours en retard** (casse `apt update`). `sync_time.sh` corrige. N'impacte pas le SLAM.
+- **À NE PAS faire sans accord** : bouger le robot, publier sur `/cmd_vel`, lancer nav2+explore, `ros2 topic pub` en boucle.
+
+---
+
+## 8. Modes & stratégie automap (décision 2026-06-19)
+
+Objectif : cartographier une pièce en autonomie, puis exécuter des missions pick&place (objets à QR code).
+**Choix produit du codeur** : pendant l'automap, **garder mqtt + mission + détecteur**, **couper seulement la caméra** (le détecteur dort sans images → ~0 % CPU). La caméra ne s'allume qu'au moment de la mission.
+
+---
+
+## 9. Causes racines connues (investigations terminées) — section anti-divergence
+
+> **Le cœur de ce doc.** Toute « cause connue » erronée ailleurs est corrigée ici, avec son niveau de preuve.
+
+### 9.1 Bras « muet » puis « ne tient pas la pose » (session 2026-06-18)
+- **Cause du bras muet [PROUVÉ]** : câble du **bus servo** du bras débranché/desserré. Après recâblage → le bras bouge (HOME + test mono-servo). Validé que le STM32 exécute bien (le **buzzer sonne**, les LEDs répondent) → ce n'était ni le logiciel, ni MQTT, ni l'USB, ni la config, ni un backup.
+- **Pas de « torque enable » logiciel** [PROUVÉ] : les servos bus tiennent leur pose seuls (mode position). Aucun service/param `torque` exposé par YB_Node (vérifié : il n'écoute que `arm6_joints`/`arm_joint`/`beep`/`cmd_vel`/`rgb`). Le `/enable` du graphe appartient à l'EKF, rien à voir.
+- **« Ne tient pas la pose » [DÉDUIT, non clos]** : très probablement batterie trop basse pour soutenir le couple (bouger ≠ tenir contre la gravité) et/ou contact bus servo encore marginal. À reconfirmer batterie chargée.
+
+### 9.2 Capteurs / SLAM sous mouvement (session 2026-06-19) [PROUVÉ]
+- Sous rotation réelle, **toute la chaîne LiDAR tient** : `/scan0`/`/scan1` ~7,14 Hz, `/scan_multi` 7,14, `/scan_fixed` 7,14, `/odom` ~6 Hz, **aucun trou**, **zéro « queue full »**, zéro « extrapolation error ».
+- **Le « gel SLAM / scan silent » des sessions précédentes ne s'est PAS reproduit** → c'était un **contact USB intermittent du LiDAR**, réglé par le recâblage. La perception est saine.
+
+### 9.3 `mqtt_bridge` CPU — FAUSSE PISTE, close par mesure propre (2026-06-19 soir) [PROUVÉ]
+> ✅ **PISTE CLOSE.** Re-test rigoureux en **état propre (reboot + dual LiDAR)** : pendant un automap qui **fonctionne** (3 goals Nav2 atteints), **mqtt_bridge = 0 % CPU** (mesuré /proc). `/tf` à 60 Hz → mqtt_bridge **0 %** : `/tf` n'inonde RIEN. Le « 120 % » des mesures d'avant = **artefact d'état churné** (graph ROS malmené toute la session + `/scan0` mort). **Aucun fix mqtt nécessaire** (le fix `/tf` 50→20 Hz a été testé puis **reverté** : inutile). L'automap marche. Seul reste = slam « queue full » drops (§9.5), non fatal.
+>
+> _Leçon : ne jamais conclure une cause sur des mesures en état churné. La re-mesure en état propre a tout renversé._ Le détail ci-dessous est **l'historique de l'enquête** (gardé pour mémoire), pas la conclusion.
+> ⚠️ Corrige aussi l'encore-plus-ancienne fiche « busy-loop 95 % broker absent » (fausse également).
+
+- **[PROUVÉ]** Le CPU de `mqtt_bridge` est **piloté à 100 % par les messages entrants** : `0 %` quand ses topics sont silencieux, **~120 %** quand ils publient. Le broker est **connecté** (TCP ESTABLISHED Mac↔robot) — ce n'est donc pas un spin sur broker mort.
+- **[PROUVÉ]** Chaîne d'élimination : `py-spy` → thread chaud dans `rclpy/executors.py:wait_for_ready_callbacks` (l'**attente de l'exécuteur**, pas les callbacks, pas paho/MQTT) · `strace` → **99,8 % userspace**, ~280 syscalls/s (donc **pas** un spin syscall/epoll, pas DDS sockets) · node rclpy **vide = 0 %** (rmw/DDS sain) · graphe ROS stable (pas de churn).
+- **[PROUVÉ]** Aucun timer rclpy dans le bridge (le dead-man teleop est un `threading.Timer`, hors exécuteur). `robot_state_publisher` est dans la même famille (~49 %, piloté par `/joint_states`).
+- **Cause racine [DÉDUIT, vérif d'isolation en cours]** : `mqtt_bridge` a **~17 souscriptions** sur un `SingleThreadedExecutor`. Le coût par-réveil de l'exécuteur rclpy Humble scale mal avec le nombre d'entités × le débit. En **automap**, slam inonde `/tf` à **50 Hz** + `/map` + `/scan_multi` + `/plan` + `/explore/frontiers` → le mono-thread se fait inonder → **1 cœur brûlé** → **Nav2 affamé → action servers ne répondent plus (timeouts) → pas d'exploration**.
+- **Fix proposé (pas encore appliqué, à valider par mesure)** : (1) slam `transform_publish_period` 0.02→0.05 (50→20 Hz). (2) `mqtt_bridge` : remplacer la souscription `/tf` brute par un **lookup TF périodique à 5 Hz** (préserve la pose web sans inonder l'exécuteur). Validation = re-mesurer le CPU de `mqtt_bridge` pendant l'automap.
+- **NOTE** : la « magnitude exacte par topic » reste **[DÉDUITE]** tant que le test d'injection contrôlée (`/tf` synthétique à 50/20 Hz → mesure CPU) n'est pas terminé.
+
+---
+
+### 9.4 La VRAIE cause des galères automap (2026-06-19 soir) — PRÉREQUIS [PROUVÉ]
+
+Re-test en état propre : **l'automap FONCTIONNE** (Nav2 atteint des goals, exploration autonome, 3 goals en 80 s). Les « galères » des sessions d'avant (Nav2 timeout, scans qui droppent, mqtt_bridge 120 %) étaient des **artefacts de 2 conditions dégradées**, pas un bug logiciel — vérifié en relisant toutes les commandes : **aucun changement de code n'a touché le robot**, il a tourné sur le code d'origine du début à la fin.
+
+1. **Batterie basse** (~10,6–10,8 V) → moteurs faibles (« failed to make progress » = le robot ne bouge pas assez) + Nano qui brownout → lectures CPU faussées (« batterie illisible = le Nano rame »).
+2. **État ROS churné** (dizaines de launch/pkill, zombies) + **`/scan0` mort** (dual LiDAR dégradé) → scans incomplets, mqtt_bridge transitoire à 120 %.
+
+**Ce qui a tout réparé ce soir : batterie chargée (12,5 V) + reboot à froid** (vide le churn + ré-énumère `/scan0`). **Zéro ligne de code.**
+
+> ⚠️ **PRÉREQUIS AVANT TOUTE SESSION AUTOMAP/NAV (non négociable) :**
+> 1. **Batterie ≥ 12 V** (sinon moteurs faibles + brownout → on debug des fantômes).
+> 2. **Reboot à froid** (état ROS propre + ré-énumération USB des 2 LiDARs).
+> Tant que ces 2 points ne sont pas faits, **ne pas chercher de fix code** — c'est quasi toujours batterie/état, pas le logiciel.
+
+### 9.5 Reste réel (mineur) : slam « queue full » drops
+
+Sous charge automap, slam_toolbox logue « Message Filter dropping… queue is full » par intermittence. **Non fatal** (map→odom reste frais, les goals passent). Piste de polish si besoin : `scan_buffer_size` / la file du message_filter tf2. Pas prioritaire — l'automap marche.
+
+## 10. Dette & bugs ouverts (détail dans `docs/DETTE.md`)
+
+- 🐛 Le bridge publie `Infinity` dans le JSON du scan (`telemetry/scan`) → JSON invalide, backend rejette. À sanitiser (`inf` → `null`).
+- 🐛 `GraspObject.color` pas mergé sur `dev` → seed/page objets plantent sans le `ALTER TABLE`.
+- 🔧 `mission_executor`/`mqtt_bridge` publient sur `/cmd_vel` au repos → conflit téléop. Ne publier que pendant une mission active.
+- 🔌 Auth MQTT : générer `infra/mosquitto/passwd` + creds (là c'est anonyme).
+- 🔋 Batterie/chargeur : blocage matériel possible, à régler physiquement (viser ≥12 V).
+
+---
+
+## 11. Conventions (NON négociable)
+
+- **Langue** : toujours répondre **en français**. Commentaires de code en français.
+- **Commits** : `type(scope): desc` sur **une seule ligne**, style humain. Scopes : `frontend backend robot infra ci mqtt ws db`. **Jamais `git commit`/`gh pr create` direct → toujours le skill `/commit`.**
+- **Mots IA BANNIS** (commits + commentaires) : implement / enhance / ensure / leverage / streamline / robust / scalable / facilitate / utilize / comprehensive / sophisticated / « This commit… » / « This function… ». Pas de `cf.` ni renvois `§X` dans le code.
+- **Git** : 1 ticket = 1 branche (`feat/T…`) = 1 PR. Toujours partir de `dev`. Jamais merge direct. Commits atomiques. Hook `git-guard` bloque commit/push sur `main`/`dev`.
+- **Rigueur** (cf. CLAUDE.md global) : standard « 1+1=2 » — vérifier avant d'affirmer, étiqueter PROUVÉ/DÉDUIT/SUPPOSÉ, isoler la variable avant d'agir, anti-tunnel.
+
+---
+
+## 12. État git & branches (au 2026-06-16, à rafraîchir via `git`)
+
+| Branche | État |
+|---------|------|
+| `dev` / `main` | base, à jour origin |
+| `feat/uc02-robot` | UC-02 robot complet, **poussée** |
+| `feat/uc02-graspobject-color` | backend `GraspObject.color` + `targetColor`, **poussée** |
+| `fix/explore-tf-drops` | fix restamper committé (`2117dc1`), **pas poussée** |
+| `feat/T8.4.1-automap-explore` | **branche courante** : mode minimal, arm HOME au boot, tuning explore, scripts (NON commité au 2026-06-19) |
+
+> Commits robot souvent dans des **worktrees** → committer avec `git -C <worktree> …`.

--- a/docs/revision-code-review-scan-restamper.md
+++ b/docs/revision-code-review-scan-restamper.md
@@ -1,0 +1,36 @@
+# Revision code review - scan_restamper.py
+
+## Bloc de contexte extrait du code
+
+```text
+scan_restamper.py - Re-stamp /scan_multi au temps courant pour slam_toolbox.
+
+Probleme racine identifie le 22 mai 2026 :
+  Les drivers LiDAR Yahboom (YDLidar X2L sur /scan0 et /scan1) publient avec
+  un timestamp ~500ms DANS LE FUTUR (drift constant +470 a +580ms mesure).
+  Le merger laserscan_multi_merger propage ce drift sur /scan_multi.
+
+Impact sur slam_toolbox :
+  Le message_filter interne attend une TF base_footprint->map au temps du
+  scan stamp. Si stamp = now+500ms, la TF cache (publiee en wall time) n'a
+  jamais d'entree dans le futur -> filter garde le scan en queue -> queue
+  deborde -> drop infini -> aucun scan jamais matche -> pas de TF map->odom
+  -> Nav2 ne peut pas planifier -> robot immobile.
+
+Solution :
+  Souscrire a /scan_multi, copier le message, ecraser msg.header.stamp avec
+  un temps wall LEGEREMENT dans le passe (now - stamp_offset), republier sur
+  /scan_fixed. Slam_toolbox abonne a /scan_fixed -> trouve la TF dans le cache
+  -> match -> publie TF map->odom -> debloque toute la stack.
+
+  Pourquoi pas now() pile : la TF odom->base_footprint (EKF Yahboom) arrive
+  avec un petit retard. Si on stampe le scan a now(), la TF a cet instant
+  n'est pas encore publiee -> le scan attend dans la queue du message_filter
+  -> queue full -> drop (vu IRL meme robot a l'arret). On recule le stamp de
+  ~0.2s pour tomber sur une pose odom deja dispo. Biais negligeable a vitesse
+  d'exploration (~2-4cm a 5cm/px).
+
+Note : on ne touche PAS a l'odom ni a la TF. L'ekf_filter_node (lance par
+base_bringup Yahboom) publie deja /odom et TF odom->base_link avec stamps
+corrects, pas de drift cote EKF.
+```

--- a/robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py
+++ b/robot/roblaude_mqtt/roblaude_mqtt/mqtt_bridge.py
@@ -18,12 +18,14 @@ from datetime import datetime, timezone
 
 import paho.mqtt.client as mqtt
 import rclpy
+from rclpy.duration import Duration
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry, OccupancyGrid, Path
 from rclpy.node import Node
+from rclpy.time import Time
 from sensor_msgs.msg import CompressedImage, JointState, LaserScan
 from std_msgs.msg import Float32, String
-from tf2_msgs.msg import TFMessage
+import tf2_ros
 
 # arm_msgs vient du workspace Yahboom (/root/yahboomcar_ws). Import optionnel
 # pour que le bridge demarre meme si le workspace Yahboom n'est pas source.
@@ -111,6 +113,23 @@ TF_PUBLISH_PERIOD_S = 0.2     # 5 Hz max
 CAMERA_PUBLISH_PERIOD_S = 0.2   # 5 Hz max — bande passante
 JOINT_STATES_PUBLISH_PERIOD_S = 0.1  # 10 Hz max — fluidite visu bras
 
+# Paires TF utiles au front. On ne souscrit plus /tf a la main : le listener
+# maintient un buffer, et on publie seulement un snapshot a 5 Hz.
+TF_SNAPSHOT_EDGES = (
+    ('map', 'odom'),
+    ('odom', 'base_footprint'),
+    ('odom', 'base_link'),
+    ('base_footprint', 'base_link'),
+    ('base_link', 'laser'),
+    ('base_link', 'laser0_frame'),
+    ('base_link', 'laser1_frame'),
+    ('base_link', 'camera_link'),
+    ('base_link', 'camera_color_optical_frame'),
+    ('base_link', 'camera_depth_optical_frame'),
+    ('base_link', 'arm_base_link'),
+    ('base_link', 'imu_link'),
+)
+
 # Clamp teleop (double securite par-dessus le clamp backend)
 TELEOP_MAX_LIN = 0.5  # m/s
 TELEOP_MAX_ANG = 1.0  # rad/s
@@ -130,6 +149,12 @@ def build_joint_states_payload(names, positions) -> dict:
         'names': list(names),
         'positions': list(positions),
     }
+
+
+def finite_or_none(value):
+    """JSON strict : NaN/Infinity deviennent null."""
+    v = float(value)
+    return v if math.isfinite(v) else None
 
 
 # Limites pour cmd/arm (securite avant que le msg ROS atteigne YB_Node).
@@ -214,17 +239,16 @@ class MqttBridge(Node):
         self.create_subscription(String, 'mission/result', self._on_mission_result, 10)
 
         # --- Mode mapping (T3.5.3) : flux temps reel SLAM/Nav2 -> MQTT ---
-        # Cache TF (les TFMessage donnent des updates partiels, on accumule)
-        self._tf_buffer = {}
         self._last_scan_publish = 0.0
-        self._last_tf_publish = 0.0
         self._last_camera_publish = 0.0
         self._last_joint_states_publish = 0.0
         self.create_subscription(OccupancyGrid, '/map', self._on_map, 10)
         self.create_subscription(LaserScan, '/scan_multi', self._on_scan, 10)
         self.create_subscription(Path, '/plan', self._on_plan, 10)
         self.create_subscription(MarkerArray, '/explore/frontiers', self._on_frontiers, 10)
-        self.create_subscription(TFMessage, '/tf', self._on_tf, 10)
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
+        self.create_timer(TF_PUBLISH_PERIOD_S, self._publish_tf_snapshot)
         # Camera + joint_states (T-final UI live)
         # Topics ROS configurables — le Yahboom M3 Pro peut publier sous
         # /usb_cam/image_raw/compressed ou /camera/color/image_raw/compressed.
@@ -490,7 +514,7 @@ class MqttBridge(Node):
             'schemaVersion': SCHEMA_VERSION,
             'messageId': str(uuid.uuid4()),
             'timestamp': now_iso(),
-            'ranges': [float(r) for r in msg.ranges],
+            'ranges': [finite_or_none(r) for r in msg.ranges],
             'angleMin': msg.angle_min,
             'angleIncrement': msg.angle_increment,
             'frameId': msg.header.frame_id,
@@ -524,18 +548,16 @@ class MqttBridge(Node):
         self.mqtt.publish(f'{self.base}/telemetry/frontiers',
                           json.dumps(payload), qos=0, retain=False)
 
-    def _on_tf(self, msg):
-        """TFMessage (updates partiels) -> cache + snapshot complet @5Hz."""
-        for t in msg.transforms:
-            self._tf_buffer[(t.header.frame_id, t.child_frame_id)] = t
-
-        now = time.monotonic()
-        if now - self._last_tf_publish < TF_PUBLISH_PERIOD_S:
-            return
-        self._last_tf_publish = now
-
+    def _publish_tf_snapshot(self):
+        """Publie un snapshot TF a 5 Hz via lookup, sans parser chaque /tf."""
         frames = []
-        for (parent, child), t in self._tf_buffer.items():
+        for parent, child in TF_SNAPSHOT_EDGES:
+            try:
+                t = self.tf_buffer.lookup_transform(
+                    parent, child, Time(), timeout=Duration(seconds=0.02)
+                )
+            except Exception:
+                continue
             tr = t.transform.translation
             r = t.transform.rotation
             frames.append({
@@ -543,6 +565,8 @@ class MqttBridge(Node):
                 'x': tr.x, 'y': tr.y, 'z': tr.z,
                 'qx': r.x, 'qy': r.y, 'qz': r.z, 'qw': r.w,
             })
+        if not frames:
+            return
         payload = {
             'schemaVersion': SCHEMA_VERSION, 'messageId': str(uuid.uuid4()),
             'timestamp': now_iso(), 'frames': frames,

--- a/robot/roblaude_mqtt/test/test_arm_command.py
+++ b/robot/roblaude_mqtt/test/test_arm_command.py
@@ -5,9 +5,10 @@ from unittest.mock import MagicMock, patch
 def _stubs():
     return {
         'rclpy': MagicMock(), 'rclpy.node': MagicMock(),
+        'rclpy.time': MagicMock(), 'rclpy.duration': MagicMock(),
         'std_msgs.msg': MagicMock(), 'nav_msgs.msg': MagicMock(),
         'sensor_msgs.msg': MagicMock(), 'geometry_msgs.msg': MagicMock(),
-        'visualization_msgs.msg': MagicMock(), 'tf2_msgs.msg': MagicMock(),
+        'visualization_msgs.msg': MagicMock(), 'tf2_ros': MagicMock(),
         'paho': MagicMock(), 'paho.mqtt': MagicMock(), 'paho.mqtt.client': MagicMock(),
         'arm_msgs': MagicMock(), 'arm_msgs.msg': MagicMock(),
     }

--- a/robot/roblaude_mqtt/test/test_camera_joints.py
+++ b/robot/roblaude_mqtt/test/test_camera_joints.py
@@ -10,9 +10,10 @@ from unittest.mock import MagicMock, patch
 def _stubs():
     return {
         'rclpy': MagicMock(), 'rclpy.node': MagicMock(),
+        'rclpy.time': MagicMock(), 'rclpy.duration': MagicMock(),
         'std_msgs.msg': MagicMock(), 'nav_msgs.msg': MagicMock(),
         'sensor_msgs.msg': MagicMock(), 'geometry_msgs.msg': MagicMock(),
-        'visualization_msgs.msg': MagicMock(), 'tf2_msgs.msg': MagicMock(),
+        'visualization_msgs.msg': MagicMock(), 'tf2_ros': MagicMock(),
         'paho': MagicMock(), 'paho.mqtt': MagicMock(), 'paho.mqtt.client': MagicMock(),
     }
 

--- a/robot/roblaude_mqtt/test/test_deadman.py
+++ b/robot/roblaude_mqtt/test/test_deadman.py
@@ -9,9 +9,10 @@ from unittest.mock import MagicMock, patch
 def _load_bridge():
     with patch.dict('sys.modules', {
         'rclpy': MagicMock(), 'rclpy.node': MagicMock(),
+        'rclpy.time': MagicMock(), 'rclpy.duration': MagicMock(),
         'std_msgs.msg': MagicMock(), 'nav_msgs.msg': MagicMock(),
         'sensor_msgs.msg': MagicMock(), 'geometry_msgs.msg': MagicMock(),
-        'visualization_msgs.msg': MagicMock(), 'tf2_msgs.msg': MagicMock(),
+        'visualization_msgs.msg': MagicMock(), 'tf2_ros': MagicMock(),
         'paho': MagicMock(), 'paho.mqtt': MagicMock(), 'paho.mqtt.client': MagicMock(),
     }):
         from roblaude_mqtt.mqtt_bridge import TeleopDeadman

--- a/robot/roblaude_mqtt/test/test_png_conversion.py
+++ b/robot/roblaude_mqtt/test/test_png_conversion.py
@@ -12,9 +12,10 @@ def test_occupancy_to_png_basic():
     from unittest.mock import MagicMock, patch
     with patch.dict('sys.modules', {
         'rclpy': MagicMock(), 'rclpy.node': MagicMock(),
+        'rclpy.time': MagicMock(), 'rclpy.duration': MagicMock(),
         'std_msgs.msg': MagicMock(), 'nav_msgs.msg': MagicMock(),
         'sensor_msgs.msg': MagicMock(), 'geometry_msgs.msg': MagicMock(),
-        'visualization_msgs.msg': MagicMock(), 'tf2_msgs.msg': MagicMock(),
+        'visualization_msgs.msg': MagicMock(), 'tf2_ros': MagicMock(),
         'paho': MagicMock(), 'paho.mqtt': MagicMock(), 'paho.mqtt.client': MagicMock(),
     }):
         from roblaude_mqtt.mqtt_bridge import occupancy_to_png
@@ -43,9 +44,10 @@ def test_occupancy_threshold_50():
     from unittest.mock import MagicMock, patch
     with patch.dict('sys.modules', {
         'rclpy': MagicMock(), 'rclpy.node': MagicMock(),
+        'rclpy.time': MagicMock(), 'rclpy.duration': MagicMock(),
         'std_msgs.msg': MagicMock(), 'nav_msgs.msg': MagicMock(),
         'sensor_msgs.msg': MagicMock(), 'geometry_msgs.msg': MagicMock(),
-        'visualization_msgs.msg': MagicMock(), 'tf2_msgs.msg': MagicMock(),
+        'visualization_msgs.msg': MagicMock(), 'tf2_ros': MagicMock(),
         'paho': MagicMock(), 'paho.mqtt': MagicMock(), 'paho.mqtt.client': MagicMock(),
     }):
         from roblaude_mqtt.mqtt_bridge import occupancy_to_png

--- a/robot/roblaude_nav/launch/slam.launch.py
+++ b/robot/roblaude_nav/launch/slam.launch.py
@@ -53,7 +53,9 @@ def generate_launch_description():
                                                  # et est detecte comme obstacle fictif (vu IRL 22 mai).
                 'max_laser_range': 4.0,          # capacite reelle merger Yahboom (warning slam si plus)
                 'minimum_time_interval': 0.5,
-                'transform_publish_period': 0.02,
+                # 20 Hz suffit pour Nav2/visualisation et libere le Nano.
+                # 50 Hz surchargeait mqtt_bridge/TF pendant l'automap.
+                'transform_publish_period': 0.05,
                 'map_update_interval': 3.0,
                 'scan_buffer_size': 10,
                 'transform_timeout': 0.5,

--- a/robot/roblaude_nav/roblaude_nav/scan_restamper.py
+++ b/robot/roblaude_nav/roblaude_nav/scan_restamper.py
@@ -1,37 +1,4 @@
 #!/usr/bin/env python3
-"""
-scan_restamper.py - Re-stamp /scan_multi au temps courant pour slam_toolbox.
-
-Probleme racine identifie le 22 mai 2026 :
-  Les drivers LiDAR Yahboom (YDLidar X2L sur /scan0 et /scan1) publient avec
-  un timestamp ~500ms DANS LE FUTUR (drift constant +470 a +580ms mesure).
-  Le merger laserscan_multi_merger propage ce drift sur /scan_multi.
-
-Impact sur slam_toolbox :
-  Le message_filter interne attend une TF base_footprint->map au temps du
-  scan stamp. Si stamp = now+500ms, la TF cache (publiee en wall time) n'a
-  jamais d'entree dans le futur -> filter garde le scan en queue -> queue
-  deborde -> drop infini -> aucun scan jamais matche -> pas de TF map->odom
-  -> Nav2 ne peut pas planifier -> robot immobile.
-
-Solution :
-  Souscrire a /scan_multi, copier le message, ecraser msg.header.stamp avec
-  un temps wall LEGEREMENT dans le passe (now - stamp_offset), republier sur
-  /scan_fixed. Slam_toolbox abonne a /scan_fixed -> trouve la TF dans le cache
-  -> match -> publie TF map->odom -> debloque toute la stack.
-
-  Pourquoi pas now() pile : la TF odom->base_footprint (EKF Yahboom) arrive
-  avec un petit retard. Si on stampe le scan a now(), la TF a cet instant
-  n'est pas encore publiee -> le scan attend dans la queue du message_filter
-  -> queue full -> drop (vu IRL meme robot a l'arret). On recule le stamp de
-  ~0.2s pour tomber sur une pose odom deja dispo. Biais negligeable a vitesse
-  d'exploration (~2-4cm a 5cm/px).
-
-Note : on ne touche PAS a l'odom ni a la TF. L'ekf_filter_node (lance par
-base_bringup Yahboom) publie deja /odom et TF odom->base_link avec stamps
-corrects, pas de drift cote EKF.
-"""
-
 import rclpy
 from rclpy.node import Node
 from rclpy.duration import Duration

--- a/robot/roblaude_pickplace/config/detection_params.yaml
+++ b/robot/roblaude_pickplace/config/detection_params.yaml
@@ -21,3 +21,7 @@ object_detector:
     max_detection_depth: 1.0     # ignore au-dela (m)
     min_detection_depth: 0.15    # ignore en-deca (m)
     depth_scale: 0.001           # 16UC1 mm -> m
+
+    # --- QR code ---
+    enable_qr_detection: true
+    qr_period_sec: 0.5          # 2 Hz, evite de charger le Jetson pendant la vision

--- a/robot/roblaude_pickplace/roblaude_pickplace/object_detector.py
+++ b/robot/roblaude_pickplace/roblaude_pickplace/object_detector.py
@@ -24,6 +24,7 @@ from std_msgs.msg import String
 
 from roblaude_pickplace.color import hex_to_hsv_ranges
 from roblaude_pickplace.detection import backproject, sample_depth_median
+from roblaude_pickplace.qr import build_qr_detections, qr_detections_to_json
 
 
 def decode_image(msg: Image):
@@ -71,6 +72,14 @@ class ObjectDetector(Node):
         self.min_depth = float(self.declare_parameter('min_detection_depth', 0.15).value)
         self.depth_scale = float(self.declare_parameter('depth_scale', 0.001).value)
 
+        # --- QR basse frequence : la camera tourne deja, le decodeur reste leger ---
+        self.enable_qr_detection = bool(
+            self.declare_parameter('enable_qr_detection', True).value)
+        self.qr_period_sec = float(self.declare_parameter('qr_period_sec', 0.5).value)
+        self.qr_detector = cv2.QRCodeDetector()
+        self.last_qr_at = 0.0
+        self.last_qr_detections = []
+
         # --- Intrinseques : valeurs de repli, ecrasees par camera_info ---
         self.fx = float(self.declare_parameter('camera_fx', 600.0).value)
         self.fy = float(self.declare_parameter('camera_fy', 600.0).value)
@@ -88,6 +97,7 @@ class ObjectDetector(Node):
         self.create_subscription(String, '/roblaude/target_color', self._on_color_cmd, 5)
 
         self.pose_pub = self.create_publisher(PoseArray, '/roblaude/detections', 10)
+        self.qr_pub = self.create_publisher(String, '/roblaude/qr_detections', 10)
         # image annotee pour le reglage HSV en vrai
         self.image_pub = self.create_publisher(Image, '/roblaude/detection_image', 5)
 
@@ -158,8 +168,41 @@ class ObjectDetector(Node):
             x3d, y3d, z3d = backproject(px, py, z, self.fx, self.fy, self.cx, self.cy)
             detections.append((x3d, y3d, z3d, px, py, int(radius)))
 
+        qr_detections = self.last_qr_detections
+        if self._should_run_qr():
+            frame = self.latest_color.header.frame_id or 'camera_color_optical_frame'
+            qr_detections = build_qr_detections(
+                color_img=color_img,
+                depth_img=depth_img,
+                detector=self.qr_detector,
+                depth_scale=self.depth_scale,
+                min_depth=self.min_depth,
+                max_depth=self.max_depth,
+                fx=self.fx,
+                fy=self.fy,
+                cx=self.cx,
+                cy=self.cy,
+                frame=frame,
+            )
+            self.last_qr_detections = qr_detections
+            self._publish_qr(qr_detections)
+
         self._publish_poses(detections)
-        self._publish_annotated(color_img, detections)
+        self._publish_annotated(color_img, detections, qr_detections)
+
+    def _should_run_qr(self):
+        if not self.enable_qr_detection:
+            return False
+        now = self.get_clock().now().nanoseconds / 1_000_000_000.0
+        if now - self.last_qr_at < self.qr_period_sec:
+            return False
+        self.last_qr_at = now
+        return True
+
+    def _publish_qr(self, detections):
+        msg = String()
+        msg.data = qr_detections_to_json(detections)
+        self.qr_pub.publish(msg)
 
     def _publish_poses(self, detections):
         pa = PoseArray()
@@ -173,7 +216,7 @@ class ObjectDetector(Node):
             pa.poses.append(p)
         self.pose_pub.publish(pa)
 
-    def _publish_annotated(self, color_img, detections):
+    def _publish_annotated(self, color_img, detections, qr_detections=None):
         if self.image_pub.get_subscription_count() == 0:
             return  # personne ne regarde, on epargne la bande passante
         annotated = color_img.copy()
@@ -182,6 +225,13 @@ class ObjectDetector(Node):
             cv2.circle(annotated, (px, py), r, col, 2)
             label = f'{z:.2f}m' if z > 0 else 'no depth'
             cv2.putText(annotated, label, (px - 30, py - r - 8),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2)
+        for qr in qr_detections or []:
+            pts = np.array(qr.points, dtype=np.int32).reshape((-1, 1, 2))
+            col = (255, 0, 255) if qr.z > 0 else (255, 255, 0)
+            cv2.polylines(annotated, [pts], isClosed=True, color=col, thickness=2)
+            label = f'QR {qr.qr} {qr.z:.2f}m' if qr.z > 0 else f'QR {qr.qr} no depth'
+            cv2.putText(annotated, label, (qr.px - 40, qr.py - qr.radius - 12),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2)
         out = Image()
         out.header = self.latest_color.header

--- a/robot/roblaude_pickplace/roblaude_pickplace/qr.py
+++ b/robot/roblaude_pickplace/roblaude_pickplace/qr.py
@@ -1,0 +1,159 @@
+"""Detection QR + projection 3D, sans dependance ROS."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+import numpy as np
+
+from roblaude_pickplace.detection import backproject, sample_depth_median
+
+
+@dataclass(frozen=True)
+class QrCandidate:
+    text: str
+    points: tuple[tuple[int, int], ...]
+    px: int
+    py: int
+    radius: int
+
+
+@dataclass(frozen=True)
+class QrDetection:
+    qr: str
+    x: float
+    y: float
+    z: float
+    px: int
+    py: int
+    frame: str
+    points: tuple[tuple[int, int], ...]
+
+
+def _normalize_points(points: Any) -> tuple[tuple[int, int], ...]:
+    arr = np.asarray(points, dtype=np.float32).reshape(-1, 2)
+    if arr.shape[0] < 4:
+        return tuple()
+    return tuple((int(round(float(x))), int(round(float(y)))) for x, y in arr[:4])
+
+
+def _center_radius(points: tuple[tuple[int, int], ...]) -> tuple[int, int, int]:
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    px = int(round(sum(xs) / len(xs)))
+    py = int(round(sum(ys) / len(ys)))
+    radius = max(1, int(round(max(max(xs) - min(xs), max(ys) - min(ys)) / 2.0)))
+    return px, py, radius
+
+
+def _candidate(text: str, points: Any) -> QrCandidate | None:
+    if not text:
+        return None
+    normalized = _normalize_points(points)
+    if len(normalized) != 4:
+        return None
+    px, py, radius = _center_radius(normalized)
+    return QrCandidate(text=text, points=normalized, px=px, py=py, radius=radius)
+
+
+def _is_cv2_error(exc: Exception, cv2_module: Any) -> bool:
+    cv2_error = getattr(cv2_module, "error", None)
+    return cv2_error is not None and isinstance(exc, cv2_error)
+
+
+def detect_qr_candidates(color_img: np.ndarray | None, detector: Any = None) -> list[QrCandidate]:
+    if color_img is None or getattr(color_img, "ndim", 0) != 3:
+        return []
+
+    cv2_module = None
+    if detector is None:
+        import cv2 as cv2_module
+
+    qr_detector = detector or cv2_module.QRCodeDetector()
+    candidates: list[QrCandidate] = []
+
+    try:
+        ok, decoded_info, points, _straight = qr_detector.detectAndDecodeMulti(color_img)
+    except (ValueError, AttributeError):
+        ok, decoded_info, points = False, [], None
+    except Exception as exc:
+        if not _is_cv2_error(exc, cv2_module):
+            raise
+        ok, decoded_info, points = False, [], None
+
+    if ok and points is not None:
+        for text, pts in zip(decoded_info, points):
+            candidate = _candidate(text, pts)
+            if candidate is not None:
+                candidates.append(candidate)
+        if candidates:
+            return candidates
+
+    try:
+        text, points, _straight = qr_detector.detectAndDecode(color_img)
+    except (ValueError, AttributeError):
+        return []
+    except Exception as exc:
+        if not _is_cv2_error(exc, cv2_module):
+            raise
+        return []
+
+    candidate = _candidate(text, points)
+    return [candidate] if candidate is not None else []
+
+
+def build_qr_detections(
+    color_img: np.ndarray | None,
+    depth_img: np.ndarray | None,
+    detector: Any,
+    depth_scale: float,
+    min_depth: float,
+    max_depth: float,
+    fx: float,
+    fy: float,
+    cx: float,
+    cy: float,
+    frame: str,
+) -> list[QrDetection]:
+    detections: list[QrDetection] = []
+    for candidate in detect_qr_candidates(color_img, detector):
+        z = sample_depth_median(
+            depth_img,
+            candidate.px,
+            candidate.py,
+            candidate.radius,
+            depth_scale,
+            min_depth,
+            max_depth,
+        )
+        x3d, y3d, z3d = backproject(candidate.px, candidate.py, z, fx, fy, cx, cy)
+        detections.append(
+            QrDetection(
+                qr=candidate.text,
+                x=float(x3d),
+                y=float(y3d),
+                z=float(z3d),
+                px=candidate.px,
+                py=candidate.py,
+                frame=frame,
+                points=candidate.points,
+            )
+        )
+    return detections
+
+
+def qr_detections_to_json(detections: list[QrDetection]) -> str:
+    payload = [
+        {
+            "qr": det.qr,
+            "x": det.x,
+            "y": det.y,
+            "z": det.z,
+            "px": det.px,
+            "py": det.py,
+            "frame": det.frame,
+        }
+        for det in detections
+    ]
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))

--- a/robot/roblaude_pickplace/test/test_qr.py
+++ b/robot/roblaude_pickplace/test/test_qr.py
@@ -1,0 +1,153 @@
+"""Tests QR sans camera reelle : OpenCV est remplace par un faux detecteur."""
+import json
+
+import numpy as np
+
+from roblaude_pickplace.qr import (
+    build_qr_detections,
+    detect_qr_candidates,
+    qr_detections_to_json,
+)
+
+
+class FakeMultiDetector:
+    def detectAndDecodeMulti(self, _image):
+        points = np.array(
+            [
+                [[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]],
+                [[50.0, 10.0], [70.0, 10.0], [70.0, 30.0], [50.0, 30.0]],
+            ],
+            dtype=np.float32,
+        )
+        return True, ["OBJ_001", ""], points, None
+
+
+class FakeSingleDetector:
+    def detectAndDecodeMulti(self, _image):
+        return False, [], None, None
+
+    def detectAndDecode(self, _image):
+        points = np.array(
+            [[[15.0, 25.0], [35.0, 25.0], [35.0, 45.0], [15.0, 45.0]]],
+            dtype=np.float32,
+        )
+        return "OBJ_SINGLE", points, None
+
+
+class FakeEmptyDetector:
+    def detectAndDecodeMulti(self, _image):
+        return True, ["", ""], np.zeros((2, 4, 2), dtype=np.float32), None
+
+    def detectAndDecode(self, _image):
+        return "", None, None
+
+
+def test_detect_qr_candidates_multi_ignore_text_empty():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    candidates = detect_qr_candidates(image, FakeMultiDetector())
+
+    assert len(candidates) == 1
+    assert candidates[0].text == "OBJ_001"
+    assert candidates[0].points == ((10, 20), (30, 20), (30, 40), (10, 40))
+    assert candidates[0].px == 20
+    assert candidates[0].py == 30
+    assert candidates[0].radius == 10
+
+
+def test_detect_qr_candidates_single_fallback():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    candidates = detect_qr_candidates(image, FakeSingleDetector())
+
+    assert len(candidates) == 1
+    assert candidates[0].text == "OBJ_SINGLE"
+    assert candidates[0].px == 25
+    assert candidates[0].py == 35
+
+
+def test_detect_qr_candidates_empty_image_or_empty_text():
+    assert detect_qr_candidates(None, FakeEmptyDetector()) == []
+    assert detect_qr_candidates(np.zeros((80, 80), dtype=np.uint8), FakeEmptyDetector()) == []
+    assert detect_qr_candidates(np.zeros((80, 80, 3), dtype=np.uint8), FakeEmptyDetector()) == []
+
+
+def test_build_qr_detections_with_depth_and_backprojection():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    depth = np.full((80, 80), 500, dtype=np.uint16)
+
+    detections = build_qr_detections(
+        color_img=image,
+        depth_img=depth,
+        detector=FakeMultiDetector(),
+        depth_scale=0.001,
+        min_depth=0.15,
+        max_depth=1.0,
+        fx=100.0,
+        fy=100.0,
+        cx=20.0,
+        cy=30.0,
+        frame="camera_color_optical_frame",
+    )
+
+    assert len(detections) == 1
+    assert detections[0].qr == "OBJ_001"
+    assert detections[0].px == 20
+    assert detections[0].py == 30
+    assert detections[0].x == 0.0
+    assert detections[0].y == 0.0
+    assert abs(detections[0].z - 0.5) < 1e-9
+    assert detections[0].frame == "camera_color_optical_frame"
+
+
+def test_build_qr_detections_invalid_depth_keeps_pixel_and_zero_xyz():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    depth = np.zeros((80, 80), dtype=np.uint16)
+
+    detections = build_qr_detections(
+        color_img=image,
+        depth_img=depth,
+        detector=FakeMultiDetector(),
+        depth_scale=0.001,
+        min_depth=0.15,
+        max_depth=1.0,
+        fx=100.0,
+        fy=100.0,
+        cx=20.0,
+        cy=30.0,
+        frame="camera_color_optical_frame",
+    )
+
+    assert len(detections) == 1
+    assert detections[0].qr == "OBJ_001"
+    assert (detections[0].x, detections[0].y, detections[0].z) == (0.0, 0.0, 0.0)
+
+
+def test_qr_detections_to_json_contract():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    depth = np.full((80, 80), 500, dtype=np.uint16)
+    detections = build_qr_detections(
+        color_img=image,
+        depth_img=depth,
+        detector=FakeMultiDetector(),
+        depth_scale=0.001,
+        min_depth=0.15,
+        max_depth=1.0,
+        fx=100.0,
+        fy=100.0,
+        cx=20.0,
+        cy=30.0,
+        frame="camera_color_optical_frame",
+    )
+
+    payload = json.loads(qr_detections_to_json(detections))
+
+    assert payload == [
+        {
+            "qr": "OBJ_001",
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.5,
+            "px": 20,
+            "py": 30,
+            "frame": "camera_color_optical_frame",
+        }
+    ]

--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -24,6 +24,7 @@ done
 # Autoriser X local pour le container
 xhost +local:root >/dev/null 2>&1 || true
 ROBLAUDE_MODE="${ROBLAUDE_MODE:-minimal}"
+ROBLAUDE_ARM_HOME_ON_BOOT="${ROBLAUDE_ARM_HOME_ON_BOOT:-true}"
 
 # Repertoires hote persistants (jetson est owner, pas de sudo)
 mkdir -p /home/jetson/roblaude_ws/scripts
@@ -38,6 +39,17 @@ if [ ! -d /etc/roblaude ]; then
     echo "ATTENTION : /etc/roblaude absent — lance install_persistence.sh d'abord"
 fi
 
+# Avant Docker : stabilise l'USB hote. Le container doit demarrer apres
+# enumeration des peripheriques critiques, sinon les drivers ROS voient des
+# devices absents ou des minors USB depasses.
+if command -v roblaude-usb-boot-guard.sh >/dev/null 2>&1; then
+    echo "Preflight USB hote..."
+    sudo -n roblaude-usb-boot-guard.sh || echo "ATTENTION : USB boot guard non OK"
+elif [ -x /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh ]; then
+    echo "Preflight USB hote..."
+    sudo -n /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh || echo "ATTENTION : USB boot guard non OK"
+fi
+
 # Recreer "m3pro" a chaque boot pour que les nouveaux volumes/flags prennent.
 # Le container persiste via --restart=unless-stopped tant que ce script n'est
 # pas rejoue (ex: relogin).
@@ -46,9 +58,9 @@ if docker ps -a --format '{{.Names}}' | grep -qx m3pro; then
     docker rm m3pro >/dev/null 2>&1 || true
 fi
 
-# DaBai DCW2 : la couleur (RGB) passe par l'UVC /dev/video0 (node pub_rgb_image),
-# la depth par /dev/bus/usb (OrbbecSDK). Sans /dev/video0 dans le container, pas
-# de flux couleur. On le passe s'il est present.
+# DaBai DCW2 : l'OrbbecSDK lit /dev/bus/usb. Il faut un bind dynamique +
+# cgroup wildcard, sinon apres re-enumeration USB le container ne voit que les
+# anciens minors (ex: 189:12) et la camera devient invisible (ex: 189:51).
 VIDEO_DEV=""
 [ -e /dev/video0 ] && VIDEO_DEV="--device=/dev/video0"
 
@@ -64,6 +76,7 @@ docker run -d \
   -e ROS_DOMAIN_ID=30 \
   -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 \
   -e ROBLAUDE_MODE="${ROBLAUDE_MODE}" \
+  -e ROBLAUDE_ARM_HOME_ON_BOOT="${ROBLAUDE_ARM_HOME_ON_BOOT}" \
   -v /run/user/1000/pulse:/run/user/1000/pulse:ro \
   -v /home/jetson/.config/pulse:/root/.config/pulse:ro \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
@@ -71,7 +84,8 @@ docker run -d \
   -v /home/jetson/robot_maps:/root/maps \
   -v /home/jetson/.local:/root/.local \
   -v /etc/roblaude:/etc/roblaude:ro \
-  --device=/dev/bus/usb \
+  -v /dev/bus/usb:/dev/bus/usb \
+  --device-cgroup-rule='c 189:* rwm' \
   --device=/dev/input \
   $VIDEO_DEV \
   --security-opt apparmor:unconfined \

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -21,6 +21,7 @@ M3PRO_WS="${M3PRO_WS:-/root/M3Pro_ws}"
 MAPS_DIR="${MAPS_DIR:-/root/maps}"
 BROKER_IP_FILE="${BROKER_IP_FILE:-/etc/roblaude/broker_ip}"
 ROBLAUDE_MODE="${ROBLAUDE_MODE:-minimal}"
+ROBLAUDE_ARM_HOME_ON_BOOT="${ROBLAUDE_ARM_HOME_ON_BOOT:-true}"
 
 export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-30}"
 export FASTDDS_BUILTIN_TRANSPORTS="${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}"
@@ -156,13 +157,21 @@ if [ "$ROBLAUDE_MODE" = "full" ]; then
         echo "[autostart] roblaude_pickplace pas encore build, detecteur non lance"
     fi
 
-    # Bras en HOME au demarrage (apres YB_Node pret).
-    arm_home_when_ready
+    # Bras en HOME au demarrage (apres YB_Node pret), sauf maintenance.
+    if [ "$ROBLAUDE_ARM_HOME_ON_BOOT" = "true" ]; then
+        arm_home_when_ready
+    else
+        echo "[autostart] ARM_HOME skip (ROBLAUDE_ARM_HOME_ON_BOOT=false)"
+    fi
 else
     echo "[autostart] mode minimal : camera/detector non lances au boot"
     # Bras en HOME au boot meme en minimal (demande explicite) : YB_Node frais +
     # pas de charge = le bon moment pour partir d'une pose connue.
-    arm_home_when_ready
+    if [ "$ROBLAUDE_ARM_HOME_ON_BOOT" = "true" ]; then
+        arm_home_when_ready
+    else
+        echo "[autostart] ARM_HOME skip (ROBLAUDE_ARM_HOME_ON_BOOT=false)"
+    fi
 fi
 
 echo "[autostart] tout lance. Logs : /tmp/roslogs/*.log"

--- a/robot/scripts/find_robot.sh
+++ b/robot/scripts/find_robot.sh
@@ -33,36 +33,41 @@ find_robot() {
 
     echo "🔍 Scan du subnet pour trouver le robot (MAC $ROBOT_MAC)..." >&2
 
-    # 2) Deduire le prefix subnet depuis l IP locale
-    local prefix="${SUBNET_PREFIX}"
-    if [ -z "$prefix" ]; then
-        local local_ip
-        local_ip=$(ipconfig getifaddr en0 2>/dev/null)
-        if [ -z "$local_ip" ]; then
-            # Fallback Linux : route par defaut
-            local_ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)
-        fi
-        prefix=$(echo "$local_ip" | cut -d. -f1-3)
+    # 2) Deduire les prefixes a scanner depuis le Wi-Fi/local normal.
+    # Decision soutenance : robot + Mac sur un vrai Wi-Fi commun, pas hotspot.
+    local prefixes=""
+    if [ -n "$SUBNET_PREFIX" ]; then
+        prefixes="$SUBNET_PREFIX"
+    else
+        local local_ips=""
+        local_ips="$local_ips $(ipconfig getifaddr en0 2>/dev/null || true)"
+        local_ips="$local_ips $(ifconfig en0 2>/dev/null | awk '/inet / {print $2}')"
+        local_ips="$local_ips $(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
+        prefixes=$(printf "%s\n" $local_ips | awk -F. 'NF==4 && $1 != "127" {print $1"."$2"."$3}' | awk '!seen[$0]++')
     fi
 
-    if [ -z "$prefix" ]; then
+    if [ -z "$prefixes" ]; then
         echo "❌ Impossible de deduire le subnet local" >&2
         return 1
     fi
 
-    # 3) Ping parallele sur tout le subnet pour peupler la table ARP
-    echo "   -> ping $prefix.1-254 en parallele..." >&2
-    for i in $(seq 1 254); do
-        ping -c 1 -W 1 -t 1 "$prefix.$i" > /dev/null 2>&1 &
-    done
-    wait 2>/dev/null
-
-    # 4) Chercher la MAC dans la table ARP (compatible macOS BSD et Linux)
+    # 3) Chercher d'abord dans ARP, puis scanner chaque subnet pour peupler ARP.
     local found_ip
     found_ip=$(arp -a 2>/dev/null | grep -i "$ROBOT_MAC" | awk -F'[()]' '{print $2}' | head -1)
 
+    local prefix
+    for prefix in $prefixes; do
+        [ -n "$found_ip" ] && break
+        echo "   -> ping $prefix.1-254 en parallele..." >&2
+        for i in $(seq 1 254); do
+            ping -c 1 -W 1 -t 1 "$prefix.$i" > /dev/null 2>&1 &
+        done
+        wait 2>/dev/null
+        found_ip=$(arp -a 2>/dev/null | grep -i "$ROBOT_MAC" | awk -F'[()]' '{print $2}' | head -1)
+    done
+
     if [ -z "$found_ip" ]; then
-        echo "❌ Robot introuvable dans $prefix.0/24 (MAC $ROBOT_MAC)" >&2
+        echo "❌ Robot introuvable dans les subnets detectes : $prefixes (MAC $ROBOT_MAC)" >&2
         echo "   Verifie que le robot est allume et sur le meme WiFi que toi." >&2
         return 1
     fi

--- a/robot/scripts/install_microros_service.sh
+++ b/robot/scripts/install_microros_service.sh
@@ -16,8 +16,20 @@ SRC="$(cd "$(dirname "$0")" && pwd)"
 echo "━━━ 1/4 : helpers dans /usr/local/bin ━━━"
 sudo install -m 0755 "$SRC/roblaude-usb-stable.sh"         /usr/local/bin/roblaude-usb-stable.sh
 sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"        /usr/local/bin/roblaude-link-stm32.sh
+sudo install -m 0755 "$SRC/roblaude-stm32-usb-recover.sh" /usr/local/bin/roblaude-stm32-usb-recover.sh
 sudo install -m 0755 "$SRC/roblaude-stm32-healthcheck.sh" /usr/local/bin/roblaude-stm32-healthcheck.sh
 sudo install -m 0755 "$SRC/roblaude-robot-status.sh"      /usr/local/bin/roblaude-robot-status.sh
+sudo install -m 0755 "$SRC/roblaude-usb-boot-guard.sh"    /usr/local/bin/roblaude-usb-boot-guard.sh
+sudo install -m 0755 "$SRC/roblaude-demo-preflight.sh"    /usr/local/bin/roblaude-demo-preflight.sh
+if [ -f "$SRC/roblaude-hub-port-power.c" ] && command -v gcc >/dev/null && command -v pkg-config >/dev/null && pkg-config --exists libusb-1.0; then
+  if sudo gcc -O2 -Wall -Wextra "$SRC/roblaude-hub-port-power.c" -o /usr/local/bin/roblaude-hub-port-power $(pkg-config --cflags --libs libusb-1.0); then
+    echo "   roblaude-hub-port-power compile"
+  else
+    echo "   compilation roblaude-hub-port-power echouee (fallback sysfs garde)"
+  fi
+else
+  echo "   gcc/libusb indisponible (fallback sysfs garde)"
+fi
 
 echo "━━━ 1bis/4 : dossier diag root-owned ━━━"
 sudo install -d -o root -g root -m 0755 /var/log/roblaude
@@ -27,6 +39,7 @@ sudo install -m 0644 "$SRC/systemd/micro-ros-agent.service"            /etc/syst
 sudo install -m 0644 "$SRC/systemd/roblaude-stm32-healthcheck.service" /etc/systemd/system/roblaude-stm32-healthcheck.service
 sudo install -m 0644 "$SRC/systemd/roblaude-stm32-healthcheck.timer"   /etc/systemd/system/roblaude-stm32-healthcheck.timer
 sudo install -m 0644 "$SRC/systemd/roblaude-usb-stable.service"        /etc/systemd/system/roblaude-usb-stable.service
+sudo install -m 0644 "$SRC/systemd/roblaude-demo-preflight.service"    /etc/systemd/system/roblaude-demo-preflight.service
 sudo install -m 0644 "$SRC/systemd/roblaude-m3pro.service"             /etc/systemd/system/roblaude-m3pro.service
 
 echo "━━━ 3/4 : on coupe l'ancien autostart GUI fragile (si present) ━━━"
@@ -38,7 +51,9 @@ GUI=/home/jetson/.config/autostart/uros.desktop
 echo "━━━ 4/4 : (re)demarrage des services ━━━"
 sudo systemctl daemon-reload
 sudo systemctl enable --now roblaude-usb-stable.service
-sudo systemctl enable --now micro-ros-agent.service
+sudo systemctl enable roblaude-demo-preflight.service
+sudo systemctl enable micro-ros-agent.service
+sudo systemctl restart micro-ros-agent.service || true
 sudo systemctl enable roblaude-m3pro.service
 sudo systemctl enable --now roblaude-stm32-healthcheck.timer
 sleep 10
@@ -48,4 +63,4 @@ echo "━━━ verif ━━━"
 echo "myserial : $(readlink -f /dev/myserial)"
 echo "agent    : $(systemctl is-active micro-ros-agent.service)"
 echo "timer    : $(systemctl is-active roblaude-stm32-healthcheck.timer)"
-sudo /usr/local/bin/roblaude-stm32-healthcheck.sh
+sudo /usr/local/bin/roblaude-stm32-healthcheck.sh || true

--- a/robot/scripts/roblaude-demo-preflight.sh
+++ b/robot/scripts/roblaude-demo-preflight.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# Preflight demo RobLaude : verifie et repare les points qui cassent l'oral.
+# Par defaut : check seul. Avec --repair : tente les reparations ciblees.
+set -u
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+REPAIR=false
+START_CAMERA=false
+BOOT_ONLY=false
+LOG_DIR=/var/log/roblaude
+LOG="$LOG_DIR/demo_preflight_$(date +%Y%m%d-%H%M%S).log"
+
+for arg in "$@"; do
+  case "$arg" in
+    --repair) REPAIR=true ;;
+    --start-camera) START_CAMERA=true ;;
+    --boot) BOOT_ONLY=true ;;
+    --help|-h)
+      echo "Usage: $0 [--repair] [--start-camera] [--boot]"
+      exit 0
+      ;;
+  esac
+done
+
+install -d -o root -g root -m 0755 "$LOG_DIR" 2>/dev/null || mkdir -p "$LOG_DIR"
+
+log() {
+  echo "$*"
+  echo "$*" >> "$LOG" 2>/dev/null || true
+}
+
+ok() { log "OK  $*"; }
+warn() { log "WARN $*"; }
+ko() { log "KO  $*"; FAILED=true; }
+
+FAILED=false
+RESTARTED_M3PRO=false
+
+usb_present() {
+  lsusb -d "$1" >/dev/null 2>&1
+}
+
+check_usb() {
+  missing=""
+  usb_present 2357:012e || missing="$missing wifi"
+  usb_present 10c4:ea60 || missing="$missing stm32"
+  usb_present 1a86:7522 || missing="$missing ch341"
+  usb_present 2bc5:06a0 || missing="$missing orbbec_depth"
+  usb_present 2bc5:0561 || missing="$missing orbbec_rgb"
+
+  if [ -z "$missing" ]; then
+    ok "USB critiques presents"
+    return 0
+  fi
+
+  warn "USB manquants:$missing"
+  if [ "$REPAIR" = true ]; then
+    if command -v roblaude-usb-boot-guard.sh >/dev/null 2>&1; then
+      log "repair: roblaude-usb-boot-guard.sh"
+      roblaude-usb-boot-guard.sh >> "$LOG" 2>&1 || true
+    elif [ -x /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh ]; then
+      log "repair: workspace roblaude-usb-boot-guard.sh"
+      /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh >> "$LOG" 2>&1 || true
+    else
+      warn "boot guard absent"
+    fi
+  fi
+
+  missing_after=""
+  usb_present 2357:012e || missing_after="$missing_after wifi"
+  usb_present 10c4:ea60 || missing_after="$missing_after stm32"
+  usb_present 1a86:7522 || missing_after="$missing_after ch341"
+  usb_present 2bc5:06a0 || missing_after="$missing_after orbbec_depth"
+  usb_present 2bc5:0561 || missing_after="$missing_after orbbec_rgb"
+  [ -z "$missing_after" ] && { ok "USB revenus apres repair"; return 0; }
+  ko "USB toujours manquants:$missing_after"
+  return 1
+}
+
+m3pro_running() {
+  docker ps --format '{{.Names}}' | grep -qx m3pro
+}
+
+m3pro_usb_dynamic_ok() {
+  m3pro_running || return 1
+  docker exec m3pro bash -lc "grep -q 'c 189:\\* rwm' /sys/fs/cgroup/devices/devices.list 2>/dev/null" >/dev/null 2>&1
+}
+
+recreate_m3pro() {
+  [ "$REPAIR" = true ] || return 1
+  log "repair: recreate m3pro avec Docker_M3Pro_Joy.sh"
+  if [ -x /home/jetson/Docker_M3Pro_Joy.sh ]; then
+    ROBLAUDE_ARM_HOME_ON_BOOT=false /home/jetson/Docker_M3Pro_Joy.sh >> "$LOG" 2>&1 || return 1
+  elif [ -x /home/jetson/roblaude_ws/scripts/Docker_M3Pro_Joy.sh ]; then
+    ROBLAUDE_ARM_HOME_ON_BOOT=false /home/jetson/roblaude_ws/scripts/Docker_M3Pro_Joy.sh >> "$LOG" 2>&1 || return 1
+  else
+    warn "Docker_M3Pro_Joy.sh absent"
+    return 1
+  fi
+  RESTARTED_M3PRO=true
+  sleep 10
+  return 0
+}
+
+check_m3pro() {
+  if ! m3pro_running; then
+    warn "m3pro absent"
+    recreate_m3pro || { ko "m3pro absent et recreate echoue"; return 1; }
+  fi
+
+  if m3pro_usb_dynamic_ok; then
+    ok "m3pro USB dynamique autorise"
+    return 0
+  fi
+
+  warn "m3pro sans cgroup USB dynamique c 189:*"
+  recreate_m3pro || { ko "m3pro vieux droits USB et recreate echoue"; return 1; }
+
+  if m3pro_usb_dynamic_ok; then
+    ok "m3pro USB dynamique OK apres recreate"
+    return 0
+  fi
+  ko "m3pro USB dynamique toujours KO"
+  return 1
+}
+
+ros_exec() {
+  docker exec \
+    -e ROS_DOMAIN_ID=30 \
+    -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 \
+    m3pro bash -lc "
+      source /opt/ros/humble/setup.bash
+      source /root/yahboomcar_ws/install/setup.bash 2>/dev/null || true
+      source /root/M3Pro_ws/install/setup.bash 2>/dev/null || true
+      source /root/roblaude_ws/install/setup.bash 2>/dev/null || true
+      export ROS_DOMAIN_ID=30
+      export FASTDDS_BUILTIN_TRANSPORTS=UDPv4
+      $*
+    "
+}
+
+check_ros_core() {
+  m3pro_running || { ko "ROS impossible, m3pro absent"; return 1; }
+  nodes=$(ros_exec "timeout 8 ros2 node list" 2>/dev/null || true)
+  if [ -n "$nodes" ]; then
+    ok "ROS graph lisible"
+  else
+    ko "ROS graph illisible"
+    return 1
+  fi
+
+  if echo "$nodes" | grep -q /YB_Node; then
+    ok "YB_Node present"
+  else
+    warn "YB_Node absent dans le graphe"
+  fi
+}
+
+check_stm32() {
+  if [ -x /usr/local/bin/roblaude-robot-status.sh ]; then
+    status=$(/usr/local/bin/roblaude-robot-status.sh 2>/dev/null || true)
+    log "$status"
+    echo "$status" | grep -q '"myserial_ok":true' && echo "$status" | grep -q '"stm32_data":true' \
+      && { ok "STM32/micro-ROS data OK"; return 0; }
+  fi
+
+  warn "STM32/micro-ROS pas confirme"
+  if [ "$REPAIR" = true ]; then
+    systemctl restart micro-ros-agent.service 2>/dev/null || true
+    sleep 8
+    if [ -x /usr/local/bin/roblaude-robot-status.sh ]; then
+      status=$(/usr/local/bin/roblaude-robot-status.sh 2>/dev/null || true)
+      log "$status"
+      echo "$status" | grep -q '"myserial_ok":true' && echo "$status" | grep -q '"stm32_data":true' \
+        && { ok "STM32/micro-ROS OK apres restart"; return 0; }
+    fi
+  fi
+  ko "STM32/micro-ROS KO"
+  return 1
+}
+
+camera_frames_ok() {
+  ros_exec "
+    timeout 8 ros2 topic echo /camera/color/camera_info --once >/tmp/roblaude_preflight_camera_info 2>/dev/null &&
+    timeout 8 ros2 topic echo /camera/color/image_raw --once >/tmp/roblaude_preflight_camera_color 2>/dev/null
+  "
+}
+
+check_camera() {
+  [ "$START_CAMERA" = true ] || { ok "camera non demandee"; return 0; }
+  if camera_frames_ok; then
+    ok "camera frames OK"
+    return 0
+  fi
+
+  warn "camera sans frames"
+  if [ "$REPAIR" = true ]; then
+    /home/jetson/roblaude_ws/scripts/start_perception.sh >> "$LOG" 2>&1 || true
+    if camera_frames_ok; then
+      ok "camera frames OK apres start_perception"
+      return 0
+    fi
+  fi
+  ko "camera frames KO"
+  return 1
+}
+
+log "=== RobLaude demo preflight $(date) repair=$REPAIR start_camera=$START_CAMERA boot=$BOOT_ONLY ==="
+log "uptime: $(uptime)"
+check_usb || true
+if [ "$BOOT_ONLY" = true ]; then
+  if [ "$FAILED" = true ]; then
+    log "RESULT=NO_GO_BOOT log=$LOG"
+    exit 1
+  fi
+  log "RESULT=GO_BOOT log=$LOG"
+  exit 0
+fi
+
+check_m3pro || true
+check_ros_core || true
+check_stm32 || true
+check_camera || true
+
+if [ "$FAILED" = true ]; then
+  log "RESULT=NO_GO log=$LOG"
+  exit 1
+fi
+
+if [ "$RESTARTED_M3PRO" = true ]; then
+  log "RESULT=GO_AFTER_M3PRO_RECREATE log=$LOG"
+else
+  log "RESULT=GO log=$LOG"
+fi
+exit 0

--- a/robot/scripts/roblaude-hub-port-power.c
+++ b/robot/scripts/roblaude-hub-port-power.c
@@ -1,0 +1,109 @@
+#include <libusb.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define USB_PORT_FEAT_POWER 8
+
+static int parse_int(const char *s, int *out) {
+  char *end = NULL;
+  long value = strtol(s, &end, 10);
+  if (end == s || *end != '\0' || value < 0 || value > 255) {
+    return -1;
+  }
+  *out = (int)value;
+  return 0;
+}
+
+static int parse_action(const char *s, int *on) {
+  if (strcmp(s, "on") == 0 || strcmp(s, "1") == 0) {
+    *on = 1;
+    return 0;
+  }
+  if (strcmp(s, "off") == 0 || strcmp(s, "0") == 0) {
+    *on = 0;
+    return 0;
+  }
+  return -1;
+}
+
+int main(int argc, char **argv) {
+  int bus = 0;
+  int dev = 0;
+  int port = 0;
+  int on = 0;
+  libusb_context *ctx = NULL;
+  libusb_device **devices = NULL;
+  libusb_device_handle *handle = NULL;
+  ssize_t count = 0;
+  int rc = 0;
+
+  if (argc != 5 ||
+      parse_int(argv[1], &bus) != 0 ||
+      parse_int(argv[2], &dev) != 0 ||
+      parse_int(argv[3], &port) != 0 ||
+      port < 1 ||
+      parse_action(argv[4], &on) != 0) {
+    fprintf(stderr, "usage: %s <busnum> <devnum> <port> <on|off>\n", argv[0]);
+    return 2;
+  }
+
+  rc = libusb_init(&ctx);
+  if (rc != 0) {
+    fprintf(stderr, "libusb_init: %s\n", libusb_error_name(rc));
+    return 1;
+  }
+
+  count = libusb_get_device_list(ctx, &devices);
+  if (count < 0) {
+    fprintf(stderr, "libusb_get_device_list: %s\n", libusb_error_name((int)count));
+    libusb_exit(ctx);
+    return 1;
+  }
+
+  for (ssize_t i = 0; i < count; i++) {
+    libusb_device *device = devices[i];
+    if ((int)libusb_get_bus_number(device) == bus &&
+        (int)libusb_get_device_address(device) == dev) {
+      rc = libusb_open(device, &handle);
+      if (rc != 0) {
+        fprintf(stderr, "libusb_open bus=%d dev=%d: %s\n", bus, dev, libusb_error_name(rc));
+      }
+      break;
+    }
+  }
+
+  if (handle == NULL) {
+    if (rc == 0) {
+      fprintf(stderr, "hub introuvable bus=%d dev=%d\n", bus, dev);
+    }
+    libusb_free_device_list(devices, 1);
+    libusb_exit(ctx);
+    return 1;
+  }
+
+  rc = libusb_control_transfer(
+      handle,
+      LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_OTHER,
+      on ? LIBUSB_REQUEST_SET_FEATURE : LIBUSB_REQUEST_CLEAR_FEATURE,
+      USB_PORT_FEAT_POWER,
+      (uint16_t)port,
+      NULL,
+      0,
+      2000);
+
+  if (rc < 0) {
+    fprintf(stderr, "port %d %s: %s\n", port, on ? "on" : "off", libusb_error_name(rc));
+    libusb_close(handle);
+    libusb_free_device_list(devices, 1);
+    libusb_exit(ctx);
+    return 1;
+  }
+
+  printf("hub bus=%d dev=%d port=%d %s\n", bus, dev, port, on ? "on" : "off");
+  libusb_close(handle);
+  libusb_free_device_list(devices, 1);
+  libusb_exit(ctx);
+  return 0;
+}

--- a/robot/scripts/roblaude-link-stm32.sh
+++ b/robot/scripts/roblaude-link-stm32.sh
@@ -3,7 +3,11 @@
 # NE JAMAIS lier le CH340 (1a86) : c'est le micro du robot (cf speech.rules).
 # On keye sur la puce, pas sur ttyUSB0/1 : l'ordre d'enumeration change au boot.
 set -u
-for i in $(seq 1 90); do
+WAIT_SECS=${ROBLAUDE_LINK_WAIT_SECS:-90}
+case "$WAIT_SECS" in
+  ''|*[!0-9]*) WAIT_SECS=90 ;;
+esac
+for i in $(seq 1 "$WAIT_SECS"); do
   for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
     [ -e "$d" ] || continue
     ln -sf "$d" /dev/myserial

--- a/robot/scripts/roblaude-stm32-healthcheck.sh
+++ b/robot/scripts/roblaude-stm32-healthcheck.sh
@@ -5,6 +5,8 @@
 set -u
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 SVC=micro-ros-agent.service
+LINK=/usr/local/bin/roblaude-link-stm32.sh
+RECOVER=/usr/local/bin/roblaude-stm32-usb-recover.sh
 # Tourne en root (oneshot systemd) : on garde le diag dans un dossier root-owned,
 # pas dans /home/jetson (sinon un compte jetson compromis pourrait piéger le chemin
 # par symlink et faire écrire root ailleurs). 0755 => lisible sans sudo.
@@ -15,27 +17,46 @@ COOLDOWN=300
 install -d -o root -g root -m 0755 "$DIAGDIR" 2>/dev/null || mkdir -p "$DIAGDIR"
 reason=""
 
-# 1. container agent vivant ?
-docker ps --format '{{.Names}}' | grep -q '^micro_ros_agent$' || reason="container micro_ros_agent absent"
+cp210_path() {
+  for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
+    [ -e "$d" ] || continue
+    readlink -f "$d"
+    return 0
+  done
+  return 1
+}
 
-# 2. myserial pointe bien sur le CP210x (jamais le CH340) ?
+cp210_present() {
+  cp210_path >/dev/null 2>&1 && return 0
+  lsusb -d 10c4:ea60 >/dev/null 2>&1 && return 0
+  return 1
+}
+
+# 1. Le STM32 est-il enumere ?
+if ! cp210_present; then
+  reason="STM32 CP210x absent du bus USB"
+fi
+
+# 2. container agent vivant ?
+if [ -z "$reason" ]; then
+  docker ps --format '{{.Names}}' | grep -q '^micro_ros_agent$' || reason="container micro_ros_agent absent"
+fi
+
+# 3. myserial pointe bien sur le CP210x (jamais le CH340) ?
 if [ -z "$reason" ]; then
   tgt=$(readlink -f /dev/myserial 2>/dev/null || true)
-  cp=""
-  for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
-    [ -e "$d" ] && cp=$(readlink -f "$d") && break
-  done
+  cp=$(cp210_path 2>/dev/null || true)
   [ -z "$cp" ] && reason="STM32 CP210x absent de /dev/serial/by-id"
   [ -z "$reason" ] && [ "$tgt" != "$cp" ] && reason="myserial->$tgt mais STM32(CP210x)=$cp"
 fi
 
-# 3. L'agent peut rester "active" apres disparition du port : lire son log.
+# 4. L'agent peut rester "active" apres disparition du port : lire son log.
 if [ -z "$reason" ]; then
   docker logs --tail 20 micro_ros_agent 2>&1 | grep -q 'Serial port not found' \
     && reason="micro_ros_agent actif mais /dev/myserial absent"
 fi
 
-# 4. Preuve de vie STM32 : un message frais, pas un node zombie.
+# 5. Preuve de vie STM32 : un message frais, pas un node zombie.
 if [ -z "$reason" ]; then
   docker ps --format '{{.Names}}' | grep -q '^m3pro$' || reason="container m3pro absent"
 fi
@@ -57,14 +78,30 @@ F="$DIAGDIR/incident_$(date +%Y%m%d-%H%M%S).log"
 [ -L "$F" ] && rm -f "$F"   # jamais suivre un symlink piégé
 {
   echo "REASON: $reason"; date; uptime
+  echo "--- usb tree ---"; lsusb 2>&1; lsusb -t 2>&1
   echo "--- myserial ---"; ls -l /dev/myserial 2>&1; ls -l /dev/serial/by-id 2>&1
   echo "--- docker ps ---"; docker ps 2>&1
+  echo "--- systemd ---"; systemctl --no-pager --plain status "$SVC" 2>&1 | sed -n '1,80p'
   echo "--- agent log ---"; docker logs --tail 40 micro_ros_agent 2>&1
   echo "--- dmesg usb ---"; dmesg 2>/dev/null | grep -Ei 'ch34|cp210|ttyusb|usb .*disconnect|Cannot enable|enumerate' | tail -30
 } > "$F" 2>&1
 echo "incident: $reason -> $F"
 
-/usr/local/bin/roblaude-link-stm32.sh || true
+if ! cp210_present; then
+  if [ -x "$RECOVER" ]; then
+    "$RECOVER" || true
+  else
+    echo "$RECOVER absent, recovery USB impossible"
+  fi
+fi
+
+if ! cp210_present; then
+  systemctl stop "$SVC" 2>/dev/null || true
+  echo "CP210x toujours absent, $SVC stoppe jusqu'au prochain healthcheck"
+  exit 1
+fi
+
+ROBLAUDE_LINK_WAIT_SECS=10 "$LINK" || true
 now=$(date +%s); last=$(cat "$STAMP" 2>/dev/null || echo 0)
 if [ $((now-last)) -ge $COOLDOWN ]; then
   echo "$now" > "$STAMP"; systemctl restart "$SVC"; echo "restart $SVC"

--- a/robot/scripts/roblaude-stm32-usb-recover.sh
+++ b/robot/scripts/roblaude-stm32-usb-recover.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Recovery USB cible pour le STM32 CP210x.
+# Sur ce robot, le CP210x tombe derriere le hub USB2 1-2, port 3
+# ("usb 1-2-port3: Cannot enable"). On reset ce hub, jamais le bus complet.
+set -u
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+HUB=${ROBLAUDE_STM32_USB_HUB:-1-2.4}
+HUB_PORT=${ROBLAUDE_STM32_USB_PORT:-1}
+PARENT_HUB=${ROBLAUDE_STM32_PARENT_USB_HUB:-1-2}
+PARENT_PORT=${ROBLAUDE_STM32_PARENT_USB_PORT:-4}
+COOLDOWN=${ROBLAUDE_STM32_USB_RESET_COOLDOWN:-300}
+OFF_SECS=${ROBLAUDE_STM32_USB_RESET_OFF_SECS:-5}
+SETTLE_SECS=${ROBLAUDE_STM32_USB_RESET_SETTLE_SECS:-15}
+STAMP=/run/roblaude-stm32-usb-reset
+LOCKDIR=/run/roblaude-stm32-usb-reset.lock
+DIAGDIR=/var/log/roblaude
+port_cycle_ran=false
+port_cycle_failed=false
+
+case "$COOLDOWN" in ''|*[!0-9]*) COOLDOWN=300 ;; esac
+case "$HUB_PORT" in ''|*[!0-9]*) HUB_PORT=1 ;; esac
+case "$PARENT_PORT" in ''|*[!0-9]*) PARENT_PORT=4 ;; esac
+case "$OFF_SECS" in ''|*[!0-9]*) OFF_SECS=5 ;; esac
+case "$SETTLE_SECS" in ''|*[!0-9]*) SETTLE_SECS=15 ;; esac
+
+install -d -o root -g root -m 0755 "$DIAGDIR" 2>/dev/null || mkdir -p "$DIAGDIR"
+LOG="$DIAGDIR/usb_recover_$(date +%Y%m%d-%H%M%S).log"
+
+log() {
+  echo "$*"
+  echo "$*" >> "$LOG" 2>/dev/null || true
+}
+
+cp210_present() {
+  lsusb -d 10c4:ea60 >/dev/null 2>&1 && return 0
+  for d in /dev/serial/by-id/*Silicon_Labs* /dev/serial/by-id/*CP210*; do
+    [ -e "$d" ] && return 0
+  done
+  return 1
+}
+
+hub_has_root_disk() {
+  check_hub=$1
+  root_src=$(findmnt -n -o SOURCE / 2>/dev/null || true)
+  [ -n "$root_src" ] || return 1
+  root_dev=$(readlink -f "$root_src" 2>/dev/null || true)
+  root_name=$(basename "$root_dev" 2>/dev/null || true)
+  [ -n "$root_name" ] || return 1
+  parent=$(lsblk -no PKNAME "$root_dev" 2>/dev/null | head -n 1 || true)
+  [ -n "$parent" ] || parent="$root_name"
+  root_sys=$(readlink -f "/sys/class/block/$parent/device" 2>/dev/null || true)
+  case "$root_sys" in
+    *"/usb$check_hub/"*|*"/$check_hub/"*|*"/$check_hub."*) return 0 ;;
+  esac
+  return 1
+}
+
+power_cycle_port() {
+  hub=$1
+  port=$2
+  label=$3
+
+  if ! command -v roblaude-hub-port-power >/dev/null 2>&1; then
+    log "roblaude-hub-port-power absent, $label impossible"
+    return 1
+  fi
+
+  if [ ! -e "/sys/bus/usb/devices/$hub" ]; then
+    log "hub $hub absent, $label impossible"
+    return 1
+  fi
+
+  busnum=$(cat "/sys/bus/usb/devices/$hub/busnum" 2>/dev/null || true)
+  devnum=$(cat "/sys/bus/usb/devices/$hub/devnum" 2>/dev/null || true)
+  if [ -z "$busnum" ] || [ -z "$devnum" ]; then
+    log "busnum/devnum absents pour $hub, $label impossible"
+    return 1
+  fi
+
+  log "power-cycle $label: hub $hub port $port off (${OFF_SECS}s), puis on (${SETTLE_SECS}s)"
+  if ! roblaude-hub-port-power "$busnum" "$devnum" "$port" off >> "$LOG" 2>&1; then
+    log "$label off echoue"
+    return 1
+  fi
+  sleep "$OFF_SECS"
+  if ! roblaude-hub-port-power "$busnum" "$devnum" "$port" on >> "$LOG" 2>&1; then
+    log "$label on echoue"
+    return 1
+  fi
+  sleep "$SETTLE_SECS"
+  return 0
+}
+
+if cp210_present; then
+  log "CP210x deja present, rien a reset"
+  exit 0
+fi
+
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  log "reset USB deja en cours"
+  exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+
+now=$(date +%s)
+last=$(cat "$STAMP" 2>/dev/null || echo 0)
+case "$last" in ''|*[!0-9]*) last=0 ;; esac
+if [ $((now-last)) -lt "$COOLDOWN" ]; then
+  log "cooldown USB actif ($((now-last))s/${COOLDOWN}s), pas de reset"
+  exit 2
+fi
+
+{
+  echo "--- before ---"
+  date
+  uptime
+  lsusb
+  lsusb -t
+  dmesg 2>/dev/null | grep -Ei 'cp210|ttyUSB|Cannot enable|unable to enumerate|1-2-port' | tail -40
+} >> "$LOG" 2>&1 || true
+
+echo "$now" > "$STAMP"
+if power_cycle_port "$HUB" "$HUB_PORT" "STM32"; then
+  port_cycle_ran=true
+else
+  port_cycle_failed=true
+fi
+
+if ! cp210_present && [ "$port_cycle_ran" = true ] && [ "$port_cycle_failed" = false ]; then
+  log "port STM32 power-cycle OK mais CP210x absent, tentative parent $PARENT_HUB port $PARENT_PORT"
+  power_cycle_port "$PARENT_HUB" "$PARENT_PORT" "hub robot parent" || port_cycle_failed=true
+fi
+
+if ! cp210_present && [ "$port_cycle_failed" = true ]; then
+  AUTH="/sys/bus/usb/devices/$PARENT_HUB/authorized"
+  if [ ! -w "$AUTH" ]; then
+    log "fallback impossible, hub $PARENT_HUB introuvable ou non modifiable ($AUTH)"
+    exit 1
+  fi
+  if hub_has_root_disk "$PARENT_HUB"; then
+    log "ABORT: le hub $PARENT_HUB contient le disque racine, reset refuse"
+    exit 1
+  fi
+  log "reset USB hub parent $PARENT_HUB: authorized=0 (${OFF_SECS}s), puis authorized=1 (${SETTLE_SECS}s)"
+  echo 0 > "$AUTH"
+  sleep "$OFF_SECS"
+  echo 1 > "$AUTH"
+  sleep "$SETTLE_SECS"
+fi
+
+for f in /sys/bus/usb/devices/*/power/control; do
+  [ -w "$f" ] || continue
+  echo on > "$f" 2>/dev/null || true
+done
+
+{
+  echo "--- after ---"
+  date
+  lsusb
+  lsusb -t
+  dmesg 2>/dev/null | grep -Ei 'cp210|ttyUSB|Cannot enable|unable to enumerate|1-2-port' | tail -60
+} >> "$LOG" 2>&1 || true
+
+if cp210_present; then
+  log "CP210x revenu apres reset USB"
+  ROBLAUDE_LINK_WAIT_SECS=10 /usr/local/bin/roblaude-link-stm32.sh >> "$LOG" 2>&1 || true
+  exit 0
+fi
+
+log "CP210x toujours absent apres reset USB"
+exit 1

--- a/robot/scripts/roblaude-usb-boot-guard.sh
+++ b/robot/scripts/roblaude-usb-boot-guard.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Verifie les ports USB critiques au boot et tente un recovery cible.
+# Objectif : avant Docker/ROS, les ports utilises doivent etre enumeres.
+set -u
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+HUB=${ROBLAUDE_USB_GUARD_HUB:-1-2}
+MAX_ATTEMPTS=${ROBLAUDE_USB_GUARD_ATTEMPTS:-2}
+OFF_SECS=${ROBLAUDE_USB_GUARD_OFF_SECS:-4}
+SETTLE_SECS=${ROBLAUDE_USB_GUARD_SETTLE_SECS:-12}
+DIAGDIR=/var/log/roblaude
+LOG="$DIAGDIR/usb_boot_guard_$(date +%Y%m%d-%H%M%S).log"
+
+case "$MAX_ATTEMPTS" in ''|*[!0-9]*) MAX_ATTEMPTS=2 ;; esac
+case "$OFF_SECS" in ''|*[!0-9]*) OFF_SECS=4 ;; esac
+case "$SETTLE_SECS" in ''|*[!0-9]*) SETTLE_SECS=12 ;; esac
+
+install -d -o root -g root -m 0755 "$DIAGDIR" 2>/dev/null || mkdir -p "$DIAGDIR"
+
+log() {
+  echo "$*"
+  echo "$*" >> "$LOG" 2>/dev/null || true
+}
+
+present() {
+  lsusb -d "$1" >/dev/null 2>&1
+}
+
+status_line() {
+  name=$1
+  vidpid=$2
+  if present "$vidpid"; then
+    echo "$name:$vidpid=ok"
+  else
+    echo "$name:$vidpid=missing"
+  fi
+}
+
+missing_required() {
+  missing=""
+  present 2357:012e || missing="$missing wifi"
+  present 10c4:ea60 || missing="$missing stm32"
+  present 1a86:7522 || missing="$missing ch341"
+  present 2bc5:06a0 || missing="$missing orbbec_depth"
+  present 2bc5:0561 || missing="$missing orbbec_rgb"
+  echo "$missing" | sed 's/^ *//'
+}
+
+fault_ports_from_dmesg() {
+  dmesg 2>/dev/null |
+    sed -n "s/.*usb ${HUB}-port\\([0-9][0-9]*\\):.*\\(Cannot enable\\|unable to enumerate\\).*/\\1/p" |
+    sort -n | uniq
+}
+
+hub_has_root_disk() {
+  root_src=$(findmnt -n -o SOURCE / 2>/dev/null || true)
+  [ -n "$root_src" ] || return 1
+  root_dev=$(readlink -f "$root_src" 2>/dev/null || true)
+  root_name=$(basename "$root_dev" 2>/dev/null || true)
+  [ -n "$root_name" ] || return 1
+  parent=$(lsblk -no PKNAME "$root_dev" 2>/dev/null | head -n 1 || true)
+  [ -n "$parent" ] || parent="$root_name"
+  root_sys=$(readlink -f "/sys/class/block/$parent/device" 2>/dev/null || true)
+  case "$root_sys" in
+    *"/usb$HUB/"*|*"/$HUB/"*|*"/$HUB."*) return 0 ;;
+  esac
+  return 1
+}
+
+hub_bus_dev() {
+  busnum=$(cat "/sys/bus/usb/devices/$HUB/busnum" 2>/dev/null || true)
+  devnum=$(cat "/sys/bus/usb/devices/$HUB/devnum" 2>/dev/null || true)
+  [ -n "$busnum" ] && [ -n "$devnum" ] || return 1
+  echo "$busnum $devnum"
+}
+
+cycle_port() {
+  port=$1
+  if ! command -v roblaude-hub-port-power >/dev/null 2>&1; then
+    log "outil roblaude-hub-port-power absent, port $port non cycle"
+    return 1
+  fi
+  bd=$(hub_bus_dev) || { log "hub $HUB sans busnum/devnum"; return 1; }
+  set -- $bd
+  busnum=$1
+  devnum=$2
+  log "power-cycle hub $HUB port $port"
+  if ! roblaude-hub-port-power "$busnum" "$devnum" "$port" off >> "$LOG" 2>&1; then
+    log "port $port off echoue"
+    return 1
+  fi
+  sleep "$OFF_SECS"
+  if ! roblaude-hub-port-power "$busnum" "$devnum" "$port" on >> "$LOG" 2>&1; then
+    log "port $port on echoue"
+    return 1
+  fi
+  sleep "$SETTLE_SECS"
+  return 0
+}
+
+cycle_hub_fallback() {
+  auth="/sys/bus/usb/devices/$HUB/authorized"
+  [ -w "$auth" ] || { log "fallback impossible, $auth non modifiable"; return 1; }
+  if hub_has_root_disk; then
+    log "fallback refuse: $HUB contient le disque racine"
+    return 1
+  fi
+  log "fallback hub entier $HUB"
+  echo 0 > "$auth"
+  sleep "$OFF_SECS"
+  echo 1 > "$auth"
+  sleep "$SETTLE_SECS"
+}
+
+ports_to_try() {
+  ports=""
+  missing=$(missing_required)
+  case " $missing " in
+    *" wifi "*) ports="$ports 1" ;;
+  esac
+  # Depuis le recablage fiable, tout le bloc robot (STM32, CH341, Orbbec)
+  # est derriere le hub lourd branche sur le port 4 du hub 1-2.
+  case " $missing " in
+    *" stm32 "*|*" ch341 "*|*" orbbec_depth "*|*" orbbec_rgb "*) ports="$ports 4" ;;
+  esac
+  for p in $(fault_ports_from_dmesg); do
+    ports="$ports $p"
+  done
+  echo "$ports" | tr ' ' '\n' | sed '/^$/d' | sort -n | uniq
+}
+
+{
+  echo "--- start ---"
+  date
+  uptime
+  echo "$(status_line wifi 2357:012e)"
+  echo "$(status_line stm32 10c4:ea60)"
+  echo "$(status_line ch341 1a86:7522)"
+  echo "$(status_line orbbec_depth 2bc5:06a0)"
+  echo "$(status_line orbbec_rgb 2bc5:0561)"
+  echo "$(status_line screen 0484:5750)"
+  lsusb
+  lsusb -t
+  dmesg 2>/dev/null | grep -Ei "usb ${HUB}-port|cp210|ttyUSB|Cannot enable|unable to enumerate" | tail -80
+} >> "$LOG" 2>&1 || true
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  missing=$(missing_required)
+  [ -z "$missing" ] && { log "USB boot guard OK"; exit 0; }
+
+  ports=$(ports_to_try)
+  [ -n "$ports" ] || { log "aucun port cible pour: $missing"; exit 1; }
+  log "tentative $attempt/$MAX_ATTEMPTS, manquants:$missing, ports:$ports"
+
+  failed=false
+  for p in $ports; do
+    cycle_port "$p" || failed=true
+  done
+  if [ "$failed" = true ]; then
+    cycle_hub_fallback || true
+  fi
+
+  {
+    echo "--- after attempt $attempt ---"
+    date
+    echo "$(status_line wifi 2357:012e)"
+    echo "$(status_line stm32 10c4:ea60)"
+    echo "$(status_line ch341 1a86:7522)"
+    echo "$(status_line orbbec_depth 2bc5:06a0)"
+    echo "$(status_line orbbec_rgb 2bc5:0561)"
+    echo "$(status_line screen 0484:5750)"
+    lsusb
+    lsusb -t
+    dmesg 2>/dev/null | grep -Ei "usb ${HUB}-port|cp210|ttyUSB|Cannot enable|unable to enumerate" | tail -80
+  } >> "$LOG" 2>&1 || true
+
+  attempt=$((attempt + 1))
+done
+
+missing=$(missing_required)
+if [ -n "$missing" ]; then
+  log "USB boot guard KO, manquants:$missing"
+  exit 1
+fi
+
+log "USB boot guard OK"
+exit 0

--- a/robot/scripts/start_perception.sh
+++ b/robot/scripts/start_perception.sh
@@ -4,28 +4,91 @@
 #   /home/jetson/roblaude_ws/scripts/start_perception.sh
 set -e
 
-docker exec \
-  -e ROS_DOMAIN_ID=30 \
-  -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 \
-  m3pro bash -lc '
-    source /opt/ros/humble/setup.bash
-    source /root/yahboomcar_ws/install/setup.bash 2>/dev/null || true
-    source /root/M3Pro_ws/install/setup.bash 2>/dev/null || true
-    source /root/roblaude_ws/install/setup.bash 2>/dev/null || true
-    mkdir -p /tmp/roslogs
+ROS_SETUP='
+  source /opt/ros/humble/setup.bash
+  source /root/yahboomcar_ws/install/setup.bash 2>/dev/null || true
+  source /root/M3Pro_ws/install/setup.bash 2>/dev/null || true
+  source /root/roblaude_ws/install/setup.bash 2>/dev/null || true
+  export ROS_DOMAIN_ID=30
+  export FASTDDS_BUILTIN_TRANSPORTS=UDPv4
+  mkdir -p /tmp/roslogs
+'
 
-    if ! ros2 node list 2>/dev/null | grep -q "^/camera/camera$"; then
-      setsid nohup ros2 launch roblaude_nav camera.launch.py >/tmp/roslogs/camera.log 2>&1 < /dev/null &
-      echo "camera lancee"
-      sleep 5
-    else
-      echo "camera deja active"
-    fi
+ros_exec() {
+  docker exec \
+    -e ROS_DOMAIN_ID=30 \
+    -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 \
+    m3pro bash -lc "$ROS_SETUP $*"
+}
 
-    if ! ros2 node list 2>/dev/null | grep -q "^/object_detector$"; then
-      setsid nohup ros2 launch roblaude_pickplace pickplace.launch.py >/tmp/roslogs/detector.log 2>&1 < /dev/null &
-      echo "detecteur lance"
-    else
-      echo "detecteur deja actif"
-    fi
+node_exists() {
+  name=$1
+  ros_exec "ros2 node list 2>/dev/null | grep -qx '$name'"
+}
+
+camera_frames_ok() {
+  ros_exec '
+    timeout 8 ros2 topic echo /camera/color/camera_info --once >/tmp/roblaude_camera_info_check 2>/dev/null &&
+    timeout 8 ros2 topic echo /camera/color/image_raw --once >/tmp/roblaude_camera_color_check 2>/dev/null
   '
+}
+
+stop_perception_nodes() {
+  ros_exec '
+    pkill -f "[r]oblaude_nav camera.launch.py" 2>/dev/null || true
+    pkill -f "[c]amera_container" 2>/dev/null || true
+    pkill -f "[o]bject_detector" 2>/dev/null || true
+    sleep 3
+  '
+}
+
+start_camera_once() {
+  ros_exec '
+    setsid nohup ros2 launch roblaude_nav camera.launch.py >/tmp/roslogs/camera.log 2>&1 < /dev/null &
+  '
+  echo "camera lancee"
+  sleep 8
+}
+
+start_detector_once() {
+  ros_exec '
+    setsid nohup ros2 launch roblaude_pickplace pickplace.launch.py >/tmp/roslogs/detector.log 2>&1 < /dev/null &
+  '
+  echo "detecteur lance"
+  sleep 2
+}
+
+if ! docker ps --format '{{.Names}}' | grep -qx m3pro; then
+  echo "KO: container m3pro absent"
+  exit 2
+fi
+
+if camera_frames_ok; then
+  echo "camera OK"
+else
+  if node_exists /camera/camera; then
+    echo "camera active mais sans frames -> relance"
+    stop_perception_nodes
+  fi
+  start_camera_once
+  if ! camera_frames_ok; then
+    echo "KO: camera sans frames apres relance"
+    ros_exec 'tail -80 /tmp/roslogs/camera.log 2>/dev/null || true'
+    exit 3
+  fi
+  echo "camera OK"
+fi
+
+if node_exists /object_detector; then
+  echo "detecteur deja actif"
+else
+  start_detector_once
+fi
+
+if ros_exec 'ros2 topic info /roblaude/qr_detections >/dev/null 2>&1'; then
+  echo "qr topic OK"
+else
+  echo "KO: /roblaude/qr_detections absent"
+  ros_exec 'tail -80 /tmp/roslogs/detector.log 2>/dev/null || true'
+  exit 4
+fi

--- a/robot/scripts/sync_time.sh
+++ b/robot/scripts/sync_time.sh
@@ -25,8 +25,8 @@ if ! find_robot; then
     exit 1
 fi
 
-SSH_OPTS="-o StrictHostKeyChecking=accept-new"
-SSH="ssh $SSH_OPTS $ROBOT_USER@$ROBOT_IP"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH="sshpass -p $ROBOT_PASS ssh $SSH_OPTS $ROBOT_USER@$ROBOT_IP"
 
 # 1) Horloge ---------------------------------------------------------------
 MAC_UTC=$(date -u +"%Y-%m-%d %H:%M:%S")
@@ -50,7 +50,28 @@ else
 fi
 
 # 2) Broker IP -------------------------------------------------------------
-MAC_IP="$(ipconfig getifaddr en0 2>/dev/null || ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
+ROBOT_PREFIX="$(echo "$ROBOT_IP" | cut -d. -f1-3)"
+MAC_IP=""
+
+# Decision soutenance : le Mac et le robot doivent etre sur le meme vrai Wi-Fi.
+# On choisit l'IP Wi-Fi du Mac qui partage le prefixe du robot.
+for iface in en0; do
+    CANDIDATE="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"
+    if [ -z "$CANDIDATE" ]; then
+        CANDIDATE="$(ifconfig "$iface" 2>/dev/null | awk '/inet / {print $2; exit}')"
+    fi
+    if [ -n "$CANDIDATE" ] && [ "$(echo "$CANDIDATE" | cut -d. -f1-3)" = "$ROBOT_PREFIX" ]; then
+        MAC_IP="$CANDIDATE"
+        break
+    fi
+done
+
+if [ -z "$MAC_IP" ]; then
+    MAC_IP="$(ipconfig getifaddr en0 2>/dev/null || true)"
+fi
+if [ -z "$MAC_IP" ]; then
+    MAC_IP="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
+fi
 echo ""
 echo "━━━ broker MQTT ━━━"
 

--- a/robot/scripts/systemd/micro-ros-agent.service
+++ b/robot/scripts/systemd/micro-ros-agent.service
@@ -10,6 +10,7 @@ Restart=always
 RestartSec=5
 TimeoutStartSec=120
 TimeoutStopSec=20
+Environment=ROBLAUDE_LINK_WAIT_SECS=20
 
 # Lie /dev/myserial au CP210x (STM32) — jamais le CH340 (micro). Cf roblaude-link-stm32.sh
 ExecStartPre=/usr/local/bin/roblaude-link-stm32.sh

--- a/robot/scripts/systemd/roblaude-demo-preflight.service
+++ b/robot/scripts/systemd/roblaude-demo-preflight.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=RobLaude demo boot preflight
+Requires=docker.service
+After=roblaude-usb-stable.service docker.service systemd-udev-settle.service
+Before=roblaude-m3pro.service
+Wants=roblaude-usb-stable.service systemd-udev-settle.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/roblaude-demo-preflight.sh --repair --boot
+TimeoutStartSec=180
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/scripts/systemd/roblaude-m3pro.service
+++ b/robot/scripts/systemd/roblaude-m3pro.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=RobLaude ROS container m3pro
 Requires=docker.service
-After=docker.service micro-ros-agent.service
-Wants=micro-ros-agent.service
+After=docker.service roblaude-demo-preflight.service micro-ros-agent.service
+Wants=roblaude-demo-preflight.service micro-ros-agent.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Résumé
- ajoute la détection QR côté pickplace et le topic `/roblaude/qr_detections`
- fiabilise le boot robot autour de l'USB, du STM32, de micro-ROS et du container `m3pro`
- garde le choix réseau final : Wi-Fi réel uniquement, sans hotspot/partage Internet
- ajoute les docs projet de référence pour la suite QR/fetch

## Vérifications
- `git diff --check`
- `PYTHONPATH=robot/roblaude_pickplace pytest robot/roblaude_pickplace/test/test_qr.py robot/roblaude_pickplace/test/test_detection.py robot/roblaude_pickplace/test/test_color.py robot/roblaude_pickplace/test/test_arm_kin.py -q`
- `./robot/scripts/find_robot.sh` -> robot trouvé à `192.168.1.80`