### PR TITLE
fix(robot): guard usb sans sudo quand root

### DIFF
--- a/robot/scripts/Docker_M3Pro_Joy.sh
+++ b/robot/scripts/Docker_M3Pro_Joy.sh
@@ -43,9 +43,18 @@ fi
 # Avant Docker : stabilise l'USB hote. Le container doit demarrer apres
 # enumeration des peripheriques critiques, sinon les drivers ROS voient des
 # devices absents ou des minors USB depasses.
+run_usb_guard() {
+    guard=$1
+    if [ "$(id -u)" -eq 0 ]; then
+        "$guard"
+    else
+        sudo -n "$guard"
+    fi
+}
+
 if command -v roblaude-usb-boot-guard.sh >/dev/null 2>&1; then
     echo "Preflight USB hote..."
-    if ! sudo -n roblaude-usb-boot-guard.sh; then
+    if ! run_usb_guard "$(command -v roblaude-usb-boot-guard.sh)"; then
         echo "ATTENTION : USB boot guard non OK"
         if [ "$ROBLAUDE_STRICT_USB_PREFLIGHT" = "true" ]; then
             echo "ABORT : USB critique absent, m3pro non lance"
@@ -54,7 +63,7 @@ if command -v roblaude-usb-boot-guard.sh >/dev/null 2>&1; then
     fi
 elif [ -x /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh ]; then
     echo "Preflight USB hote..."
-    if ! sudo -n /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh; then
+    if ! run_usb_guard /home/jetson/roblaude_ws/scripts/roblaude-usb-boot-guard.sh; then
         echo "ATTENTION : USB boot guard non OK"
         if [ "$ROBLAUDE_STRICT_USB_PREFLIGHT" = "true" ]; then
             echo "ABORT : USB critique absent, m3pro non lance"


### PR DESCRIPTION
## Résumé
- corrige le launcher `Docker_M3Pro_Joy.sh` quand il est lancé par systemd en root
- appelle `roblaude-usb-boot-guard.sh` directement si UID=0, sinon via `sudo -n`
- évite l'abort faux positif `root is not in the sudoers file` alors que le preflight USB est `GO`

## Vérifications
- `bash -n robot/scripts/Docker_M3Pro_Joy.sh`
- `git diff --check`
- déployé sur le robot `192.168.1.80`
- `systemctl restart roblaude-m3pro.service` -> `m3pro`, `micro_ros_agent`, `YB_Node` actifs
