### PR TITLE
fix(robot): boot no-go si usb critique absent

### DIFF
--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -25,6 +25,7 @@ done
 xhost +local:root >/dev/null 2>&1 || true
 ROBLAUDE_MODE="${ROBLAUDE_MODE:-minimal}"
 ROBLAUDE_ARM_HOME_ON_BOOT="${ROBLAUDE_ARM_HOME_ON_BOOT:-true}"
+ROBLAUDE_STRICT_USB_PREFLIGHT="${ROBLAUDE_STRICT_USB_PREFLIGHT:-true}"
 
 # Repertoires hote persistants (jetson est owner, pas de sudo)
 mkdir -p /home/jetson/roblaude_ws/scripts
@@ -44,10 +45,22 @@ fi
 # devices absents ou des minors USB depasses.
 if command -v roblaude-usb-boot-guard.sh >/dev/null 2>&1; then
     echo "Preflight USB hote..."
-    sudo -n roblaude-usb-boot-guard.sh || echo "ATTENTION : USB boot guard non OK"
+    if ! sudo -n roblaude-usb-boot-guard.sh; then
+        echo "ATTENTION : USB boot guard non OK"
+        if [ "$ROBLAUDE_STRICT_USB_PREFLIGHT" = "true" ]; then
+            echo "ABORT : USB critique absent, m3pro non lance"
+            exit 1
+        fi
+    fi
 elif [ -x /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh ]; then
     echo "Preflight USB hote..."
-    sudo -n /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh || echo "ATTENTION : USB boot guard non OK"
+    if ! sudo -n /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh; then
+        echo "ATTENTION : USB boot guard non OK"
+        if [ "$ROBLAUDE_STRICT_USB_PREFLIGHT" = "true" ]; then
+            echo "ABORT : USB critique absent, m3pro non lance"
+            exit 1
+        fi
+    fi
 fi
 
 # Recreer "m3pro" a chaque boot pour que les nouveaux volumes/flags prennent.

--- a/robot/scripts/install_microros_service.sh
+++ b/robot/scripts/install_microros_service.sh
@@ -14,6 +14,7 @@ set -e
 SRC="$(cd "$(dirname "$0")" && pwd)"
 
 echo "━━━ 1/4 : helpers dans /usr/local/bin ━━━"
+sudo install -o jetson -g jetson -m 0755 "$SRC/Docker_M3Pro_Joy.sh"          /home/jetson/Docker_M3Pro_Joy.sh
 sudo install -m 0755 "$SRC/roblaude-usb-stable.sh"         /usr/local/bin/roblaude-usb-stable.sh
 sudo install -m 0755 "$SRC/roblaude-link-stm32.sh"        /usr/local/bin/roblaude-link-stm32.sh
 sudo install -m 0755 "$SRC/roblaude-stm32-usb-recover.sh" /usr/local/bin/roblaude-stm32-usb-recover.sh

--- a/robot/scripts/roblaude-demo-preflight.sh
+++ b/robot/scripts/roblaude-demo-preflight.sh
@@ -9,6 +9,7 @@ START_CAMERA=false
 BOOT_ONLY=false
 LOG_DIR=/var/log/roblaude
 LOG="$LOG_DIR/demo_preflight_$(date +%Y%m%d-%H%M%S).log"
+STATUS_FILE=${ROBLAUDE_PREFLIGHT_STATUS_FILE:-/run/roblaude-demo-preflight.status}
 
 for arg in "$@"; do
   case "$arg" in
