### PR TITLE
[T6.2.2] lecture apriltags objets

### DIFF
--- a/robot/roblaude_pickplace/roblaude_pickplace/object_detector.py
+++ b/robot/roblaude_pickplace/roblaude_pickplace/object_detector.py
@@ -72,11 +72,11 @@ class ObjectDetector(Node):
         self.min_depth = float(self.declare_parameter('min_detection_depth', 0.15).value)
         self.depth_scale = float(self.declare_parameter('depth_scale', 0.001).value)
 
-        # --- QR basse frequence : la camera tourne deja, le decodeur reste leger ---
+        # --- QR/AprilTag basse frequence : la camera tourne deja, decodeur leger ---
         self.enable_qr_detection = bool(
             self.declare_parameter('enable_qr_detection', True).value)
         self.qr_period_sec = float(self.declare_parameter('qr_period_sec', 0.5).value)
-        self.qr_detector = cv2.QRCodeDetector()
+        self.qr_detector = None
         self.last_qr_at = 0.0
         self.last_qr_detections = []
 
@@ -230,7 +230,7 @@ class ObjectDetector(Node):
             pts = np.array(qr.points, dtype=np.int32).reshape((-1, 1, 2))
             col = (255, 0, 255) if qr.z > 0 else (255, 255, 0)
             cv2.polylines(annotated, [pts], isClosed=True, color=col, thickness=2)
-            label = f'QR {qr.qr} {qr.z:.2f}m' if qr.z > 0 else f'QR {qr.qr} no depth'
+            label = f'TAG {qr.qr} {qr.z:.2f}m' if qr.z > 0 else f'TAG {qr.qr} no depth'
             cv2.putText(annotated, label, (qr.px - 40, qr.py - qr.radius - 12),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2)
         out = Image()