@@ -32,6 +33,18 @@ log() {
 ok() { log "OK  $*"; }
 warn() { log "WARN $*"; }
 ko() { log "KO  $*"; FAILED=true; }
+
+write_status() {
+  status=$1
+  reason=${2:-}
+  install -d -m 0755 "$(dirname "$STATUS_FILE")" 2>/dev/null || true
+  {
+    echo "status=$status"
+    echo "reason=$reason"
+    echo "log=$LOG"
+    date -Is 2>/dev/null | sed 's/^/time=/'
+  } > "$STATUS_FILE" 2>/dev/null || true
+}
 
 FAILED=false
 RESTARTED_M3PRO=false
@@ -72,7 +85,8 @@ check_usb() {
   usb_present 1a86:7522 || missing_after="$missing_after ch341"
   usb_present 2bc5:06a0 || missing_after="$missing_after orbbec_depth"
   usb_present 2bc5:0561 || missing_after="$missing_after orbbec_rgb"
-  [ -z "$missing_after" ] && { ok "USB revenus apres repair"; return 0; }
+  [ -z "$missing_after" ] && { ok "USB revenus apres repair"; write_status "GO" "usb-ok"; return 0; }
+  write_status "NO_GO" "usb-missing:$missing_after"
   ko "USB toujours manquants:$missing_after"
   return 1
 }
@@ -207,7 +221,9 @@ check_camera() {
 
 log "=== RobLaude demo preflight $(date) repair=$REPAIR start_camera=$START_CAMERA boot=$BOOT_ONLY ==="
 log "uptime: $(uptime)"
-check_usb || true
+if check_usb; then
+  write_status "GO" "usb-ok"
+fi
 if [ "$BOOT_ONLY" = true ]; then
   if [ "$FAILED" = true ]; then
     log "RESULT=NO_GO_BOOT log=$LOG"
@@ -215,6 +231,12 @@ if [ "$BOOT_ONLY" = true ]; then
   fi
   log "RESULT=GO_BOOT log=$LOG"
   exit 0
+fi
+
+if [ "$FAILED" = true ]; then
+  log "STOP: USB critique KO, on ne lance pas Docker/ROS/camera en etat degrade"
+  log "RESULT=NO_GO log=$LOG"
+  exit 1
 fi
 
 check_m3pro || true

--- a/robot/scripts/roblaude-stm32-healthcheck.sh
+++ b/robot/scripts/roblaude-stm32-healthcheck.sh
@@ -5,6 +5,8 @@
 set -u
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 SVC=micro-ros-agent.service
+M3PRO_SVC=roblaude-m3pro.service
+PREFLIGHT_SVC=roblaude-demo-preflight.service
 LINK=/usr/local/bin/roblaude-link-stm32.sh
 RECOVER=/usr/local/bin/roblaude-stm32-usb-recover.sh
 # Tourne en root (oneshot systemd) : on garde le diag dans un dossier root-owned,
@@ -107,6 +109,15 @@ if [ $((now-last)) -ge $COOLDOWN ]; then
   echo "$now" > "$STAMP"; systemctl restart "$SVC"; echo "restart $SVC"
 else
   echo "cooldown actif, pas de restart"
+fi
+
+# Si l'USB est revenu apres un boot NO-GO, on retente la sequence demo propre.
+# Le service m3pro depend du preflight : si camera/STM32/CH341 restent absents,
+# il restera bloque sans casser le Wi-Fi/SSH.
+if cp210_present; then
+  systemctl reset-failed "$PREFLIGHT_SVC" "$M3PRO_SVC" 2>/dev/null || true
+  systemctl start "$PREFLIGHT_SVC" 2>/dev/null || true
+  systemctl start "$M3PRO_SVC" 2>/dev/null || true
 fi
 # garde les 30 plus recents (noms horodates -> tri lexical = chronologique)
 find "$DIAGDIR" -maxdepth 1 -name 'incident_*.log' -type f | sort | head -n -30 | while read -r f; do rm -f -- "$f"; done

--- a/robot/scripts/roblaude-usb-boot-guard.sh
+++ b/robot/scripts/roblaude-usb-boot-guard.sh
@@ -5,6 +5,8 @@ set -u
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 HUB=${ROBLAUDE_USB_GUARD_HUB:-1-2}
+SAFE_PORTS=${ROBLAUDE_USB_GUARD_SAFE_PORTS:-4}
+ALLOW_HUB_FALLBACK=${ROBLAUDE_USB_GUARD_ALLOW_HUB_FALLBACK:-false}
 MAX_ATTEMPTS=${ROBLAUDE_USB_GUARD_ATTEMPTS:-2}
 OFF_SECS=${ROBLAUDE_USB_GUARD_OFF_SECS:-4}
 SETTLE_SECS=${ROBLAUDE_USB_GUARD_SETTLE_SECS:-12}
@@ -115,9 +117,6 @@ cycle_hub_fallback() {
 ports_to_try() {
   ports=""
   missing=$(missing_required)
-  case " $missing " in
-    *" wifi "*) ports="$ports 1" ;;
-  esac
   # Depuis le recablage fiable, tout le bloc robot (STM32, CH341, Orbbec)
   # est derriere le hub lourd branche sur le port 4 du hub 1-2.
   case " $missing " in
@@ -126,7 +125,13 @@ ports_to_try() {
   for p in $(fault_ports_from_dmesg); do
     ports="$ports $p"
   done
-  echo "$ports" | tr ' ' '\n' | sed '/^$/d' | sort -n | uniq
+  # Mode demo strict : ne jamais toucher aux ports hors whitelist. Ca garde le
+  # Wi-Fi/SSH vivant meme si un vieux dmesg mentionne un autre port.
+  echo "$ports" | tr ' ' '\n' | sed '/^$/d' | sort -n | uniq |
+    awk -v safe="$SAFE_PORTS" '
+      BEGIN { split(safe, a, /[ ,]+/); for (i in a) allowed[a[i]]=1 }
+      allowed[$0] { print }
+    '
 }
 
 {
@@ -157,8 +162,10 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
   for p in $ports; do
     cycle_port "$p" || failed=true
   done
-  if [ "$failed" = true ]; then
+  if [ "$failed" = true ] && [ "$ALLOW_HUB_FALLBACK" = true ]; then
     cycle_hub_fallback || true
+  elif [ "$failed" = true ]; then
+    log "fallback hub entier desactive (ROBLAUDE_USB_GUARD_ALLOW_HUB_FALLBACK=false)"
   fi
 
   {

--- a/robot/scripts/systemd/roblaude-m3pro.service
+++ b/robot/scripts/systemd/roblaude-m3pro.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=RobLaude ROS container m3pro
-Requires=docker.service
+Requires=docker.service roblaude-demo-preflight.service
 After=docker.service roblaude-demo-preflight.service micro-ros-agent.service
-Wants=roblaude-demo-preflight.service micro-ros-agent.service
+Wants=micro-ros-agent.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Résumé
- bloque le démarrage `m3pro` si le preflight USB critique échoue
- garde Linux/Wi-Fi/SSH disponibles en statut `NO_GO` au lieu de lancer une démo cassée
- limite le boot guard aux ports USB whitelistés pour ne pas couper le réseau
- fait relancer `preflight + m3pro` par le healthcheck si le STM32 revient plus tard
- installe toujours le launcher Docker à jour dans `/home/jetson/Docker_M3Pro_Joy.sh`

## Vérifications
- `bash -n` sur les scripts modifiés
- `git diff --check`
- déployé sur le robot `192.168.1.80`
- test runtime: port USB critique KO -> `roblaude-m3pro.service` reste inactive et `/run/roblaude-demo-preflight.status` contient `status=NO_GO` avec les périphériques manquants