--- a/robot/roblaude_pickplace/roblaude_pickplace/qr.py
+++ b/robot/roblaude_pickplace/roblaude_pickplace/qr.py
@@ -1,4 +1,4 @@
-"""Detection QR + projection 3D, sans dependance ROS."""
+"""Detection QR/AprilTag + projection 3D, sans dependance ROS."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -57,14 +57,155 @@ def _candidate(text: str, points: Any) -> QrCandidate | None:
     return QrCandidate(text=text, points=normalized, px=px, py=py, radius=radius)
 
 
+def _zbar_points(decoded: Any) -> tuple[tuple[int, int], ...]:
+    polygon = getattr(decoded, "polygon", None)
+    if polygon and len(polygon) >= 4:
+        return tuple((int(p.x), int(p.y)) for p in polygon[:4])
+
+    rect = getattr(decoded, "rect", None)
+    if rect is None:
+        return tuple()
+    left = int(getattr(rect, "left", 0))
+    top = int(getattr(rect, "top", 0))
+    width = int(getattr(rect, "width", 0))
+    height = int(getattr(rect, "height", 0))
+    if width <= 0 or height <= 0:
+        return tuple()
+    return ((left, top), (left + width, top), (left + width, top + height), (left, top + height))
+
+
+def _load_zbar_decode(zbar_decode: Any = None) -> Any | None:
+    if zbar_decode is None:
+        try:
+            from pyzbar.pyzbar import decode as zbar_decode
+        except Exception:
+            return None
+    return zbar_decode
+
+
+def _detect_qr_candidates_zbar(color_img: np.ndarray, zbar_decode: Any = None) -> list[QrCandidate]:
+    zbar_decode = _load_zbar_decode(zbar_decode)
+    if zbar_decode is None:
+        return []
+
+    candidates: list[QrCandidate] = []
+    try:
+        decoded_items = zbar_decode(color_img)
+    except Exception:
+        return []
+
+    for decoded in decoded_items:
+        raw = getattr(decoded, "data", b"")
+        text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
+        candidate = _candidate(text, _zbar_points(decoded))
+        if candidate is not None:
+            candidates.append(candidate)
+    return candidates
+
+
+MARKER_DICTIONARIES = (
+    "DICT_APRILTAG_36h11",
+    "DICT_APRILTAG_36h10",
+    "DICT_APRILTAG_25h9",
+    "DICT_APRILTAG_16h5",
+    "DICT_4X4_50",
+    "DICT_4X4_100",
+    "DICT_5X5_50",
+    "DICT_5X5_100",
+    "DICT_6X6_50",
+    "DICT_6X6_100",
+)
+
+
+def _aruco_dictionary(aruco_module: Any, name: str) -> Any | None:
+    if not hasattr(aruco_module, name):
+        return None
+    dictionary_id = getattr(aruco_module, name)
+    if hasattr(aruco_module, "getPredefinedDictionary"):
+        return aruco_module.getPredefinedDictionary(dictionary_id)
+    if hasattr(aruco_module, "Dictionary_get"):
+        return aruco_module.Dictionary_get(dictionary_id)
+    return None
+
+
+def _aruco_parameters(aruco_module: Any) -> Any | None:
+    if hasattr(aruco_module, "DetectorParameters_create"):
+        return aruco_module.DetectorParameters_create()
+    if hasattr(aruco_module, "DetectorParameters"):
+        return aruco_module.DetectorParameters()
+    return None
+
+
+def _marker_text(dictionary_name: str, marker_id: int) -> str:
+    return f"{dictionary_name.removeprefix('DICT_')}:{marker_id}"
+
+
+def _detect_qr_candidates_aruco(color_img: np.ndarray, aruco_module: Any = None) -> list[QrCandidate]:
+    cv2_module = None
+    if aruco_module is None:
+        try:
+            import cv2 as cv2_module
+            aruco_module = cv2_module.aruco
+        except Exception:
+            return []
+
+    if not hasattr(aruco_module, "detectMarkers"):
+        return []
+
+    image = color_img
+    if cv2_module is not None:
+        image = cv2_module.cvtColor(color_img, cv2_module.COLOR_RGB2GRAY)
+    parameters = _aruco_parameters(aruco_module)
+
+    for dictionary_name in MARKER_DICTIONARIES:
+        dictionary = _aruco_dictionary(aruco_module, dictionary_name)
+        if dictionary is None:
+            continue
+        try:
+            corners, ids, _rejected = aruco_module.detectMarkers(
+                image,
+                dictionary,
+                parameters=parameters,
+            )
+        except Exception:
+            continue
+        if ids is None or len(ids) == 0:
+            continue
+
+        candidates: list[QrCandidate] = []
+        for marker_id, pts in zip(np.asarray(ids).reshape(-1), corners):
+            candidate = _candidate(_marker_text(dictionary_name, int(marker_id)), pts)
+            if candidate is not None:
+                candidates.append(candidate)
+        if candidates:
+            return candidates
+    return []
+
+
 def _is_cv2_error(exc: Exception, cv2_module: Any) -> bool:
     cv2_error = getattr(cv2_module, "error", None)
     return cv2_error is not None and isinstance(exc, cv2_error)
 
 
-def detect_qr_candidates(color_img: np.ndarray | None, detector: Any = None) -> list[QrCandidate]:
+def detect_qr_candidates(
+    color_img: np.ndarray | None,
+    detector: Any = None,
+    zbar_decode: Any = None,
+    aruco_module: Any = None,
+) -> list[QrCandidate]:
     if color_img is None or getattr(color_img, "ndim", 0) != 3:
         return []
+
+    if detector is None:
+        zbar_decode_resolved = _load_zbar_decode(zbar_decode)
+        if zbar_decode_resolved is not None:
+            candidates = _detect_qr_candidates_zbar(color_img, zbar_decode_resolved)
+            if candidates:
+                return candidates
+
+        candidates = _detect_qr_candidates_aruco(color_img, aruco_module)
+        if candidates:
+            return candidates
 
     cv2_module = None
     if detector is None:
@@ -93,14 +234,16 @@ def detect_qr_candidates(color_img: np.ndarray | None, detector: Any = None) -> 
     try:
         text, points, _straight = qr_detector.detectAndDecode(color_img)
     except (ValueError, AttributeError):
-        return []
+        return _detect_qr_candidates_zbar(color_img, zbar_decode)
     except Exception as exc:
         if not _is_cv2_error(exc, cv2_module):
             raise
-        return []
+        return _detect_qr_candidates_zbar(color_img, zbar_decode)
 
     candidate = _candidate(text, points)
-    return [candidate] if candidate is not None else []
+    if candidate is not None:
+        return [candidate]
+    return _detect_qr_candidates_zbar(color_img, zbar_decode)
 
 
 def build_qr_detections(

--- a/robot/roblaude_pickplace/test/test_qr.py
+++ b/robot/roblaude_pickplace/test/test_qr.py
@@ -1,5 +1,6 @@
 """Tests QR sans camera reelle : OpenCV est remplace par un faux detecteur."""
 import json
+from types import SimpleNamespace
 
 import numpy as np
 
@@ -42,6 +43,44 @@ class FakeEmptyDetector:
         return "", None, None
 
 
+def fake_zbar_decode(_image):
+    return [
+        SimpleNamespace(
+            data=b"OBJ_ZBAR",
+            polygon=[
+                SimpleNamespace(x=5, y=6),
+                SimpleNamespace(x=25, y=6),
+                SimpleNamespace(x=25, y=26),
+                SimpleNamespace(x=5, y=26),
+            ],
+        )
+    ]
+
+
+class FakeAruco:
+    DICT_APRILTAG_36h11 = 1
+
+    @staticmethod
+    def DetectorParameters_create():
+        return object()
+
+    @staticmethod
+    def Dictionary_get(dictionary_id):
+        return f"dict:{dictionary_id}"
+
+    @staticmethod
+    def detectMarkers(_image, dictionary, parameters=None):
+        if dictionary != "dict:1":
+            return [], None, []
+        corners = [
+            np.array(
+                [[[10.0, 12.0], [30.0, 12.0], [30.0, 32.0], [10.0, 32.0]]],
+                dtype=np.float32,
+            )
+        ]
+        return corners, np.array([[1]], dtype=np.int32), []
+
+
 def test_detect_qr_candidates_multi_ignore_text_empty():
     image = np.zeros((80, 80, 3), dtype=np.uint8)
     candidates = detect_qr_candidates(image, FakeMultiDetector())
@@ -68,6 +107,40 @@ def test_detect_qr_candidates_empty_image_or_empty_text():
     assert detect_qr_candidates(None, FakeEmptyDetector()) == []
     assert detect_qr_candidates(np.zeros((80, 80), dtype=np.uint8), FakeEmptyDetector()) == []
     assert detect_qr_candidates(np.zeros((80, 80, 3), dtype=np.uint8), FakeEmptyDetector()) == []
+
+
+def test_detect_qr_candidates_zbar_fallback():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    candidates = detect_qr_candidates(image, FakeEmptyDetector(), zbar_decode=fake_zbar_decode)
+
+    assert len(candidates) == 1
+    assert candidates[0].text == "OBJ_ZBAR"
+    assert candidates[0].points == ((5, 6), (25, 6), (25, 26), (5, 26))
+    assert candidates[0].px == 15
+    assert candidates[0].py == 16
+
+
+def test_detect_qr_candidates_zbar_without_opencv_detector():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    candidates = detect_qr_candidates(image, detector=None, zbar_decode=fake_zbar_decode)
+
+    assert len(candidates) == 1
+    assert candidates[0].text == "OBJ_ZBAR"
+
+
+def test_detect_qr_candidates_apriltag_fallback():
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+    candidates = detect_qr_candidates(
+        image,
+        detector=None,
+        zbar_decode=lambda _image: [],
+        aruco_module=FakeAruco,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].text == "APRILTAG_36h11:1"
+    assert candidates[0].px == 20
+    assert candidates[0].py == 22
 
 
 def test_build_qr_detections_with_depth_and_backprojection():

--- a/robot/scripts/container_autostart.sh
+++ b/robot/scripts/container_autostart.sh
@@ -40,6 +40,13 @@ if ! python3 -c "import paho.mqtt" 2>/dev/null; then
         exit 1
     }
 fi
+if ! python3 -c "import pyzbar.pyzbar" 2>/dev/null; then
+    echo "[autostart] installation pyzbar (fallback QR)..."
+    pip install --quiet --user 'pyzbar~=0.1' || {
+        echo "[autostart] ECHEC pip install pyzbar"
+        echo "[autostart] QR decode indisponible tant que pyzbar manque"
+    }
+fi
 
 # --- Source de l'env ROS et des drivers Yahboom (dans l'image, jamais wipes) ---
 source /opt/ros/humble/setup.bash

--- a/robot/scripts/roblaude-robot-status.sh
+++ b/robot/scripts/roblaude-robot-status.sh
@@ -3,6 +3,7 @@
 # Lu par le backend via SSH pour la page Reparation du front.
 set -u
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+TOPIC_TIMEOUT="${ROBOT_STATUS_TOPIC_TIMEOUT:-10}"
 
 # 1. /dev/myserial pointe-t-il bien sur le STM32 (CP210x) ?
 myserial_ok=false
@@ -41,8 +42,8 @@ if [ "$m3pro" = up ] && [ "$myserial_ok" = true ] && [ "$agent_log_ok" = true ];
       source /opt/ros/humble/setup.bash
       source /root/yahboomcar_ws/install/setup.bash 2>/dev/null || true
       source /root/roblaude_ws/install/setup.bash 2>/dev/null || true
-      timeout 4 ros2 topic echo /battery --once >/tmp/roblaude_battery_check 2>/dev/null ||
-      timeout 4 ros2 topic echo /odom_raw --once >/tmp/roblaude_odom_raw_check 2>/dev/null
+      timeout '"$TOPIC_TIMEOUT"' ros2 topic echo /battery --once >/tmp/roblaude_battery_check 2>/dev/null ||
+      timeout '"$TOPIC_TIMEOUT"' ros2 topic echo /odom_raw --once >/tmp/roblaude_odom_raw_check 2>/dev/null
     ' && stm32_data=true
 fi
 


### PR DESCRIPTION
## Ce qui change

Le detecteur accepte maintenant les marqueurs AprilTag/ArUco en plus des vrais QR.
Pour ne pas casser l'app et les scripts existants, la sortie reste publiee sur
`/roblaude/qr_detections`, mais un objet tague sort avec un identifiant du type
`APRILTAG_36h11:1`.

Le fallback `pyzbar` reste en place pour les QR classiques, et l'autostart installe
`pyzbar` si le container Yahboom ne l'a pas encore. Le script de sante robot a aussi
un timeout de lecture STM32 moins agressif, parce que 4 secondes donnait des faux
negatifs quand camera + detection tournaient.

## Pourquoi

Sur le robot reel, OpenCV annonce `Library QUIRC is not linked`, donc son decodeur QR
ne decode rien. Ensuite, la frame camera a montre que les objets devant la camera ne
sont pas des QR mais des AprilTags. L'image capturee a ete reconnue comme
`DICT_APRILTAG_36h11`, id `1`.

## Tests

- `PYTHONPATH=robot/roblaude_pickplace pytest robot/roblaude_pickplace/test/test_qr.py -q`
- `bash -n robot/scripts/container_autostart.sh robot/scripts/roblaude-robot-status.sh`
- `git diff --check`

## Notes robot

Le patch a ete deploye et build sur le robot avant commit. La detection AprilTag est
prete cote code, mais le test live a ete interrompu par une panne USB du hub robot :
le hub CP210x/Orbbec a decroche (`cp210x`, `ch341`, `orbbec_depth`, `orbbec_rgb`
absents). Le robot doit etre redemarre proprement avant de reprendre le test camera.
